### PR TITLE
fix(Typography): add font-weight support. Add monospace feature

### DIFF
--- a/src/components/Header/Heading.js
+++ b/src/components/Header/Heading.js
@@ -6,23 +6,23 @@ import typography from "../../theme/typography";
 import { mediumAndUp, largeAndUp } from "../../theme/mediaQueries";
 import spacing from "../../theme/spacing";
 
-const Light = styled.span`
+const Span = styled.span`
   font-weight: ${typography.weight.light};
 `;
 
-const ExtraBold = Light.extend`
+const Strong = Span.extend`
   font-weight: ${typography.weight.extraBold};
 `;
 
 const margins = styled.span`
+  ${({ monospace }) => (monospace ? `font-family: monospace, monospace` : "")};
   margin-top: 0;
   margin-bottom: 0;
   padding-bottom: ${spacing.cozy};
   line-height: ${({ lineHeight }) => typography.lineHeight[lineHeight]};
   color: ${p => (p.color ? p.color : colors.white.base)};
-  font-weight: ${typography.weight.regular};
+  font-weight: ${({ weight }) => typography.weight[weight]};
   font-size: ${({ size }) => typography.size[size.small]};
-
   ${mediumAndUp`
     font-size: ${({ size }) => typography.size[size.medium]};
   `};
@@ -71,13 +71,15 @@ const Heading = ({
 
 Heading.propTypes = {
   level: PropTypes.oneOf([1, 2, 3, 4, 5]),
-  size: PropTypes.oneOf([Object.keys(typography.size)]),
+  size: PropTypes.oneOf(Object.keys(typography.size)),
   responsiveSize: PropTypes.shape({
-    small: PropTypes.oneOf([Object.keys(typography.size)]),
-    medium: PropTypes.oneOf([Object.keys(typography.size)]),
-    large: PropTypes.oneOf([Object.keys(typography.size)])
+    small: PropTypes.oneOf(Object.keys(typography.size)),
+    medium: PropTypes.oneOf(Object.keys(typography.size)),
+    large: PropTypes.oneOf(Object.keys(typography.size))
   }),
-  lineHeight: PropTypes.oneOf([Object.keys(typography.lineHeight)]),
+  weight: PropTypes.oneOf(["light", "regular", "extraBold"]),
+  lineHeight: PropTypes.oneOf(Object.keys(typography.lineHeight)),
+  monospace: PropTypes.bool,
   children: PropTypes.node
 };
 
@@ -90,14 +92,14 @@ Heading.defaultProps = {
     large: null
   },
   lineHeight: "body",
+  weight: "regular",
+  monospace: false,
   children: null
 };
 
-Heading.Span = Light; // NOTE: deprecated
-Heading.Light = Light;
-Heading.Light.displayName = "Light";
-Heading.Strong = ExtraBold; // NOTE: deprecated
-Heading.ExtraBold = ExtraBold;
-Heading.ExtraBold.displayName = "ExtraBold";
+Heading.Span = Span; // NOTE: deprecated
+Heading.Strong = Strong; // NOTE: deprecated
+
+Heading.displayName = "Heading";
 
 export default Heading;

--- a/src/components/Text/Base.js
+++ b/src/components/Text/Base.js
@@ -85,7 +85,8 @@ TextBase.propTypes = {
   secondary: PropTypes.bool,
   disabled: PropTypes.bool,
   children: PropTypes.node.isRequired,
-  allCaps: PropTypes.bool
+  allCaps: PropTypes.bool,
+  monospace: PropTypes.bool
 };
 
 TextBase.defaultProps = {
@@ -103,7 +104,8 @@ TextBase.defaultProps = {
   primary: false,
   secondary: false,
   disabled: false,
-  allCaps: false
+  allCaps: false,
+  monospace: false
 };
 
 TextBase.displayName = "Text";

--- a/src/components/Text/Base.styles.js
+++ b/src/components/Text/Base.styles.js
@@ -9,6 +9,7 @@ const Base = styled.div`
   font-weight: ${({ weight }) => typography.weight[weight]};
   line-height: ${typography.lineHeight.body};
   text-transform: ${({ allCaps }) => (allCaps ? "uppercase" : "none")};
+  ${({ monospace }) => (monospace ? `font-family: monospace, monospace` : "")};
   color: ${({ variant, accent, primary, secondary, disabled }) =>
     getFontColor({ variant, accent, primary, secondary, disabled })};
 


### PR DESCRIPTION
**What**:

Heading can receive weight prop and monospace prop

**Why**:

Heading can be used without Heading.Span and Heading.Strong. Support for monospace is required.

**How**:

Define weight prop in Heading component and use it to set font-weight. Set monospace prop to true to get monospace text or heading

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
