### PR TITLE
fix(Breadcrumbs): remove unnecessary styles

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumb.js
+++ b/src/components/Breadcrumbs/Breadcrumb.js
@@ -11,7 +11,6 @@ const Breadcrumb = ({ children, className, variant, ...props }) => (
       className={classNames(className, `breadcrumb--${variant}`)}
       itemScope
       itemType="http://schema.org/Breadcrumb"
-      childrenLen={children && Array.from(children).length}
     >
       {children}
     </StyledBreadcrumb>

--- a/src/components/Breadcrumbs/Breadcrumb.styles.js
+++ b/src/components/Breadcrumbs/Breadcrumb.styles.js
@@ -7,11 +7,7 @@ const StyledBreadcrumb = ListUnstyled.extend`
   font-weight: ${typography.weight.semiBold};
   display: flex;
   flex-flow: row;
-  ${({ childrenLen }) =>
-    childrenLen &&
-    `
-    flex: 0 1 ${Math.floor(100 / childrenLen)}%;
-  `} align-items: center;
+  align-items: center;
 
   &.breadcrumb--none {
     color: inherit;

--- a/src/components/Breadcrumbs/__tests__/Breadcrumb.spec.js
+++ b/src/components/Breadcrumbs/__tests__/Breadcrumb.spec.js
@@ -1,6 +1,5 @@
 import React from "react";
 import renderer from "react-test-renderer";
-
 import Breadcrumb from "../";
 
 describe("<Breadcrumb />", () => {

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
@@ -13,9 +13,6 @@ exports[`<Breadcrumb /> renders correctly 1`] = `
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
-  -webkit-flex: 0 1 50%;
-  -ms-flex: 0 1 50%;
-  flex: 0 1 50%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Interpolation in Breadcrumbs styles causes tests to fail when no children passed to the component. I realized that we do not need this rule at all, hence removing it.
<!-- Why are these changes necessary? -->

**Why**:

It breaks jest snapshot testing that throws this exception and does not create any value:

undefined:254:914: property missing ':'

      at Object.<anonymous> (src/Venue/Hero/__tests__/index.spec.js:40:18)
          at new Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
<!-- How were these changes implemented? -->

**How**:

Removed interpolation that was causing error
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
