### PR TITLE
fix(DrawerProvider): Fix scroll when closed

### DIFF
--- a/src/components/Drawer/Provider.js
+++ b/src/components/Drawer/Provider.js
@@ -28,15 +28,15 @@ export default class DrawerProvider extends React.Component {
     );
   }
 
-  componentDidUpdate() {
-    const { isOpen } = this.state;
-    /* istanbul ignore next */
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.isOpen === false) return;
+    if (this.state.isOpen === true) return;
     if (
-      !isOpen &&
       typeof window !== "undefined" &&
       typeof window.scrollTo === "function"
     ) {
       window.scrollTo(0, this.scrollPosition);
+      this.scrollPosition = 0;
     }
   }
 

--- a/src/components/Drawer/__tests__/Provider.spec.js
+++ b/src/components/Drawer/__tests__/Provider.spec.js
@@ -84,4 +84,71 @@ describe("DrawerProvider", () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it("calls window scroll when closed", () => {
+    window.scrollTo = jest.fn();
+    const { getByTestId } = render(
+      <DrawerProvider>
+        <div>
+          <Consumer>
+            {({ setContent, toggleDrawer }) => (
+              <button
+                data-testid="button"
+                onClick={() => {
+                  setContent(
+                    <div data-testid="drawer-content">Drawer Content</div>
+                  );
+                  toggleDrawer();
+                }}
+              >
+                ClickMe!
+              </button>
+            )}
+          </Consumer>
+          Content
+        </div>
+      </DrawerProvider>
+    );
+
+    Simulate.click(getByTestId("button"));
+    Simulate.click(getByTestId("button"));
+
+    expect(window.scrollTo).toHaveBeenCalled();
+  });
+
+  it("calls does not  call window scroll with children change", () => {
+    window.scrollTo = jest.fn();
+    const { getByTestId } = render(<MockComponent />);
+
+    Simulate.click(getByTestId("button"));
+    Simulate.click(getByTestId("button"));
+
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
 });
+
+class MockComponent extends React.Component {
+  state = { count: 0 };
+
+  render() {
+    return (
+      <DrawerProvider>
+        <div>
+          <Consumer>
+            {() => (
+              <button
+                data-testid="button"
+                onClick={() =>
+                  this.setState(({ count }) => ({ count: count + 1 }))
+                }
+              >
+                ClickMe!
+              </button>
+            )}
+          </Consumer>
+          Content {this.state.count}
+        </div>
+      </DrawerProvider>
+    );
+  }
+}

--- a/src/components/Header/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/index.spec.js.snap
@@ -82,6 +82,7 @@ exports[`Header renders with custom level 1`] = `
   -ms-flex-align: flex-end;
   align-items: flex-end;
   min-height: 122px;
+  z-index: 1;
 }
 
 .c3 {
@@ -92,6 +93,7 @@ exports[`Header renders with custom level 1`] = `
   padding-right: 16px;
   box-sizing: border-box;
   padding-top: 60px;
+  z-index: 2;
 }
 
 .c7 {
@@ -331,6 +333,7 @@ exports[`Header renders with default 1`] = `
   -ms-flex-align: flex-end;
   align-items: flex-end;
   min-height: 122px;
+  z-index: 1;
 }
 
 .c3 {
@@ -341,6 +344,7 @@ exports[`Header renders with default 1`] = `
   padding-right: 16px;
   box-sizing: border-box;
   padding-top: 60px;
+  z-index: 2;
 }
 
 .c7 {
@@ -579,6 +583,7 @@ exports[`Header renders withOverlay 1`] = `
   -ms-flex-align: flex-end;
   align-items: flex-end;
   min-height: 122px;
+  z-index: 1;
 }
 
 .c3 {
@@ -589,6 +594,7 @@ exports[`Header renders withOverlay 1`] = `
   padding-right: 16px;
   box-sizing: border-box;
   padding-top: 60px;
+  z-index: 2;
 }
 
 .c7 {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -19,6 +19,7 @@ const HeaderGradient = styled(Gradient)`
   position: relative;
   align-items: flex-end;
   min-height: 122px;
+  z-index: 1;
   ${smallAndUp`
     min-height: 140px;
   `} ${mediumAndUp`
@@ -28,6 +29,7 @@ const HeaderGradient = styled(Gradient)`
 
 const HeaderContainer = Container.extend`
   padding-top: 60px;
+  z-index: 2;
 `;
 
 const Header = ({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes logic for scrolling back to original position
<!-- Why are these changes necessary? -->

**Why**:
When there is any children change & the drawer is closed the user is scrolled to top. This should not happen.
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
