### PR TITLE
feat(DropDownOpen) Add isOpen prop to DropDownGroup to override internal isOpen state

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -360,6 +360,10 @@ rows:
     Type: string
     Default: N/A
     Notes: for variant 1
+  - Prop: isOpen
+    Type: boolean
+    Default: false
+    Notes: Used to override internal isOpen state
   - Prop: placeholder
     Type: string
     Default: N/A

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -187,7 +187,17 @@ class DropDownGroup extends React.Component {
   thisComponent = React.createRef();
 
   render() {
-    const { children, value, onChange, variant, ...props } = this.props;
+    const {
+      children,
+      value,
+      onChange,
+      variant,
+      isOpen: isOpenProp,
+      ...props
+    } = this.props;
+    const { isOpen: isOpenState } = this.state;
+    const isOpen = isOpenProp || isOpenState;
+
     return (
       <SelectionProvider
         onChange={onChange}
@@ -206,7 +216,7 @@ class DropDownGroup extends React.Component {
               <StyledGroup
                 onClick={this.onClick}
                 className={classNames({
-                  "dropdown--active": this.state.isOpen,
+                  "dropdown--active": isOpen,
                   "dropdown--border": variant === 0,
                   "dropdown--no-border": variant === 1
                 })}
@@ -216,7 +226,7 @@ class DropDownGroup extends React.Component {
                     "dropdown--selected": true,
                     "dropdown--border": variant === 0,
                     "dropdown--no-border": variant === 1,
-                    "dropdown--alignment": variant === 1 && this.state.isOpen
+                    "dropdown--alignment": variant === 1 && isOpen
                   })}
                 >
                   {this.displayLabel(selected, variant)}
@@ -224,7 +234,7 @@ class DropDownGroup extends React.Component {
 
                 <StyledChevron
                   className={classNames({
-                    "dropdown__icon--hide": this.state.isOpen,
+                    "dropdown__icon--hide": isOpen,
                     "dropdown--no-border": variant === 1
                   })}
                   direction="down"
@@ -235,10 +245,10 @@ class DropDownGroup extends React.Component {
               <StyledChildWrapper
                 className={classNames({
                   dropdown__items: true,
-                  "dropdown--clicked": this.state.isOpen
+                  "dropdown--clicked": isOpen
                 })}
               >
-                <DropDownProvider value={this.state}>
+                <DropDownProvider value={{ ...this.state, isOpen }}>
                   <StyledKeyboardProvider
                     role="listbox"
                     keywordSearch
@@ -262,7 +272,8 @@ DropDownGroup.propTypes = {
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
   variant: PropTypes.number,
-  label: PropTypes.string
+  label: PropTypes.string,
+  isOpen: PropTypes.bool
 };
 
 DropDownGroup.defaultProps = {
@@ -270,6 +281,7 @@ DropDownGroup.defaultProps = {
   onChange: null,
   placeholder: "",
   variant: 0,
-  label: "Sort By:"
+  label: "Sort By:",
+  isOpen: false
 };
 export default DropDownGroup;

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -31,6 +31,12 @@ describe("DropDownGroup", () => {
     ).toMatchSnapshot();
   });
 
+  it("renders default input correctly when the isOpen prop with a value of true is passed", () => {
+    expect(
+      renderComponent({ isOpen: true }).container.firstChild
+    ).toMatchSnapshot();
+  });
+
   it("Should open the drop down onClick", () => {
     const { container, getByTestId } = renderComponent();
 
@@ -68,9 +74,40 @@ describe("DropDownGroup", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it("Click outside should not close the dropdown when the isOpen prop equals true", () => {
+    const { container, getByTestId } = renderComponent({ isOpen: true });
+
+    fireEvent.click(getByTestId("test-dropContainer"));
+    fireEvent.click(getByTestId("test-outSideComponent"));
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   it("Space bar should select and close dropdown", () => {
     const onChange = jest.fn();
     const { container, getByTestId } = renderComponent({ onChange });
+
+    fireEvent.keyDown(getByTestId("test-dropContainer"), {
+      key: "ArrowDown",
+      keyCode: 40,
+      which: 40,
+      bubbles: true
+    });
+
+    fireEvent.keyDown(getByTestId("test-dropDownOptionOne"), {
+      key: "",
+      keyCode: 32,
+      which: 32,
+      bubbles: true
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("Space bar should select and not close dropdown when the isOpen prop equals true", () => {
+    const onChange = jest.fn();
+    const { container, getByTestId } = renderComponent({
+      onChange,
+      isOpen: true
+    });
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "ArrowDown",

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -210,6 +210,76 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
 </div>
 `;
 
+exports[`DropDownGroup Click outside should not close the dropdown when the isOpen prop equals true 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div>
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    class="sc-htpNat dEypGd"
+    data-testid="test-dropContainer"
+    label="Sort By:"
+    placeholder=""
+    tabindex="0"
+  >
+    <label
+      class="dropdown--active dropdown--border sc-bdVaJa jOVSaQ"
+    >
+      <div
+        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+      />
+      <svg
+        class="dropdown__icon--hide sc-bxivhb bfTkLM"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown--clicked sc-bwzfXH bNMXLY"
+    >
+      <div
+        class="sc-EHOje hRvppO"
+        role="listbox"
+      >
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionOne"
+          tabindex="-1"
+          value="ValueOne"
+        >
+          Option One
+        </span>
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionTwo"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionThree"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DropDownGroup Should open the drop down onClick 1`] = `
 <div
   data-testid="test-outSideComponent"
@@ -354,6 +424,78 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
 </div>
 `;
 
+exports[`DropDownGroup Space bar should select and not close dropdown when the isOpen prop equals true 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div>
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    class="sc-htpNat dEypGd"
+    data-testid="test-dropContainer"
+    label="Sort By:"
+    placeholder=""
+    tabindex="0"
+  >
+    <label
+      class="dropdown--active dropdown--border sc-bdVaJa jOVSaQ"
+    >
+      <div
+        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+      >
+        Option One
+      </div>
+      <svg
+        class="dropdown__icon--hide sc-bxivhb bfTkLM"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown--clicked sc-bwzfXH bNMXLY"
+    >
+      <div
+        class="sc-EHOje hRvppO"
+        role="listbox"
+      >
+        <span
+          class="dropdown__selected sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionOne"
+          tabindex="-1"
+          value="ValueOne"
+        >
+          Option One
+        </span>
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionTwo"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionThree"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DropDownGroup renders default input 1`] = `
 <div
   data-testid="test-outSideComponent"
@@ -389,6 +531,76 @@ exports[`DropDownGroup renders default input 1`] = `
     </label>
     <div
       class="dropdown__items sc-bwzfXH bNMXLY"
+    >
+      <div
+        class="sc-EHOje hRvppO"
+        role="listbox"
+      >
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionOne"
+          tabindex="-1"
+          value="ValueOne"
+        >
+          Option One
+        </span>
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionTwo"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-bZQynM kUhPug"
+          data-testid="test-dropDownOptionThree"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup renders default input correctly when the isOpen prop with a value of true is passed 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div>
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    class="sc-htpNat dEypGd"
+    data-testid="test-dropContainer"
+    label="Sort By:"
+    placeholder=""
+    tabindex="0"
+  >
+    <label
+      class="dropdown--active dropdown--border sc-bdVaJa jOVSaQ"
+    >
+      <div
+        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+      />
+      <svg
+        class="dropdown__icon--hide sc-bxivhb bfTkLM"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown--clicked sc-bwzfXH bNMXLY"
     >
       <div
         class="sc-EHOje hRvppO"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am adding an isOpen prop to DropDownGroup to override internal isOpen state.

<!-- Why are these changes necessary? -->

**Why**: These changes are necessary to override the default DropDownGroup behavior for when the group should remain open due a unique use case, such as expanding another UI while leaving the DropDownGroup open when a specific DropDownOption is clicked.

<!-- How were these changes implemented? -->

**How**: These changes are implemented by adding an isOpen prop to DropDownGroup to override internal isOpen state.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
