### PR TITLE
fix(Toggle) no focus onclick and box sizing update

### DIFF
--- a/src/components/Input/Toggle/Toggle.js
+++ b/src/components/Input/Toggle/Toggle.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
@@ -12,47 +12,55 @@ import {
   ReactThumbCenteringContainer
 } from "./Toggle.styles";
 
-const Toggle = ({ value, size, disabled, onClick, onToggle, ...rest }) => (
-  <ActiveArea
-    className={classNames(
-      disabled ? "toggle--disabled" : "toggle--enabled",
-      value ? "toggle--active" : "toggle--inactive",
-      {
-        "toggle--small": size === "small",
-        "toggle--large": size === "large"
-      }
-    )}
-    role="switch"
-    aria-checked={value}
-    size={size}
-    onClick={composeEventHandlers(onClick, onToggle)}
-    disabled={disabled}
-    {...rest}
-  >
-    <ReactToggle>
-      <ReactToggleTrack />
-      <ReactThumbCenteringContainer>
-        <ReactToggleThumb />
-      </ReactThumbCenteringContainer>
-    </ReactToggle>
-  </ActiveArea>
-);
-
-Toggle.propTypes = {
-  value: PropTypes.bool.isRequired,
-  onToggle: PropTypes.func,
-  onClick: PropTypes.func,
-  size: PropTypes.oneOf(TOGGLE_SIZES),
-  disabled: PropTypes.bool
-};
-
 const noop = () => {};
 
-Toggle.defaultProps = {
-  disabled: false,
-  onClick: noop,
-  onToggle: noop,
-  size: TOGGLE_SIZES[1]
-};
+class Toggle extends Component {
+  static propTypes = {
+    value: PropTypes.bool.isRequired,
+    onToggle: PropTypes.func,
+    onClick: PropTypes.func,
+    size: PropTypes.oneOf(TOGGLE_SIZES),
+    disabled: PropTypes.bool
+  };
+  static defaultProps = {
+    disabled: false,
+    onClick: noop,
+    onToggle: noop,
+    size: TOGGLE_SIZES[1]
+  };
+  render() {
+    const { value, size, disabled, onClick, onToggle, ...rest } = this.props;
+    return (
+      <ActiveArea
+        className={classNames(
+          disabled ? "toggle--disabled" : "toggle--enabled",
+          value ? "toggle--active" : "toggle--inactive",
+          {
+            "toggle--small": size === "small",
+            "toggle--large": size === "large"
+          }
+        )}
+        role="switch"
+        aria-checked={value}
+        size={size}
+        onClick={composeEventHandlers(onClick, onToggle, () =>
+          this.activeArea.blur()
+        )}
+        disabled={disabled}
+        {...rest}
+        innerRef={el => {
+          this.activeArea = el;
+        }}
+      >
+        <ReactToggle>
+          <ReactToggleTrack />
+          <ReactThumbCenteringContainer>
+            <ReactToggleThumb />
+          </ReactThumbCenteringContainer>
+        </ReactToggle>
+      </ActiveArea>
+    );
+  }
+}
 
 export default Toggle;

--- a/src/components/Input/Toggle/Toggle.styles.js
+++ b/src/components/Input/Toggle/Toggle.styles.js
@@ -29,6 +29,7 @@ export const ActiveArea = styled.button`
 `;
 
 export const ReactToggleTrack = styled.div`
+  box-sizing: border-box;
   padding: 0;
   border-radius: 21px;
   display: flex;

--- a/src/components/Input/__tests__/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Toggle.spec.js.snap
@@ -38,6 +38,7 @@ exports[`<Toggle /> renders regular disabled active toggle correctly 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   padding: 0;
   border-radius: 21px;
   display: -webkit-box;
@@ -257,6 +258,7 @@ exports[`<Toggle /> renders regular disabled inactive toggle correctly 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   padding: 0;
   border-radius: 21px;
   display: -webkit-box;
@@ -476,6 +478,7 @@ exports[`<Toggle /> renders regular size active toggle correctly 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   padding: 0;
   border-radius: 21px;
   display: -webkit-box;
@@ -695,6 +698,7 @@ exports[`<Toggle /> renders small size active toggle correctly 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   padding: 0;
   border-radius: 21px;
   display: -webkit-box;


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Toggle elements should not get focus after a click. And a box-sizing: border-box rule is added.
<!-- Why are these changes necessary? -->

**Why**:
Requirements for no focus. Styling updated due to a bug.
<!-- How were these changes implemented? -->

**How**:
element.blur() is called after click. Once we merge PRs that have `blur` function I will extract it and move it to `src/utils`.
The component is turned into a class component because it uses refs to get access to the correct target for triggering `blur`
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
