### PR TITLE
fix(Build) Remove cache directive from travis script since node_modules cache seems to be corrupted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: false
 language: node_js
-cache:
-  directories:
-    - node_modules
 notifications:
   email: false
 node_js:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## Please note: I am going to get the Travis CI node_modules cache cleared manually by someone with permissions, which will hopefully enable us to avert this fix.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am removing the caching directive from our Travis CI script since node_modules cache seems to be corrupted.

<!-- Why are these changes necessary? -->

**Why**: Due to our node_modules cache being corrupted, we are unable to execute the node binaries that we typically run in our CI.

<!-- How were these changes implemented? -->

**How**: I am removing the caching directive from our Travis CI script.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
