### PR TITLE
fix(Colors): remove gray06 and replace it with white

### DIFF
--- a/src/components/Button/Base.styles.js
+++ b/src/components/Button/Base.styles.js
@@ -5,32 +5,32 @@ import { typography, constants, themes } from "../../theme";
 
 const colorVariants = {
   standard: theme => ({
-    color: theme.gray06,
+    color: theme.white.base,
     backgroundColor: theme.primary.base,
     backgroundColorHover: theme.primary.medium,
     backgroundColorPressed: theme.primary.dark,
     borderColor: theme.transparent
   }),
   standardDisabled: theme => ({
-    color: theme.gray06,
+    color: theme.white.base,
     backgroundColor: theme.primary.base,
     borderColor: theme.transparent
   }),
   special: theme => ({
-    color: theme.gray06,
+    color: theme.white.base,
     backgroundColor: theme.special.base,
     backgroundColorHover: theme.special.medium,
     backgroundColorPressed: theme.special.dark,
     borderColor: theme.transparent
   }),
   specialDisabled: theme => ({
-    color: theme.gray06,
+    color: theme.white.base,
     backgroundColor: theme.special.base,
     borderColor: theme.transparent
   }),
   outline: theme => ({
     color: theme.primary.base,
-    backgroundColor: theme.gray06,
+    backgroundColor: theme.white.base,
     backgroundColorHover: theme.primary.light,
     backgroundColorPressed: theme.primary.muted,
     borderColor: theme.primary.base

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -12,7 +12,7 @@ exports[`<Button /> renders link button correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -44,7 +44,7 @@ exports[`<Button /> renders link button correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -74,7 +74,7 @@ exports[`<Button /> renders outline large size button correctly 1`] = `
   border-radius: 2px;
   cursor: pointer;
   color: #026cdf;
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
   border: 1px solid #026cdf;
   -webkit-transition: -webkit-transform 0.1s linear;
   -webkit-transition: transform 0.1s linear;
@@ -131,7 +131,7 @@ exports[`<Button /> renders outline regular size button correctly 1`] = `
   border-radius: 2px;
   cursor: pointer;
   color: #026cdf;
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
   border: 1px solid #026cdf;
   -webkit-transition: -webkit-transform 0.1s linear;
   -webkit-transition: transform 0.1s linear;
@@ -188,7 +188,7 @@ exports[`<Button /> renders outline regular size disabled button correctly 1`] =
   border-radius: 2px;
   cursor: pointer;
   color: #026cdf;
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
   border: 1px solid #026cdf;
   -webkit-transition: -webkit-transform 0.1s linear;
   -webkit-transition: transform 0.1s linear;
@@ -246,7 +246,7 @@ exports[`<Button /> renders outline small size button correctly 1`] = `
   border-radius: 2px;
   cursor: pointer;
   color: #026cdf;
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
   border: 1px solid #026cdf;
   -webkit-transition: -webkit-transform 0.1s linear;
   -webkit-transition: transform 0.1s linear;
@@ -302,7 +302,7 @@ exports[`<Button /> renders special large size button correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #1bab1e;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -332,7 +332,7 @@ exports[`<Button /> renders special large size button correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #1bab1e;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -359,7 +359,7 @@ exports[`<Button /> renders special regular size button correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #1bab1e;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -389,7 +389,7 @@ exports[`<Button /> renders special regular size button correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #1bab1e;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -416,7 +416,7 @@ exports[`<Button /> renders special regular size disabled button correctly 1`] =
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #1bab1e;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -446,7 +446,7 @@ exports[`<Button /> renders special regular size disabled button correctly 1`] =
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #1bab1e;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -474,7 +474,7 @@ exports[`<Button /> renders special small size button correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #1bab1e;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -504,7 +504,7 @@ exports[`<Button /> renders special small size button correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #1bab1e;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -531,7 +531,7 @@ exports[`<Button /> renders standard large size button correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -561,7 +561,7 @@ exports[`<Button /> renders standard large size button correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -588,7 +588,7 @@ exports[`<Button /> renders standard regular size button correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -618,7 +618,7 @@ exports[`<Button /> renders standard regular size button correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -645,7 +645,7 @@ exports[`<Button /> renders standard regular size disabled button correctly 1`] 
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -675,7 +675,7 @@ exports[`<Button /> renders standard regular size disabled button correctly 1`] 
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -703,7 +703,7 @@ exports[`<Button /> renders standard small size button correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -733,7 +733,7 @@ exports[`<Button /> renders standard small size button correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;

--- a/src/components/Input/Toggle/Toggle.styles.js
+++ b/src/components/Input/Toggle/Toggle.styles.js
@@ -54,7 +54,7 @@ export const ReactToggleTrack = styled.div`
   }
 
   .toggle--inactive & {
-    background-color: ${themes.global.gray06};
+    background-color: ${themes.global.white.base};
     border-color: ${themes.global.gray02};
   }
 
@@ -121,7 +121,7 @@ export const ReactToggleThumb = styled.div`
   }
 
   .toggle--active & {
-    background-color: ${themes.global.gray06};
+    background-color: ${themes.global.white.base};
   }
 
   .toggle--inactive & {

--- a/src/components/Input/__tests__/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Toggle.spec.js.snap
@@ -74,7 +74,7 @@ exports[`<Toggle /> renders regular disabled active toggle correctly 1`] = `
 }
 
 .toggle--inactive .c3 {
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
   border-color: #999999;
 }
 
@@ -172,7 +172,7 @@ exports[`<Toggle /> renders regular disabled active toggle correctly 1`] = `
 }
 
 .toggle--active .c5 {
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
 }
 
 .toggle--inactive .c5 {
@@ -293,7 +293,7 @@ exports[`<Toggle /> renders regular disabled inactive toggle correctly 1`] = `
 }
 
 .toggle--inactive .c3 {
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
   border-color: #999999;
 }
 
@@ -391,7 +391,7 @@ exports[`<Toggle /> renders regular disabled inactive toggle correctly 1`] = `
 }
 
 .toggle--active .c5 {
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
 }
 
 .toggle--inactive .c5 {
@@ -512,7 +512,7 @@ exports[`<Toggle /> renders regular size active toggle correctly 1`] = `
 }
 
 .toggle--inactive .c3 {
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
   border-color: #999999;
 }
 
@@ -610,7 +610,7 @@ exports[`<Toggle /> renders regular size active toggle correctly 1`] = `
 }
 
 .toggle--active .c5 {
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
 }
 
 .toggle--inactive .c5 {
@@ -731,7 +731,7 @@ exports[`<Toggle /> renders small size active toggle correctly 1`] = `
 }
 
 .toggle--inactive .c3 {
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
   border-color: #999999;
 }
 
@@ -829,7 +829,7 @@ exports[`<Toggle /> renders small size active toggle correctly 1`] = `
 }
 
 .toggle--active .c5 {
-  background-color: #ffffff;
+  background-color: rgba(255,255,255,1);
 }
 
 .toggle--inactive .c5 {

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -94,7 +94,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -498,7 +498,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -902,7 +902,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -1315,7 +1315,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -1719,7 +1719,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -2123,7 +2123,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -2536,7 +2536,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -2940,7 +2940,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -3344,7 +3344,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -3757,7 +3757,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -4161,7 +4161,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -4565,7 +4565,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -4978,7 +4978,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -5223,7 +5223,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -5627,7 +5627,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -6031,7 +6031,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -6443,7 +6443,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -6847,7 +6847,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -7251,7 +7251,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -7664,7 +7664,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -8068,7 +8068,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -8472,7 +8472,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-csuQGl iFsyeU"
+              class="sc-csuQGl cVbJVv"
               role="button"
               width="102px"
             >
@@ -8884,7 +8884,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -9008,7 +9008,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >
@@ -9132,7 +9132,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-csuQGl iFsyeU"
+            class="sc-csuQGl cVbJVv"
             role="button"
             width="102px"
           >

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -200,7 +200,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -246,7 +246,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -847,7 +847,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -893,7 +893,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -1588,7 +1588,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -1634,7 +1634,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;
@@ -2302,7 +2302,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
   text-transform: capitalize;
   border-radius: 2px;
   cursor: pointer;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   -webkit-transition: -webkit-transform 0.1s linear;
@@ -2348,7 +2348,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
-  color: #ffffff;
+  color: rgba(255,255,255,1);
   background-color: #026cdf;
   border: 1px solid transparent;
   cursor: not-allowed;

--- a/src/theme/colorThemes.js
+++ b/src/theme/colorThemes.js
@@ -34,7 +34,6 @@ const global = {
   gray03: "#bfbfbf",
   gray04: "#ebebeb",
   gray05: "#f6f6f6",
-  gray06: "#ffffff",
   error: {
     base: "#d93a3a",
     dark: "#a22b2b",


### PR DESCRIPTION
**What**:

Removed gray06 color and use white instead.

**Why**:

White is better description for this hex code

**How**:

Removed gray06 from the colors definition and replaced its usage with white.base

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
