### PR TITLE
feat(NavBar): animate NavBar when it renders/disappears

### DIFF
--- a/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
@@ -183,13 +183,6 @@ exports[`NavBar renders fixed 1`] = `
   background-color: transparent;
   color: rgba(255,255,255,1);
   font-weight: 600;
-  -webkit-transition-property: -webkit-transform;
-  -webkit-transition-property: transform;
-  transition-property: transform;
-  -webkit-transition-duration: 300ms;
-  transition-duration: 300ms;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c0.nav--relative {
@@ -202,9 +195,6 @@ exports[`NavBar renders fixed 1`] = `
 
 .c0.nav--fixed {
   position: fixed;
-  -webkit-transform: translateY(0px);
-  -ms-transform: translateY(0px);
-  transform: translateY(0px);
 }
 
 .c0 .linkItem:visited {
@@ -232,6 +222,16 @@ exports[`NavBar renders fixed 1`] = `
   height: 60px;
   z-index: 4;
   background-image: linear-gradient(77deg,rgba(0,0,0,0),#000000);
+}
+
+.c0.nav--fade-in {
+  -webkit-animation: fadeIn 0.3s ease-in-out;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.c0.nav--fade-out {
+  -webkit-animation: fadeOut 0.3s ease-in-out;
+  animation: fadeOut 0.3s ease-in-out;
 }
 
 .c1 {
@@ -307,7 +307,7 @@ exports[`NavBar renders fixed 1`] = `
 }
 
 <nav
-  className="nav--relative c0"
+  className="nav--fixed nav--fade-in c0"
   role="navigation"
   style={
     Object {
@@ -635,13 +635,6 @@ exports[`NavBar renders inverted 1`] = `
   background-color: transparent;
   color: rgba(255,255,255,1);
   font-weight: 600;
-  -webkit-transition-property: -webkit-transform;
-  -webkit-transition-property: transform;
-  transition-property: transform;
-  -webkit-transition-duration: 300ms;
-  transition-duration: 300ms;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c0.nav--relative {
@@ -654,9 +647,6 @@ exports[`NavBar renders inverted 1`] = `
 
 .c0.nav--fixed {
   position: fixed;
-  -webkit-transform: translateY(0px);
-  -ms-transform: translateY(0px);
-  transform: translateY(0px);
 }
 
 .c0 .linkItem:visited {
@@ -684,6 +674,16 @@ exports[`NavBar renders inverted 1`] = `
   height: 60px;
   z-index: 4;
   background-image: linear-gradient(77deg,rgba(0,0,0,0),#000000);
+}
+
+.c0.nav--fade-in {
+  -webkit-animation: fadeIn 0.3s ease-in-out;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.c0.nav--fade-out {
+  -webkit-animation: fadeOut 0.3s ease-in-out;
+  animation: fadeOut 0.3s ease-in-out;
 }
 
 .c1 {
@@ -759,7 +759,7 @@ exports[`NavBar renders inverted 1`] = `
 }
 
 <nav
-  className="nav--relative nav--inverted c0"
+  className="nav--relative nav--inverted nav--fade-in c0"
   role="navigation"
   style={
     Object {
@@ -1131,13 +1131,6 @@ exports[`NavBar renders with defaults 1`] = `
   background-color: transparent;
   color: rgba(255,255,255,1);
   font-weight: 600;
-  -webkit-transition-property: -webkit-transform;
-  -webkit-transition-property: transform;
-  transition-property: transform;
-  -webkit-transition-duration: 300ms;
-  transition-duration: 300ms;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c0.nav--relative {
@@ -1150,9 +1143,6 @@ exports[`NavBar renders with defaults 1`] = `
 
 .c0.nav--fixed {
   position: fixed;
-  -webkit-transform: translateY(0px);
-  -ms-transform: translateY(0px);
-  transform: translateY(0px);
 }
 
 .c0 .linkItem:visited {
@@ -1180,6 +1170,16 @@ exports[`NavBar renders with defaults 1`] = `
   height: 60px;
   z-index: 4;
   background-image: linear-gradient(77deg,rgba(0,0,0,0),#000000);
+}
+
+.c0.nav--fade-in {
+  -webkit-animation: fadeIn 0.3s ease-in-out;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.c0.nav--fade-out {
+  -webkit-animation: fadeOut 0.3s ease-in-out;
+  animation: fadeOut 0.3s ease-in-out;
 }
 
 .c1 {
@@ -1249,7 +1249,7 @@ exports[`NavBar renders with defaults 1`] = `
 }
 
 <nav
-  className="nav--relative c0"
+  className="nav--relative nav--fade-in c0"
   role="navigation"
   style={
     Object {

--- a/src/components/NavBar/__tests__/index.spec.js
+++ b/src/components/NavBar/__tests__/index.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { render } from "react-testing-library";
 
 import NavBar from "../index";
 
@@ -36,7 +37,7 @@ describe("NavBar", () => {
     expect(
       renderer
         .create(
-          <NavBar fixed>
+          <NavBar position="fixed">
             <NavBar.MenuButton isFirst />
             Content
             <NavBar.LogoContainer href="http://localhost/new/">
@@ -86,4 +87,23 @@ describe("NavBar", () => {
         )
         .toJSON()
     ).toMatchSnapshot());
+
+  it("should reset animation while updating", () => {
+    const { rerender, container } = render(
+      <NavBar position="fixed">Content</NavBar>
+    );
+    expect(
+      container.firstChild.classList.contains("nav--fade-out")
+    ).toBeFalsy();
+
+    rerender(<NavBar position="absolute">Content</NavBar>);
+    expect(
+      container.firstChild.classList.contains("nav--fade-out")
+    ).toBeTruthy();
+
+    rerender(<NavBar position="fixed">Content</NavBar>);
+    expect(
+      container.firstChild.classList.contains("nav--fade-out")
+    ).toBeFalsy();
+  });
 });


### PR DESCRIPTION
**What**:
NavBar component is now animated: slowly appearing and disappearing.

**Why**:
UI requirement.

**How**:
"nav--fadeIn" class is added to the root component - it contains animation for slow appearing of the NavBar. So that animation works on each scroll we need to remove this class, trigger browser reflow (with the use of calling navbar.offsetWidth;), and then add it again.
Also, on scrolling the page up we add the class "nav--fadeOut" which allows NavBar to slowly disappear. And then we remove this class while scrolling down. When the component is rendered only once, "nav--fadeOut" doesn't affect it at all.

**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Ready to be merged 