### PR TITLE
fix(DropDown): fix DropDownGroup and DropDownItem styling

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -76,6 +76,9 @@ const StyledChildWrapper = styled.div`
     display: flex;
     overflow: auto;
     height: 135px;
+    width: 100%;
+    overflow-x: hidden;
+    z-index: 10;
   }
 `;
 
@@ -83,6 +86,7 @@ const StyledGroupWrapper = styled.div`
   position: relative;
   color: grey;
   width: 100%;
+  outline: none;
 `;
 
 const StyledChevron = styled(ChevronIcon)`

--- a/src/components/Input/DropDown/DropDownInput.js
+++ b/src/components/Input/DropDown/DropDownInput.js
@@ -8,16 +8,16 @@ const StyledDropDownItem = styled.span`
   .dropdown__items & {
     appearance: none;
     height: 36px;
-    margin-left: 8px;
-    margin-right: 8px;
-    margin-top: 4px;
-    padding: 0 12px;
+    margin: 4px 8px 0 8px;
+    padding: 7px 12px;
     font-size: 16px;
     text-align: left;
     border: none;
     background-color: ${colors.white.base};
-    display: flex;
     align-items: center;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+
     &:hover,
     &:focus,
     &.dropdown__selected {

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -9,7 +9,7 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
   </div>
   <div
     aria-haspopup="listbox"
-    class="sc-htpNat bEXorH"
+    class="sc-htpNat dEypGd"
     data-testid="test-dropContainer"
     label="Sort By:"
     placeholder=""
@@ -34,14 +34,14 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown--clicked sc-bwzfXH ewSIUN"
+      class="dropdown__items dropdown--clicked sc-bwzfXH jymXbx"
     >
       <div
         class="sc-EHOje hRvppO"
         role="listbox"
       >
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionOne"
           tabindex="-1"
           value="ValueOne"
@@ -49,7 +49,7 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
           Option One
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionTwo"
           tabindex="-1"
           value="ValueTwo"
@@ -57,7 +57,7 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
           Second Option
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionThree"
           tabindex="-1"
           value="ValueThree"
@@ -79,7 +79,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   </div>
   <div
     aria-haspopup="listbox"
-    class="sc-htpNat bEXorH"
+    class="sc-htpNat dEypGd"
     data-testid="test-dropContainer"
     label="Sort By:"
     placeholder=""
@@ -104,14 +104,14 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown--clicked sc-bwzfXH ewSIUN"
+      class="dropdown__items dropdown--clicked sc-bwzfXH jymXbx"
     >
       <div
         class="sc-EHOje hRvppO"
         role="listbox"
       >
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionOne"
           tabindex="-1"
           value="ValueOne"
@@ -119,7 +119,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
           Option One
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionTwo"
           tabindex="-1"
           value="ValueTwo"
@@ -127,7 +127,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
           Second Option
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionThree"
           tabindex="-1"
           value="ValueThree"
@@ -149,7 +149,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   </div>
   <div
     aria-haspopup="listbox"
-    class="sc-htpNat bEXorH"
+    class="sc-htpNat dEypGd"
     data-testid="test-dropContainer"
     label="Sort By:"
     placeholder=""
@@ -174,14 +174,14 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH ewSIUN"
+      class="dropdown__items sc-bwzfXH jymXbx"
     >
       <div
         class="sc-EHOje hRvppO"
         role="listbox"
       >
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionOne"
           tabindex="-1"
           value="ValueOne"
@@ -189,7 +189,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
           Option One
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionTwo"
           tabindex="-1"
           value="ValueTwo"
@@ -197,7 +197,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
           Second Option
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionThree"
           tabindex="-1"
           value="ValueThree"
@@ -219,7 +219,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   </div>
   <div
     aria-haspopup="listbox"
-    class="sc-htpNat bEXorH"
+    class="sc-htpNat dEypGd"
     data-testid="test-dropContainer"
     label="Sort By:"
     placeholder=""
@@ -244,14 +244,14 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH ewSIUN"
+      class="dropdown__items sc-bwzfXH jymXbx"
     >
       <div
         class="sc-EHOje hRvppO"
         role="listbox"
       >
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionOne"
           tabindex="-1"
           value="ValueOne"
@@ -259,7 +259,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
           Option One
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionTwo"
           tabindex="-1"
           value="ValueTwo"
@@ -267,7 +267,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
           Second Option
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionThree"
           tabindex="-1"
           value="ValueThree"
@@ -291,7 +291,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   </div>
   <div
     aria-haspopup="listbox"
-    class="sc-htpNat bEXorH"
+    class="sc-htpNat dEypGd"
     data-testid="test-dropContainer"
     label="Sort By:"
     placeholder=""
@@ -318,14 +318,14 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH ewSIUN"
+      class="dropdown__items sc-bwzfXH jymXbx"
     >
       <div
         class="sc-EHOje hRvppO"
         role="listbox"
       >
         <span
-          class="dropdown__selected sc-bZQynM kkZNKr"
+          class="dropdown__selected sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionOne"
           tabindex="-1"
           value="ValueOne"
@@ -333,7 +333,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
           Option One
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionTwo"
           tabindex="-1"
           value="ValueTwo"
@@ -341,7 +341,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
           Second Option
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionThree"
           tabindex="-1"
           value="ValueThree"
@@ -363,7 +363,7 @@ exports[`DropDownGroup renders default input 1`] = `
   </div>
   <div
     aria-haspopup="listbox"
-    class="sc-htpNat bEXorH"
+    class="sc-htpNat dEypGd"
     data-testid="test-dropContainer"
     label="Sort By:"
     placeholder=""
@@ -388,14 +388,14 @@ exports[`DropDownGroup renders default input 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH ewSIUN"
+      class="dropdown__items sc-bwzfXH jymXbx"
     >
       <div
         class="sc-EHOje hRvppO"
         role="listbox"
       >
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionOne"
           tabindex="-1"
           value="ValueOne"
@@ -403,7 +403,7 @@ exports[`DropDownGroup renders default input 1`] = `
           Option One
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionTwo"
           tabindex="-1"
           value="ValueTwo"
@@ -411,7 +411,7 @@ exports[`DropDownGroup renders default input 1`] = `
           Second Option
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionThree"
           tabindex="-1"
           value="ValueThree"
@@ -433,7 +433,7 @@ exports[`DropDownGroup renders variant 1 1`] = `
   </div>
   <div
     aria-haspopup="listbox"
-    class="sc-htpNat bEXorH"
+    class="sc-htpNat dEypGd"
     data-testid="test-dropContainer"
     label="Sort By:"
     placeholder="Select An Option"
@@ -460,14 +460,14 @@ exports[`DropDownGroup renders variant 1 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items sc-bwzfXH ewSIUN"
+      class="dropdown__items sc-bwzfXH jymXbx"
     >
       <div
         class="sc-EHOje hRvppO"
         role="listbox"
       >
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionOne"
           tabindex="-1"
           value="ValueOne"
@@ -475,7 +475,7 @@ exports[`DropDownGroup renders variant 1 1`] = `
           Option One
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionTwo"
           tabindex="-1"
           value="ValueTwo"
@@ -483,7 +483,7 @@ exports[`DropDownGroup renders variant 1 1`] = `
           Second Option
         </span>
         <span
-          class="sc-bZQynM kkZNKr"
+          class="sc-bZQynM kUhPug"
           data-testid="test-dropDownOptionThree"
           tabindex="-1"
           value="ValueThree"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixed several DropDown styling issues:
- removed accessive blue outline of a DropDown Container on click;
- made DropDown items list the same width as the input itself;
- truncated DropDown list item, if the text if longer than DropDown input;
- set DropDown items list z-index to 10, so that it lays on top of other page elements.

<!-- Why are these changes necessary? -->

**Why**: due to incorrect DropDown appearance.

<!-- How were these changes implemented? -->

**How**: Fixed CSS styling for those components.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
