### PR TITLE
feat(DropDownOption): Pass className prop to StyledDropDownItem (#177)

### DIFF
--- a/src/components/Drawer/Drawer.styles.js
+++ b/src/components/Drawer/Drawer.styles.js
@@ -66,4 +66,6 @@ export const ContentWrapper = styled.div`
   &.drawer--open {
     overflow: hidden;
   }
+  flex: 1 0 auto;
+  display: flex;
 `;

--- a/src/components/Drawer/__tests__/__snapshots__/Provider.spec.js.snap
+++ b/src/components/Drawer/__tests__/__snapshots__/Provider.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DrawerProvider renders child elements 1`] = `"<div class=\\"sc-ifAKCX eaZCGx\\"><div>Content</div></div>"`;
+exports[`DrawerProvider renders child elements 1`] = `"<div class=\\"sc-ifAKCX hHPvih\\"><div>Content</div></div>"`;
 
 exports[`DrawerProvider sets content 1`] = `
 <div>
   <div
-    class="sc-ifAKCX eaZCGx"
+    class="sc-ifAKCX hHPvih"
   >
     <div>
       <button
@@ -22,7 +22,7 @@ exports[`DrawerProvider sets content 1`] = `
 exports[`DrawerProvider toggles drawer 1`] = `
 <div>
   <div
-    class="drawer--open sc-ifAKCX eaZCGx"
+    class="drawer--open sc-ifAKCX hHPvih"
   >
     <div>
       <button


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix the ContentWrapper inside DrawerProvider to take up the entire height using flex properties.
<!-- Why are these changes necessary? -->

**Why**:
That is the expected behavior.
<!-- How were these changes implemented? -->

**How**:
Add flex: 1 0 auto and display: flex properties to ContentWrapper inside DrawerProvider.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
