### PR TITLE
fix(SearchInput): fixed typo in pseudo-element for IE

### DIFF
--- a/src/components/Input/Search.js
+++ b/src/components/Input/Search.js
@@ -35,7 +35,7 @@ const Input = styled.input.attrs({
   &::placeholder {
     color: ${props => (props.invert ? "#26262699" : colors.white.base)};
   }
-  &::ms-clear {
+  &::-ms-clear {
     display: none;
   }
   &::-webkit-search-cancel-button {

--- a/src/components/Input/__tests__/__snapshots__/Search.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Search.spec.js.snap
@@ -49,7 +49,7 @@ exports[`SearchInput renders default input 1`] = `
   color: rgba(255,255,255,1);
 }
 
-.c2::ms-clear {
+.c2::-ms-clear {
   display: none;
 }
 
@@ -167,7 +167,7 @@ exports[`SearchInput renders inverted input 1`] = `
   color: #26262699;
 }
 
-.c2::ms-clear {
+.c2::-ms-clear {
   display: none;
 }
 
@@ -285,7 +285,7 @@ exports[`SearchInput renders slim & inverted input 1`] = `
   color: #26262699;
 }
 
-.c2::ms-clear {
+.c2::-ms-clear {
   display: none;
 }
 
@@ -403,7 +403,7 @@ exports[`SearchInput renders slim input 1`] = `
   color: rgba(255,255,255,1);
 }
 
-.c2::ms-clear {
+.c2::-ms-clear {
   display: none;
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix typo in CSS pseudo-element for SearchInput

<!-- Why are these changes necessary? -->

**Why**: IE creates unwanted clear button at the edge of an input

<!-- How were these changes implemented? -->

**How**: Typo in CSS pseudo-element was fixed

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
