### PR TITLE
fix(Button): set display block for a StyledButtonLink

### DIFF
--- a/catalog/pages/buttons/index.md
+++ b/catalog/pages/buttons/index.md
@@ -15,6 +15,9 @@ rows:
     Type: string
     Default: '`regular`'
     Notes: Determines button size. Possible sizes are `small`, `regular`, `large`
+  - Prop: href
+    Type: string
+    Notes: Determines wether underlying HTML element should be an `a`
   - Prop: children
     Type: node
     Default:
@@ -118,6 +121,28 @@ rows:
                 </Spacing>
                 <Spacing top={{small: "moderate"}}>
                     <Button variant="transparent" size="large" disabled>My cool button</Button>
+                </Spacing>
+            </Column>
+        </Row>
+    </Container>
+</ThemeProvider>
+```
+
+### Linked button
+
+```react
+---
+<ThemeProvider theme={{ themeName: 'tm' }}>
+    <Container>
+        <Row>
+            <Column small={3}/>
+            <Column small={6}>
+                <Button size="small" href="#">My cool button</Button>
+                <Spacing top={{small: "moderate"}}>
+                    <Button href="#">My cool button</Button>
+                </Spacing>
+                <Spacing top={{small: "moderate"}}>
+                    <Button size="large" href="#">My cool button</Button>
                 </Spacing>
             </Column>
         </Row>

--- a/src/components/Button/Base.styles.js
+++ b/src/components/Button/Base.styles.js
@@ -154,5 +154,6 @@ StyledButton.defaultProps = {
 };
 
 export const StyledButtonLink = StyledButton.withComponent(`a`).extend`
+  display: block;
   text-decoration: none;
 `;

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -20,6 +20,7 @@ exports[`<Button /> renders link button correctly 1`] = `
   transition: transform 0.1s linear;
   -webkit-transition: background-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: background-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  display: block;
   -webkit-text-decoration: none;
   text-decoration: none;
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixing linked button to be styled properly
<!-- Why are these changes necessary? -->

**Why**:

Button styles require block element
<!-- How were these changes implemented? -->

**How**:

Added `display: block` rule to the StyledButtonLink styles
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
