### PR TITLE
fix(CalendarView): fix key warning in <DayTile />

### DIFF
--- a/catalog/pages/calendar_view/index.md
+++ b/catalog/pages/calendar_view/index.md
@@ -12,11 +12,11 @@ rows:
     Default: "null"
     Notes: Optional
   - Prop: ctaButtons
-    Type: array<DayTile.Button>
-    Notes: Optional. CTA Buttons / Links corresponding to the data displayed (eg. links to EDP). Usage of <DayTile.Button /> component is required to in order to get proper button's style.
+    Type: element<DayTile.ButtonsGroup>
+    Notes: Optional. CTA Buttons / Links corresponding to the data displayed (eg. links to EDP). Usage of <DayTile.ButtonsGroup />, <DayTile.ButtonsGroup.Item />, <DayTile.Button /> components is required in order to get proper button's style.
   - Prop: dateLabel
-    Type: node
-    Notes: Required. A numeric "day of month" value
+    Type: string
+    Notes: Required. A string that contains numeric "day of month" value
   - Prop: image
     Type: node
     Default: "null"
@@ -30,9 +30,9 @@ rows:
     Default: "false"
     Notes: Optional. A flag that controls highlighted state (eg. in case of present local events)
   - Prop: moreButton
-    Type: element
+    Type: element<DayTile.MoreButton>
     Default: "null"
-    Notes: Optional. A button to use in place of More Button (eg. if more than 2 CTA buttons required, a "+X More y" label is recommended)
+    Notes: Optional. A button to use in place of More Button (eg. if more than 2 CTA buttons required, a "+X More y" label is recommended). Usage of <DayTile.MoreButton /> component is required in order to achieve proper styling.
   - Prop: onOverflowClick
     Type: function
     Notes: Optional. An `onClick` handler for the Overflow Button
