### PR TITLE
fix(Button) fallback value for theme is global

### DIFF
--- a/catalog/pages/buttons/index.md
+++ b/catalog/pages/buttons/index.md
@@ -29,7 +29,7 @@ rows:
 
 ```react
 ---
-<ThemeProvider theme={{ themeName: 'b2c' }}>
+<ThemeProvider theme={{ themeName: 'global' }}>
     <Container>
         <Row>
             <Column small={3}/>
@@ -54,7 +54,7 @@ rows:
 
 ```react
 ---
-<ThemeProvider theme={{ themeName: 'b2c' }}>
+<ThemeProvider theme={{ themeName: 'global' }}>
     <Container>
         <Row>
             <Column small={3}/>
@@ -79,7 +79,7 @@ rows:
 
 ```react
 ---
-<ThemeProvider theme={{ themeName: 'b2c' }}>
+<ThemeProvider theme={{ themeName: 'global' }}>
     <Container>
         <Row>
             <Column small={3}/>
@@ -104,6 +104,7 @@ rows:
 
 ```react
 ---
+//incorrect theme name
 <ThemeProvider theme={{ themeName: 'b2c' }}>
     <Container>
         <Row>

--- a/src/components/Button/Base.js
+++ b/src/components/Button/Base.js
@@ -1,9 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { ThemeProvider } from "styled-components";
 
 import { StyledButton, StyledButtonLink } from "./Base.styles";
 import { BUTTON_VARIANTS, BUTTON_SIZES } from "./constants";
 import getRelByTarget from "../../utils/link";
