### PR TITLE
fix(DropDown) Default label to empty string; implement placeholder

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -389,7 +389,7 @@ span: 6
 <Container>
     <Row>
         <Column medium={6}>
-            <DropDownGroup variant={0}>
+            <DropDownGroup variant={0} placeholder="Select an option">
                 <DropDownOption value="0" index={0}>Option One</DropDownOption>
                 <DropDownOption value="1" index={1}>Option Two</DropDownOption>
                 <DropDownOption value="2" index={2}>Option Three</DropDownOption>

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -75,10 +75,11 @@ const StyledChildWrapper = styled.div`
     flex: 1;
     display: flex;
     overflow: auto;
-    height: 135px;
     width: 100%;
     overflow-x: hidden;
     z-index: 10;
+    height: auto;
+    max-height: 300px;
   }
 `;
 
@@ -149,7 +150,7 @@ class DropDownGroup extends React.Component {
   };
 
   getCurrentSelection = value => {
-    const [label = null] = React.Children.toArray(this.props.children).filter(
+    const [label = ""] = React.Children.toArray(this.props.children).filter(
       c => c.props.value === value
     );
 
@@ -166,7 +167,9 @@ class DropDownGroup extends React.Component {
   };
 
   displayLabel = (selected, variant) => {
-    if (variant === 0 && selected.length === 0) return selected.length === 0;
+    const { placeholder } = this.props;
+
+    if (variant === 0 && selected.length === 0) return placeholder;
 
     if (variant === 0 && selected.length > 0)
       return this.getCurrentSelection(selected[0]);

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -16,9 +16,16 @@ describe("DropDownGroup", () => {
     expect(renderComponent().container.firstChild).toMatchSnapshot();
   });
 
-  it("renders variant 1", () => {
+  it("renders variant 0 with a placeholder prop", () => {
     expect(
       renderComponent({ placeholder: "Select An Option", variant: 1 }).container
+        .firstChild
+    ).toMatchSnapshot();
+  });
+
+  it("renders variant 1 with a label prop", () => {
+    expect(
+      renderComponent({ label: "Selected Option:", variant: 1 }).container
         .firstChild
     ).toMatchSnapshot();
   });

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -34,7 +34,7 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown--clicked sc-bwzfXH jymXbx"
+      class="dropdown__items dropdown--clicked sc-bwzfXH bNMXLY"
     >
       <div
         class="sc-EHOje hRvppO"
@@ -104,7 +104,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown--clicked sc-bwzfXH jymXbx"
+      class="dropdown__items dropdown--clicked sc-bwzfXH bNMXLY"
     >
       <div
         class="sc-EHOje hRvppO"
@@ -174,7 +174,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH jymXbx"
+      class="dropdown__items sc-bwzfXH bNMXLY"
     >
       <div
         class="sc-EHOje hRvppO"
@@ -244,7 +244,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH jymXbx"
+      class="dropdown__items sc-bwzfXH bNMXLY"
     >
       <div
         class="sc-EHOje hRvppO"
@@ -318,7 +318,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH jymXbx"
+      class="dropdown__items sc-bwzfXH bNMXLY"
     >
       <div
         class="sc-EHOje hRvppO"
@@ -388,7 +388,7 @@ exports[`DropDownGroup renders default input 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH jymXbx"
+      class="dropdown__items sc-bwzfXH bNMXLY"
     >
       <div
         class="sc-EHOje hRvppO"
@@ -424,7 +424,7 @@ exports[`DropDownGroup renders default input 1`] = `
 </div>
 `;
 
-exports[`DropDownGroup renders variant 1 1`] = `
+exports[`DropDownGroup renders variant 0 with a placeholder prop 1`] = `
 <div
   data-testid="test-outSideComponent"
 >
@@ -445,7 +445,7 @@ exports[`DropDownGroup renders variant 1 1`] = `
       <div
         class="dropdown--selected dropdown--no-border sc-ifAKCX dIQjbB"
       >
-        Sort By: null
+        Sort By: 
       </div>
       <svg
         class="dropdown--no-border sc-bxivhb bfTkLM"
@@ -460,7 +460,79 @@ exports[`DropDownGroup renders variant 1 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH jymXbx"
+      class="dropdown__items sc-bwzfXH bNMXLY"
+    >
+      <div
+        class="sc-EHOje hRvppO"
+        role="listbox"
+      >
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionOne"
+          tabindex="-1"
+          value="ValueOne"
+        >
+          Option One
+        </span>
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionTwo"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionThree"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div>
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    class="sc-htpNat dEypGd"
+    data-testid="test-dropContainer"
+    label="Selected Option:"
+    placeholder=""
+    tabindex="0"
+  >
+    <label
+      class="dropdown--no-border sc-bdVaJa jOVSaQ"
+    >
+      <div
+        class="dropdown--selected dropdown--no-border sc-ifAKCX dIQjbB"
+      >
+        Selected Option: 
+      </div>
+      <svg
+        class="dropdown--no-border sc-bxivhb bfTkLM"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items sc-bwzfXH bNMXLY"
     >
       <div
         class="sc-EHOje hRvppO"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am defaulting `label` to an empty string, rather than `null` and implementing the `placeholder` prop for `variant` 0.

<!-- Why are these changes necessary? -->

**Why**: I am proposing these changes to ensure `null` never appears on the front-end when a label is missing and to enable the use of a placeholder for `variant` 0.

<!-- How were these changes implemented? -->

**How**: I have made these changes within `src/components/Input/DropDown/DropDownGroup.js`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