@@ -61,10 +61,14 @@ responsive: true
   title="Henderson, NV — Sunset Station Outdoor Amphitheater"
   subTitle="On Sale: Fri, 08/17/18 10:00 AM"
   ctaButtons={
-    [
-      <DayTile.Button>2:00 pm</DayTile.Button>,
-      <DayTile.Button>6:00 pm</DayTile.Button>
-    ]
+    <DayTile.ButtonsGroup>
+        <DayTile.ButtonsGroup.Item>
+          <DayTile.Button>2:00 pm</DayTile.Button>
+        </DayTile.ButtonsGroup.Item>
+        <DayTile.ButtonsGroup.Item>
+          <DayTile.Button>6:00 pm</DayTile.Button>
+        </DayTile.ButtonsGroup.Item>
+    </DayTile.ButtonsGroup>
   }
   moreButton={
     <DayTile.MoreButton
@@ -93,10 +97,14 @@ responsive: true
   title="Henderson, NV — Sunset Station Outdoor Amphitheater"
   subTitle="On Sale: Fri, 08/17/18 10:00 AM"
   ctaButtons={
-    [
-      <DayTile.Button>2:00 pm</DayTile.Button>,
-      <DayTile.Button>6:00 pm</DayTile.Button>
-    ]
+    <DayTile.ButtonsGroup>
+        <DayTile.ButtonsGroup.Item>
+          <DayTile.Button>2:00 pm</DayTile.Button>
+        </DayTile.ButtonsGroup.Item>
+        <DayTile.ButtonsGroup.Item>
+          <DayTile.Button>6:00 pm</DayTile.Button>
+        </DayTile.ButtonsGroup.Item>
+    </DayTile.ButtonsGroup>
   }
   moreButton={
     <DayTile.MoreButton
@@ -134,10 +142,14 @@ responsive: true
     />
   }
   ctaButtons={
-    [
-      <DayTile.Button>2:00 pm</DayTile.Button>,
-      <DayTile.Button>6:00 pm</DayTile.Button>
-    ]
+    <DayTile.ButtonsGroup>
+        <DayTile.ButtonsGroup.Item>
+          <DayTile.Button>2:00 pm</DayTile.Button>
+        </DayTile.ButtonsGroup.Item>
+        <DayTile.ButtonsGroup.Item>
+          <DayTile.Button>6:00 pm</DayTile.Button>
+        </DayTile.ButtonsGroup.Item>
+    </DayTile.ButtonsGroup>
   }
   moreButton={
     <DayTile.MoreButton
@@ -174,10 +186,14 @@ responsive: true
     />
   }
   ctaButtons={
-    [
-      <DayTile.Button>2:00 pm</DayTile.Button>,
-      <DayTile.Button>6:00 pm</DayTile.Button>
-    ]
+    <DayTile.ButtonsGroup>
+        <DayTile.ButtonsGroup.Item>
+          <DayTile.Button>2:00 pm</DayTile.Button>
+        </DayTile.ButtonsGroup.Item>
+        <DayTile.ButtonsGroup.Item>
+          <DayTile.Button>6:00 pm</DayTile.Button>
+        </DayTile.ButtonsGroup.Item>
+    </DayTile.ButtonsGroup>
   }
   moreButton={
     <DayTile.MoreButton

--- a/src/components/CalendarView/DayTile.js
+++ b/src/components/CalendarView/DayTile.js
@@ -57,15 +57,7 @@ const DayTile = ({
         {withImage ? overflowButton : null}
       </DayTileContent>
       <DayTileFooter>
-        {ctaButtons.length ? (
-          <DayTileButtonsGroup>
-            {ctaButtons.map(button => (
-              <DayTileButtonsGroup.Item key={button}>
-                {button}
-              </DayTileButtonsGroup.Item>
-            ))}
-          </DayTileButtonsGroup>
-        ) : null}
+        {ctaButtons}
         {moreButton}
       </DayTileFooter>
       {children}
@@ -75,7 +67,7 @@ const DayTile = ({
 
 DayTile.propTypes = {
   children: PropTypes.node,
-  ctaButtons: PropTypes.arrayOf(PropTypes.element),
+  ctaButtons: PropTypes.element,
   dateLabel: PropTypes.string.isRequired,
   image: PropTypes.element,
   isDisabled: PropTypes.bool,
@@ -89,7 +81,7 @@ DayTile.propTypes = {
 
 DayTile.defaultProps = {
   children: null,
-  ctaButtons: [],
+  ctaButtons: null,
   image: null,
   isDisabled: false,
   isHighlighted: false,
@@ -100,6 +92,7 @@ DayTile.defaultProps = {
   withOverflow: false
 };
 
+DayTile.ButtonsGroup = DayTileButtonsGroup;
 DayTile.Button = DayTileButton;
 DayTile.MoreButton = DayTileMoreButton;
 

--- a/src/components/CalendarView/__tests__/DayTile.spec.js
+++ b/src/components/CalendarView/__tests__/DayTile.spec.js
@@ -6,10 +6,16 @@ const DEFAULT_PROPS = {
   dateLabel: "10",
   title: "Henderson, NV — Sunset Station Outdoor Amphitheater",
   subTitle: "On Sale: Fri, 08/17/18 10:00 AM",
-  ctaButtons: [
-    <DayTile.Button>2:00 pm</DayTile.Button>,
-    <DayTile.Button>6:00 pm</DayTile.Button>
-  ],
+  ctaButtons: (
+    <DayTile.ButtonsGroup>
+      <DayTile.ButtonsGroup.Item>
+        <DayTile.Button>2:00 pm</DayTile.Button>
+      </DayTile.ButtonsGroup.Item>
+      <DayTile.ButtonsGroup.Item>
+        <DayTile.Button>6:00 pm</DayTile.Button>
+      </DayTile.ButtonsGroup.Item>
+    </DayTile.ButtonsGroup>
+  ),
   moreButton: <DayTile.MoreButton>+4 More Times</DayTile.MoreButton>,
   onOverflowClick: () => {},
   withOverflow: true


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Current implementation pollutes console with a warning about child's keys not being unique, as a React.Element has been used as a key in DayTile's Button Group. 
<!-- Why are these changes necessary? -->

**Why**:

That's wrong, error-prone, pollutes logs and we don't want that.
<!-- How were these changes implemented? -->

**How**:

Changed component's ctaButtons prop to accept ButtonsGroup element instead of an array that makes it hard to determine the key, as throughout the library we do not allow array indexes as keys (enforced by https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md)
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
