### PR TITLE
fix(Toggle): cursor in disabled state is pointer

### DIFF
--- a/src/components/Input/Toggle/Toggle.styles.js
+++ b/src/components/Input/Toggle/Toggle.styles.js
@@ -9,11 +9,7 @@ export const ActiveArea = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: not-allowed;
-
-  &.toggle--enabled {
-    cursor: pointer;
-  }
+  cursor: pointer;
 
   &.toggle--small {
     width: 44px;

--- a/src/components/Input/__tests__/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Toggle.spec.js.snap
@@ -18,10 +18,6 @@ exports[`<Toggle /> renders regular disabled active toggle correctly 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  cursor: not-allowed;
-}
-
-.c1.toggle--enabled {
   cursor: pointer;
 }
 
@@ -238,10 +234,6 @@ exports[`<Toggle /> renders regular disabled inactive toggle correctly 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  cursor: not-allowed;
-}
-
-.c1.toggle--enabled {
   cursor: pointer;
 }
 
@@ -458,10 +450,6 @@ exports[`<Toggle /> renders regular size active toggle correctly 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  cursor: not-allowed;
-}
-
-.c1.toggle--enabled {
   cursor: pointer;
 }
 
@@ -678,10 +666,6 @@ exports[`<Toggle /> renders small size active toggle correctly 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  cursor: not-allowed;
-}
-
-.c1.toggle--enabled {
   cursor: pointer;
 }
 


### PR DESCRIPTION
**What**:

Toggle cursor when disabled is pointer

**Why**:

For compatibility with other inputs

**How**:

Cursor is always pointer when toggle is hovered

**Checklist**:

* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->