### PR TITLE
fix(Buttons&Heading): buttons disabled state in Safari. Heading line height prop

### DIFF
--- a/src/components/Button/Base.styles.js
+++ b/src/components/Button/Base.styles.js
@@ -127,6 +127,7 @@ export const StyledButton = styled.button`
   }
 
   &:disabled {
+    transform: none;
     color: ${({ variant, theme: { themeName } }) => {
       const buttonTheme = themes[themeName];
       return colorVariants[variant](buttonTheme).color;

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -41,6 +41,9 @@ exports[`<Button /> renders link button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;
@@ -97,6 +100,9 @@ exports[`<Button /> renders outline large size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #026cdf;
   background-color: transparent;
   border: 1px solid #026cdf;
@@ -151,6 +157,9 @@ exports[`<Button /> renders outline regular size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #026cdf;
   background-color: transparent;
   border: 1px solid #026cdf;
@@ -205,6 +214,9 @@ exports[`<Button /> renders outline regular size disabled button correctly 1`] =
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #026cdf;
   background-color: transparent;
   border: 1px solid #026cdf;
@@ -260,6 +272,9 @@ exports[`<Button /> renders outline small size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #026cdf;
   background-color: transparent;
   border: 1px solid #026cdf;
@@ -314,6 +329,9 @@ exports[`<Button /> renders special large size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #1bab1e;
   border: 1px solid transparent;
@@ -368,6 +386,9 @@ exports[`<Button /> renders special regular size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #1bab1e;
   border: 1px solid transparent;
@@ -422,6 +443,9 @@ exports[`<Button /> renders special regular size disabled button correctly 1`] =
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #1bab1e;
   border: 1px solid transparent;
@@ -477,6 +501,9 @@ exports[`<Button /> renders special small size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #1bab1e;
   border: 1px solid transparent;
@@ -531,6 +558,9 @@ exports[`<Button /> renders standard large size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;
@@ -585,6 +615,9 @@ exports[`<Button /> renders standard regular size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;
@@ -639,6 +672,9 @@ exports[`<Button /> renders standard regular size disabled button correctly 1`] 
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;
@@ -694,6 +730,9 @@ exports[`<Button /> renders standard small size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;
@@ -748,6 +787,9 @@ exports[`<Button /> renders transparent large size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #026cdf;
   background-color: transparent;
   border: 1px solid transparent;
@@ -802,6 +844,9 @@ exports[`<Button /> renders transparent regular size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #026cdf;
   background-color: transparent;
   border: 1px solid transparent;
@@ -856,6 +901,9 @@ exports[`<Button /> renders transparent regular size disabled button correctly 1
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #026cdf;
   background-color: transparent;
   border: 1px solid transparent;
@@ -911,6 +959,9 @@ exports[`<Button /> renders transparent small size button correctly 1`] = `
 }
 
 .c0:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #026cdf;
   background-color: transparent;
   border: 1px solid transparent;

--- a/src/components/Header/Heading.js
+++ b/src/components/Header/Heading.js
@@ -40,14 +40,7 @@ const levels = [
   margins.withComponent("h5")
 ];
 
-const Heading = ({
-  level,
-  size,
-  responsiveSize,
-  lineHeight,
-  children,
-  ...props
-}) => {
+const Heading = ({ level, size, responsiveSize, children, ...props }) => {
   const H = levels[level - 1];
   return (
     <H
@@ -91,7 +84,7 @@ Heading.defaultProps = {
     medium: null,
     large: null
   },
-  lineHeight: "body",
+  lineHeight: "header",
   weight: "regular",
   monospace: false,
   children: null

--- a/src/components/Header/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/index.spec.js.snap
@@ -107,6 +107,7 @@ exports[`Header renders with custom level 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   padding-bottom: 8px;
+  line-height: 1.25;
   color: blue;
   font-weight: 400;
   font-size: 24px;
@@ -355,6 +356,7 @@ exports[`Header renders with default 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   padding-bottom: 8px;
+  line-height: 1.25;
   color: rgba(255,255,255,1);
   font-weight: 400;
   font-size: 24px;
@@ -602,6 +604,7 @@ exports[`Header renders withOverlay 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   padding-bottom: 8px;
+  line-height: 1.25;
   color: rgba(255,255,255,1);
   font-weight: 400;
   font-size: 24px;

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -94,7 +94,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -498,7 +498,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -902,7 +902,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -1315,7 +1315,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -1719,7 +1719,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -2123,7 +2123,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -2536,7 +2536,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -2940,7 +2940,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -3344,7 +3344,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -3757,7 +3757,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -4161,7 +4161,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -4565,7 +4565,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -4978,7 +4978,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -5223,7 +5223,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -5627,7 +5627,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -6031,7 +6031,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -6443,7 +6443,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -6847,7 +6847,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -7251,7 +7251,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -7664,7 +7664,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -8068,7 +8068,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -8472,7 +8472,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl jMcRHO"
+              class="sc-csuQGl iFsyeU"
               role="button"
               width="102px"
             >
@@ -8884,7 +8884,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -9008,7 +9008,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >
@@ -9132,7 +9132,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl jMcRHO"
+            class="sc-csuQGl iFsyeU"
             role="button"
             width="102px"
           >

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -243,6 +243,9 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
 }
 
 .c19:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;
@@ -887,6 +890,9 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 }
 
 .c19:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;
@@ -1625,6 +1631,9 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 }
 
 .c19:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;
@@ -2336,6 +2345,9 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
 }
 
 .c19:disabled {
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
   color: #ffffff;
   background-color: #026cdf;
   border: 1px solid transparent;


### PR DESCRIPTION
**What**:

Buttons disabled state in Safari is working as expected now.
Heading component uses lineHeight prop.

**Why**:

In Safari when button is disabled it should not transform.
Heading should use the line height passed as prop.

**How**:

When button is disabled sets transform css property to none.
Heading now is passing lineHeight prop to the styled component.

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->