### PR TITLE
fix(SearchInput): Update size prop from px count to small

### DIFF
--- a/src/components/Input/Search.js
+++ b/src/components/Input/Search.js
@@ -113,7 +113,7 @@ export default class SearchInput extends React.Component {
         )}
       >
         <IconContainer slim={slim} invert={invert}>
-          <SearchIcon size={16} />
+          <SearchIcon size="small" />
         </IconContainer>
         <Input
           {...{

--- a/src/components/Input/__tests__/__snapshots__/Search.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Search.spec.js.snap
@@ -94,7 +94,29 @@ exports[`SearchInput renders default input 1`] = `
 >
   <div
     className="c1"
-  />
+  >
+    <svg
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fillRule="evenodd"
+      >
+        <path
+          d="M16 0H0v16h16z"
+        />
+        <path
+          d="M12 6.5a5.5 5.5 0 1 0-11 0 5.5 5.5 0 0 0 11 0zm-.564 4.229l4.418 4.417a.5.5 0 0 1-.708.708l-4.417-4.418a6.5 6.5 0 1 1 .707-.707z"
+          fill="currentColor"
+          fillOpacity=".5"
+          fillRule="nonzero"
+        />
+      </g>
+    </svg>
+  </div>
   <input
     className="c2"
     onBlur={[Function]}
@@ -198,7 +220,29 @@ exports[`SearchInput renders inverted input 1`] = `
 >
   <div
     className="c1"
-  />
+  >
+    <svg
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fillRule="evenodd"
+      >
+        <path
+          d="M16 0H0v16h16z"
+        />
+        <path
+          d="M12 6.5a5.5 5.5 0 1 0-11 0 5.5 5.5 0 0 0 11 0zm-.564 4.229l4.418 4.417a.5.5 0 0 1-.708.708l-4.417-4.418a6.5 6.5 0 1 1 .707-.707z"
+          fill="currentColor"
+          fillOpacity=".5"
+          fillRule="nonzero"
+        />
+      </g>
+    </svg>
+  </div>
   <input
     className="c2"
     onBlur={[Function]}
@@ -302,7 +346,29 @@ exports[`SearchInput renders slim & inverted input 1`] = `
 >
   <div
     className="c1"
-  />
+  >
+    <svg
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fillRule="evenodd"
+      >
+        <path
+          d="M16 0H0v16h16z"
+        />
+        <path
+          d="M12 6.5a5.5 5.5 0 1 0-11 0 5.5 5.5 0 0 0 11 0zm-.564 4.229l4.418 4.417a.5.5 0 0 1-.708.708l-4.417-4.418a6.5 6.5 0 1 1 .707-.707z"
+          fill="currentColor"
+          fillOpacity=".5"
+          fillRule="nonzero"
+        />
+      </g>
+    </svg>
+  </div>
   <input
     className="c2"
     onBlur={[Function]}
@@ -406,7 +472,29 @@ exports[`SearchInput renders slim input 1`] = `
 >
   <div
     className="c1"
-  />
+  >
+    <svg
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fillRule="evenodd"
+      >
+        <path
+          d="M16 0H0v16h16z"
+        />
+        <path
+          d="M12 6.5a5.5 5.5 0 1 0-11 0 5.5 5.5 0 0 0 11 0zm-.564 4.229l4.418 4.417a.5.5 0 0 1-.708.708l-4.417-4.418a6.5 6.5 0 1 1 .707-.707z"
+          fill="currentColor"
+          fillOpacity=".5"
+          fillRule="nonzero"
+        />
+      </g>
+    </svg>
+  </div>
   <input
     className="c2"
     onBlur={[Function]}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: The SearchInput component's SearchIcon child did not have its size prop updated when the icons were refactored.

<!-- Why are these changes necessary? -->

**Why**: I have updated the SearchInput component's SearchIcon child's size prop, so the icon will render correctly instead of returning null.

<!-- How were these changes implemented? -->

**How**: I have updated the SearchInput component's SearchIcon child's size prop, so the icon will render correctly instead of returning null.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
