### PR TITLE
fix(MentButtom): Allow additional props to be passed to MenuButton in DrawerMenu

### DIFF
--- a/src/components/NavBar/DrawerMenu.js
+++ b/src/components/NavBar/DrawerMenu.js
@@ -37,7 +37,7 @@ class DrawerMenu extends React.Component {
   }
 
   render() {
-    const { onClick, toggleDrawer, isOpen } = this.props;
+    const { onClick, toggleDrawer, isOpen, ...rest } = this.props;
 
     return (
       <MenuButton
@@ -47,6 +47,7 @@ class DrawerMenu extends React.Component {
           "hamburger--opened": isOpen,
           "hamburger--closed": !isOpen
         })}
+        {...rest}
       />
     );
   }


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Allow additional props to be passed to MenuButton in DrawerMenu
<!-- Why are these changes necessary? -->

**Why**:
So that additional styling and any data attributes can be passed to MenuButton to customize it.
<!-- How were these changes implemented? -->

**How**:
Using rest operator to collect the additional props.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
