### PR TITLE
fix(Inputs): Safari fixes and remove hover behavior when input is in error state

### DIFF
--- a/src/components/Input/Input.styles.js
+++ b/src/components/Input/Input.styles.js
@@ -21,18 +21,15 @@ export const FieldInputWrapper = styled.div`
 
 export const FieldInputText = styled.label`
   font-size: ${typography.size.uno};
-  height: 13px;
   line-height: 1.25;
   text-align: left;
   color: ${getThemeValue("gray01")};
   position: relative;
   .text--input-small & {
     font-size: ${typography.size.mini};
-    line-height: 1.3;
   }
   .text--input-large & {
     font-size: ${typography.size.hecto};
-    line-height: 1.29;
   }
   .text--input-disabled & {
     opacity: 0.4;
@@ -65,9 +62,9 @@ export const FieldInputBox = styled.input.attrs({
   width: 100%;
   border-radius: ${constants.borderRadius.small};
   background-color: ${getThemeValue("white", "base")};
-  border: solid 1px ${getThemeValue("gray02")};
+  border: 1px solid ${getThemeValue("gray02")};
   padding-left: 10px;
-  line-height: 2.57;
+  line-height: normal;
   font-size: ${typography.size.hecto};
   color: ${getThemeValue("gray01")};
   &.text--input-left {
@@ -89,10 +86,10 @@ export const FieldInputBox = styled.input.attrs({
     opacity: 0.4;
   }
   &:focus {
-    border: 1px ${getThemeValue("primary", "base")} solid;
+    border: 1px solid ${getThemeValue("primary", "base")};
     padding-left: 10px;
     border-radius: ${constants.borderRadius.small};
-    box-shadow: inset 0 0 4px 0 ${getThemeValue("primary", "base")};
+    box-shadow: 0 0 4px 0 inset ${getThemeValue("primary", "base")};
     background-color: ${getThemeValue("white", "base")};
     outline: none;
     .text--input-small & {
@@ -103,7 +100,17 @@ export const FieldInputBox = styled.input.attrs({
     }
   }
   &:hover {
-    border: 2px ${getThemeValue("primary", "base")} solid;
+    border: 2px solid ${getThemeValue("primary", "base")};
+    .text__error & {
+      border: 1px solid ${getThemeValue("error", "base")};
+      padding-left: 10px;
+    }
+    .text__error.text--input-small & {
+      padding-left: 8px;
+    }
+    .text__error.text--input-large & {
+      padding-left: 12px;
+    }
     padding-left: 9px;
     .text--input-small & {
       padding-left: 7px;
@@ -123,14 +130,13 @@ export const FieldInputBox = styled.input.attrs({
     padding-left: 12px;
   }
   .text__error & {
-    border-color: ${getThemeValue("error", "base")};
+    border: 1px solid ${getThemeValue("error", "base")};
   }
 `;
 
 export const FieldErrorText = styled.label`
   opacity: 0;
   font-size: ${typography.size.uno};
-  height: 13px;
   line-height: 1.25;
   text-align: left;
   color: ${getThemeValue("error", "base")};

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Input renders default input 1`] = `
   class="text--input-regular text--input-top sc-bdVaJa cBKMGA"
 >
   <label
-    class="sc-bwzfXH yJMup"
+    class="sc-bwzfXH ddQPaW"
     id="test1firstname__label"
   >
     First Name
@@ -15,7 +15,7 @@ exports[`Input renders default input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb jZNkaQ"
+      class="sc-bxivhb hlBmN"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -23,7 +23,7 @@ exports[`Input renders default input 1`] = `
     />
     <label
       aria-invalid="false"
-      class="sc-ifAKCX dfGglR"
+      class="sc-ifAKCX gWpzXV"
       role="alert"
     />
   </div>
@@ -35,7 +35,7 @@ exports[`Input renders disabled input 1`] = `
   class="text--input-regular text--input-top text--input-disabled sc-bdVaJa cBKMGA"
 >
   <label
-    class="sc-bwzfXH yJMup"
+    class="sc-bwzfXH ddQPaW"
     id="test1firstname__label"
   >
     First Name
@@ -45,7 +45,7 @@ exports[`Input renders disabled input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb jZNkaQ"
+      class="sc-bxivhb hlBmN"
       disabled=""
       id="test1firstname__input"
       name="test1"
@@ -54,7 +54,7 @@ exports[`Input renders disabled input 1`] = `
     />
     <label
       aria-invalid="false"
-      class="sc-ifAKCX dfGglR"
+      class="sc-ifAKCX gWpzXV"
       role="alert"
     />
   </div>
@@ -66,7 +66,7 @@ exports[`Input renders input with error 1`] = `
   class="text--input-regular text--input-top text__error sc-bdVaJa cBKMGA"
 >
   <label
-    class="sc-bwzfXH yJMup"
+    class="sc-bwzfXH ddQPaW"
     id="test1firstname__label"
   >
     First Name
@@ -76,7 +76,7 @@ exports[`Input renders input with error 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb jZNkaQ"
+      class="sc-bxivhb hlBmN"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -84,7 +84,7 @@ exports[`Input renders input with error 1`] = `
     />
     <label
       aria-invalid="true"
-      class="sc-ifAKCX dfGglR"
+      class="sc-ifAKCX gWpzXV"
       role="alert"
     >
       Something Went Wrong
@@ -98,7 +98,7 @@ exports[`Input renders large input 1`] = `
   class="text--input-large text--input-top sc-bdVaJa cBKMGA"
 >
   <label
-    class="sc-bwzfXH yJMup"
+    class="sc-bwzfXH ddQPaW"
     id="test1firstname__label"
   >
     First Name
@@ -108,7 +108,7 @@ exports[`Input renders large input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb jZNkaQ"
+      class="sc-bxivhb hlBmN"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -116,7 +116,7 @@ exports[`Input renders large input 1`] = `
     />
     <label
       aria-invalid="false"
-      class="sc-ifAKCX dfGglR"
+      class="sc-ifAKCX gWpzXV"
       role="alert"
     />
   </div>
@@ -128,7 +128,7 @@ exports[`Input renders left labeled input 1`] = `
   class="text--input-regular text--input-left sc-bdVaJa cBKMGA"
 >
   <label
-    class="sc-bwzfXH yJMup"
+    class="sc-bwzfXH ddQPaW"
     id="test1firstname__label"
   >
     First Name
@@ -138,7 +138,7 @@ exports[`Input renders left labeled input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb jZNkaQ"
+      class="sc-bxivhb hlBmN"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -146,7 +146,7 @@ exports[`Input renders left labeled input 1`] = `
     />
     <label
       aria-invalid="false"
-      class="sc-ifAKCX dfGglR"
+      class="sc-ifAKCX gWpzXV"
       role="alert"
     />
   </div>
@@ -158,7 +158,7 @@ exports[`Input renders small input 1`] = `
   class="text--input-small text--input-top sc-bdVaJa cBKMGA"
 >
   <label
-    class="sc-bwzfXH yJMup"
+    class="sc-bwzfXH ddQPaW"
     id="test1firstname__label"
   >
     First Name
@@ -168,7 +168,7 @@ exports[`Input renders small input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb jZNkaQ"
+      class="sc-bxivhb hlBmN"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -176,7 +176,7 @@ exports[`Input renders small input 1`] = `
     />
     <label
       aria-invalid="false"
-      class="sc-ifAKCX dfGglR"
+      class="sc-ifAKCX gWpzXV"
       role="alert"
     />
   </div>
@@ -188,7 +188,7 @@ exports[`Input renders top labeled input 1`] = `
   class="text--input-regular text--input-top sc-bdVaJa cBKMGA"
 >
   <label
-    class="sc-bwzfXH yJMup"
+    class="sc-bwzfXH ddQPaW"
     id="test1firstname__label"
   >
     First Name
@@ -198,7 +198,7 @@ exports[`Input renders top labeled input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb jZNkaQ"
+      class="sc-bxivhb hlBmN"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -206,7 +206,7 @@ exports[`Input renders top labeled input 1`] = `
     />
     <label
       aria-invalid="false"
-      class="sc-ifAKCX dfGglR"
+      class="sc-ifAKCX gWpzXV"
       role="alert"
     />
   </div>


### PR DESCRIPTION
**What**:

Fix input in Safari and remove hover behavior when input is in error state

**Why**:

Inputs should not break in Safari browser. Inputs should not have 2px red border when hovered and in error state. The border should remain 1px red.

**How**:

Add input line height. Remove static height for label and error label. When input has error class overwrite hover behavior.

**Checklist**:

* [N/A] Documentation
* [x] Tests
* [x] Ready to be merged 
