### PR TITLE
fix(Breadcrumbs): fix interpolation to return string instead of a falsy value

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumb.js
+++ b/src/components/Breadcrumbs/Breadcrumb.js
@@ -11,7 +11,7 @@ const Breadcrumb = ({ children, className, variant, ...props }) => (
       className={classNames(className, `breadcrumb--${variant}`)}
       itemScope
       itemType="http://schema.org/Breadcrumb"
-      childrenLen={children && Array.from(children).length}
+      childrenLen={React.Children.count(children)}
     >
       {children}
     </StyledBreadcrumb>

--- a/src/components/Breadcrumbs/Breadcrumb.styles.js
+++ b/src/components/Breadcrumbs/Breadcrumb.styles.js
@@ -8,10 +8,11 @@ const StyledBreadcrumb = ListUnstyled.extend`
   display: flex;
   flex-flow: row;
   ${({ childrenLen }) =>
-    childrenLen &&
-    `
+    childrenLen > 0
+      ? `
     flex: 0 1 ${Math.floor(100 / childrenLen)}%;
-  `} align-items: center;
+  `
+      : ""} align-items: center;
 
   &.breadcrumb--none {
     color: inherit;

--- a/src/components/Breadcrumbs/__tests__/Breadcrumb.spec.js
+++ b/src/components/Breadcrumbs/__tests__/Breadcrumb.spec.js
@@ -13,4 +13,11 @@ describe("<Breadcrumb />", () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it("should render when empty list passed in", () => {
+    const component = renderer.create(<Breadcrumb>{[]}</Breadcrumb>);
+    const tree = component.toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
@@ -67,3 +67,65 @@ exports[`<Breadcrumb /> renders correctly 1`] = `
   </ol>
 </nav>
 `;
+
+exports[`<Breadcrumb /> should render when empty list passed in 1`] = `
+.c0 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  font-weight: 600;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row;
+  -ms-flex-flow: row;
+  flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0.breadcrumb--none {
+  color: inherit;
+}
+
+.c0.breadcrumb--light {
+  color: rgba(255,255,255,1);
+}
+
+.c0.breadcrumb--dark {
+  color: rgba(38,38,38,1);
+}
+
+.c0.breadcrumb--accent {
+  color: #026cdf;
+}
+
+.c0 li:last-of-type {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c0 li:not(:last-of-type):after {
+  padding: 0 4px;
+  content: "/";
+}
+
+<nav
+  style={
+    Object {
+      "maxWidth": "100%",
+      "overflow": "hidden",
+    }
+  }
+>
+  <ol
+    className="breadcrumb--light c0"
+    itemScope={true}
+    itemType="http://schema.org/Breadcrumb"
+  />
+</nav>
+`;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Interpolation in Breadcrumbs styles causes tests to fail when no children passed to the component.
<!-- Why are these changes necessary? -->

**Why**:

It breaks jest snapshot testing that throws this exception:

undefined:254:914: property missing ':'

      at Object.<anonymous> (src/Venue/Hero/__tests__/index.spec.js:40:18)
          at new Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
<!-- How were these changes implemented? -->

**How**:

Added ternary operator to return empty string
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
