### PR TITLE
fix(DayTile): increment min-height by the size of the outer border

### DIFF
--- a/src/components/CalendarView/DayTile.js
+++ b/src/components/CalendarView/DayTile.js
@@ -16,7 +16,7 @@ const DayTile = styled.div.attrs({
   display: flex;
   flex-flow: column nowrap;
   height: 100%;
-  min-height: 190px;
+  min-height: 192px;
   background-color: ${colors.white.base};
   border: solid 1px ${colors.onyx.muted};
   border-radius: ${constants.borderRadius.small};

--- a/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
@@ -11,7 +11,7 @@ exports[`CalendarView should render without errors 1`] = `
   -ms-flex-flow: column nowrap;
   flex-flow: column nowrap;
   height: 100%;
-  min-height: 190px;
+  min-height: 192px;
   background-color: rgba(255,255,255,1);
   border: solid 1px rgba(38,38,38,0.4);
   border-radius: 2px;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Increased min-height in order to accommodate for the outer border and a DayTile's Item that also has a min-height of 190px.
<!-- Why are these changes necessary? -->

**Why**:

Content jumps in between transitions from empty tile to a tile with content
<!-- How were these changes implemented? -->

**How**:

Changed min-height to 192px
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