+import themes from "../../theme/colorThemes";
+
+/**
+ * Provides a default `global` theme when no theme provider is used higher up
+ * the components tree. Or incorrect theme name is used.
+ */
+const defaultTheme = ({ themeName } = {}) =>
+  Object.keys(themes).includes(themeName)
+    ? { themeName }
+    : { themeName: "global" };
 
 const Button = ({ variant, size, children, ...rest }) => {
   const { href } = rest;
@@ -25,9 +36,11 @@ const Button = ({ variant, size, children, ...rest }) => {
   }
 
   return (
-    <StyledButton variant={variant} size={size} {...rest}>
-      {children}
-    </StyledButton>
+    <ThemeProvider theme={defaultTheme}>
+      <StyledButton variant={variant} size={size} {...rest}>
+        {children}
+      </StyledButton>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/Button/Base.js
+++ b/src/components/Button/Base.js
@@ -5,16 +5,14 @@ import { ThemeProvider } from "styled-components";
 import { StyledButton, StyledButtonLink } from "./Base.styles";
 import { BUTTON_VARIANTS, BUTTON_SIZES } from "./constants";
 import getRelByTarget from "../../utils/link";
-import themes from "../../theme/colorThemes";
+import { themes } from "../../theme";
 
 /**
  * Provides a default `global` theme when no theme provider is used higher up
  * the components tree. Or incorrect theme name is used.
  */
 const defaultTheme = ({ themeName } = {}) =>
-  Object.keys(themes).includes(themeName)
-    ? { themeName }
-    : { themeName: "global" };
+  themes[themeName] ? { themeName } : { themeName: "global" };
 
 const Button = ({ variant, size, children, ...rest }) => {
   const { href } = rest;

--- a/src/components/Button/__tests__/Base.spec.js
+++ b/src/components/Button/__tests__/Base.spec.js
@@ -1,6 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { render, Simulate } from "react-testing-library";
+import { ThemeProvider } from "styled-components";
 
 import { Button } from "../";
 
@@ -13,7 +14,7 @@ describe("<Button />", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("renders standard regular size button correctly", () => {
+  it("renders stuandard regular size button correctly", () => {
     const component = renderer.create(<Button>Dummy Label</Button>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
@@ -163,5 +164,14 @@ describe("<Button />", () => {
 
     Simulate.click(getByText("Dummy Label"));
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it("should render button with global theme when incorrect theme name is used", () => {
+    const { container } = render(
+      <ThemeProvider theme={{ themeName: "test" }}>
+        <Button>Dummy Label</Button>
+      </ThemeProvider>
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/Button/__tests__/Base.spec.js
+++ b/src/components/Button/__tests__/Base.spec.js
@@ -14,7 +14,7 @@ describe("<Button />", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("renders stuandard regular size button correctly", () => {
+  it("renders standard regular size button correctly", () => {
     const component = renderer.create(<Button>Dummy Label</Button>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -546,6 +546,60 @@ exports[`<Button /> renders standard large size button correctly 1`] = `
 </button>
 `;
 
+exports[`<Button /> renders standard regular size button correctly 1`] = `
+.c0 {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 2.43;
+  width: 100%;
+  padding: 0 12px 0 12px;
+  min-width: 60px;
+  text-align: center;
+  text-transform: capitalize;
+  border-radius: 2px;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #026cdf;
+  border: 1px solid transparent;
+  -webkit-transition: -webkit-transform 0.1s linear;
+  -webkit-transition: transform 0.1s linear;
+  transition: transform 0.1s linear;
+  -webkit-transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c0:hover {
+  background-color: #0150a7;
+}
+
+.c0:active {
+  -webkit-transform: scale(0.98,0.98) translate(0,1px);
+  -ms-transform: scale(0.98,0.98) translate(0,1px);
+  transform: scale(0.98,0.98) translate(0,1px);
+  background-color: #013670;
+}
+
+.c0:disabled {
+  color: #ffffff;
+  background-color: #026cdf;
+  border: 1px solid transparent;
+  cursor: not-allowed;
+  opacity: 0.2;
+}
+
+<button
+  className="c0"
+  size="regular"
+>
+  Dummy Label
+</button>
+`;
+
 exports[`<Button /> renders standard regular size disabled button correctly 1`] = `
 .c0 {
   font-weight: 600;
@@ -650,60 +704,6 @@ exports[`<Button /> renders standard small size button correctly 1`] = `
 <button
   className="c0"
   size="small"
->
-  Dummy Label
-</button>
-`;
-
-exports[`<Button /> renders stuandard regular size button correctly 1`] = `
-.c0 {
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 2.43;
-  width: 100%;
-  padding: 0 12px 0 12px;
-  min-width: 60px;
-  text-align: center;
-  text-transform: capitalize;
-  border-radius: 2px;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #026cdf;
-  border: 1px solid transparent;
-  -webkit-transition: -webkit-transform 0.1s linear;
-  -webkit-transition: transform 0.1s linear;
-  transition: transform 0.1s linear;
-  -webkit-transition: background-color 0.3s ease;
-  transition: background-color 0.3s ease;
-}
-
-.c0:focus {
-  outline: none;
-  box-shadow: 0 0 5px 0 #026cdf;
-}
-
-.c0:hover {
-  background-color: #0150a7;
-}
-
-.c0:active {
-  -webkit-transform: scale(0.98,0.98) translate(0,1px);
-  -ms-transform: scale(0.98,0.98) translate(0,1px);
-  transform: scale(0.98,0.98) translate(0,1px);
-  background-color: #013670;
-}
-
-.c0:disabled {
-  color: #ffffff;
-  background-color: #026cdf;
-  border: 1px solid transparent;
-  cursor: not-allowed;
-  opacity: 0.2;
-}
-
-<button
-  className="c0"
-  size="regular"
 >
   Dummy Label
 </button>

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -546,60 +546,6 @@ exports[`<Button /> renders standard large size button correctly 1`] = `
 </button>
 `;
 
-exports[`<Button /> renders standard regular size button correctly 1`] = `
-.c0 {
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 2.43;
-  width: 100%;
-  padding: 0 12px 0 12px;
-  min-width: 60px;
-  text-align: center;
-  text-transform: capitalize;
-  border-radius: 2px;
-  cursor: pointer;
-  color: #ffffff;
-  background-color: #026cdf;
-  border: 1px solid transparent;
-  -webkit-transition: -webkit-transform 0.1s linear;
-  -webkit-transition: transform 0.1s linear;
-  transition: transform 0.1s linear;
-  -webkit-transition: background-color 0.3s ease;
-  transition: background-color 0.3s ease;
-}
-
-.c0:focus {
-  outline: none;
-  box-shadow: 0 0 5px 0 #026cdf;
-}
-
-.c0:hover {
-  background-color: #0150a7;
-}
-
-.c0:active {
-  -webkit-transform: scale(0.98,0.98) translate(0,1px);
-  -ms-transform: scale(0.98,0.98) translate(0,1px);
-  transform: scale(0.98,0.98) translate(0,1px);
-  background-color: #013670;
-}
-
-.c0:disabled {
-  color: #ffffff;
-  background-color: #026cdf;
-  border: 1px solid transparent;
-  cursor: not-allowed;
-  opacity: 0.2;
-}
-
-<button
-  className="c0"
-  size="regular"
->
-  Dummy Label
-</button>
-`;
-
 exports[`<Button /> renders standard regular size disabled button correctly 1`] = `
 .c0 {
   font-weight: 600;
@@ -704,6 +650,60 @@ exports[`<Button /> renders standard small size button correctly 1`] = `
 <button
   className="c0"
   size="small"
+>
+  Dummy Label
+</button>
+`;
+
+exports[`<Button /> renders stuandard regular size button correctly 1`] = `
+.c0 {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 2.43;
+  width: 100%;
+  padding: 0 12px 0 12px;
+  min-width: 60px;
+  text-align: center;
+  text-transform: capitalize;
+  border-radius: 2px;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: #026cdf;
+  border: 1px solid transparent;
+  -webkit-transition: -webkit-transform 0.1s linear;
+  -webkit-transition: transform 0.1s linear;
+  transition: transform 0.1s linear;
+  -webkit-transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c0:hover {
+  background-color: #0150a7;
+}
+
+.c0:active {
+  -webkit-transform: scale(0.98,0.98) translate(0,1px);
+  -ms-transform: scale(0.98,0.98) translate(0,1px);
+  transform: scale(0.98,0.98) translate(0,1px);
+  background-color: #013670;
+}
+
+.c0:disabled {
+  color: #ffffff;
+  background-color: #026cdf;
+  border: 1px solid transparent;
+  cursor: not-allowed;
+  opacity: 0.2;
+}
+
+<button
+  className="c0"
+  size="regular"
 >
   Dummy Label
 </button>
@@ -921,6 +921,14 @@ exports[`<Button /> renders transparent small size button correctly 1`] = `
 <button
   className="c0"
   size="small"
+>
+  Dummy Label
+</button>
+`;
+
+exports[`<Button /> should render button with global theme when incorrect theme name is used 1`] = `
+<button
+  class="sc-bdVaJa fmoPgI"
 >
   Dummy Label
 </button>

--- a/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
@@ -211,7 +211,7 @@ exports[`NavBar renders fixed 1`] = `
 
 .c0.nav--inverted {
   background-color: rgba(255,255,255,1);
-  border-bottom: 1px solid #D1D1D1;
+  border-bottom: 1px solid undefined;
   color: rgba(38,38,38,1);
   font-weight: 400;
 }
@@ -671,7 +671,7 @@ exports[`NavBar renders inverted 1`] = `
 
 .c0.nav--inverted {
   background-color: rgba(255,255,255,1);
-  border-bottom: 1px solid #D1D1D1;
+  border-bottom: 1px solid undefined;
   color: rgba(38,38,38,1);
   font-weight: 400;
 }
@@ -1175,7 +1175,7 @@ exports[`NavBar renders with defaults 1`] = `
 
 .c0.nav--inverted {
   background-color: rgba(255,255,255,1);
-  border-bottom: 1px solid #D1D1D1;
+  border-bottom: 1px solid undefined;
   color: rgba(38,38,38,1);
   font-weight: 400;
 }

--- a/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
@@ -211,7 +211,7 @@ exports[`NavBar renders fixed 1`] = `
 
 .c0.nav--inverted {
   background-color: rgba(255,255,255,1);
-  border-bottom: 1px solid undefined;
+  border-bottom: 1px solid #D1D1D1;
   color: rgba(38,38,38,1);
   font-weight: 400;
 }
@@ -671,7 +671,7 @@ exports[`NavBar renders inverted 1`] = `
 
 .c0.nav--inverted {
   background-color: rgba(255,255,255,1);
-  border-bottom: 1px solid undefined;
+  border-bottom: 1px solid #D1D1D1;
   color: rgba(38,38,38,1);
   font-weight: 400;
 }
@@ -1175,7 +1175,7 @@ exports[`NavBar renders with defaults 1`] = `
 
 .c0.nav--inverted {
   background-color: rgba(255,255,255,1);
-  border-bottom: 1px solid undefined;
+  border-bottom: 1px solid #D1D1D1;
   color: rgba(38,38,38,1);
   font-weight: 400;
 }

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -26,7 +26,7 @@ const colors = {
   summerSky: "#3AC7FF",
   blackPearl: "#1F262D",
   slate: "#999999",
-  f: "#D1D1D1",
+  moonstone: "#D1D1D1",
   shale: "#E6E6E6",
   quartz: "#f6f6f6",
   lightGray: "#E0E0E0",

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -1,5 +1,4 @@
 const colors = {
-  // Deprecated colors. Should be removed
   azure: {
     base: "rgba(2, 108, 223, 1)",
     light: "rgba(2, 108, 223, 0.2)",
@@ -27,7 +26,7 @@ const colors = {
   summerSky: "#3AC7FF",
   blackPearl: "#1F262D",
   slate: "#999999",
-  moonstone: "#D1D1D1",
+  f: "#D1D1D1",
   shale: "#E6E6E6",
   quartz: "#f6f6f6",
   lightGray: "#E0E0E0",
@@ -68,9 +67,10 @@ const colors = {
     muted: "#F5CDCD"
   },
   caution: {
-    base: "#f2bd2a",
-    dark: "#b98800",
-    light: "#fff5d9"
+    base: "#F2BD2A",
+    dark: "#C19B2E",
+    light: "#F8DE94",
+    muted: "#FBEEC9"
   },
   positive: {
     base: "#1BAB1E",
@@ -78,11 +78,6 @@ const colors = {
     light: "#8DD58E",
     muted: "#C5E9C6"
   },
-  defaultGradient: {
-    from: "#026cdf",
-    to: "#3ac7ff"
-  },
-  // Onyx and white are specific for typography. Should not be removed
   onyx: {
     base: "rgba(38, 38, 38, 1)",
     light: "rgba(38, 38, 38, 0.6)",
@@ -93,6 +88,10 @@ const colors = {
     lighter: "rgba(255, 255, 255, 0.2)",
     light: "rgba(255, 255, 255, 0.7)",
     muted: "rgba(255, 255, 255, 0.5)"
+  },
+  defaultGradient: {
+    from: "#026cdf",
+    to: "#3ac7ff"
   }
 };
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Provide a fallback value of `global` for a button theme name when an incorrect name is provided in a `themeProvider`.

<!-- Why are these changes necessary? -->

**Why**:
At the moment when a user provides an incorrect theme name an application crashes.

<!-- How were these changes implemented? -->

**How**:
Provide additional `themeProvider` that checks if a theme name specified in a provider higher up the components tree exists. If it does nothing happens, if it doesn't `global` is provided as a theme name.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
