### PR TITLE
feat(DropDownWidth) Remove width constraint from DropDownOption

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -104,14 +104,12 @@ const StyledSelectedText = styled.div`
 
   &.dropdown--border {
     margin-left: 15px;
-    width: 60%;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   &.dropdown--no-border {
     margin-right: 8px;
-    width: 60%;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -19,7 +19,7 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
       class="dropdown--active dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="dropdown__icon--hide sc-bxivhb bfTkLM"
@@ -89,7 +89,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
       class="dropdown--active dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="dropdown__icon--hide sc-bxivhb bfTkLM"
@@ -159,7 +159,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
       class="dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="sc-bxivhb bfTkLM"
@@ -229,7 +229,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
       class="dropdown--active dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="dropdown__icon--hide sc-bxivhb bfTkLM"
@@ -299,7 +299,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
       class="dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="sc-bxivhb bfTkLM"
@@ -371,7 +371,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
       class="dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       >
         Option One
       </div>
@@ -443,7 +443,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
       class="dropdown--active dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       >
         Option One
       </div>
@@ -515,7 +515,7 @@ exports[`DropDownGroup renders default input 1`] = `
       class="dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="sc-bxivhb bfTkLM"
@@ -585,7 +585,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
       class="dropdown--active dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="dropdown__icon--hide sc-bxivhb bfTkLM"
@@ -655,7 +655,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
       class="dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="sc-bxivhb bfTkLM"
@@ -725,7 +725,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
       class="dropdown--border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--border sc-ifAKCX iEvNXJ"
       />
       <svg
         class="sc-bxivhb bfTkLM"
@@ -790,7 +790,7 @@ exports[`DropDownGroup renders variant 0 with a placeholder prop 1`] = `
       class="dropdown--no-border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--no-border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--no-border sc-ifAKCX iEvNXJ"
       >
         Sort By: 
       </div>
@@ -862,7 +862,7 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
       class="dropdown--no-border sc-bdVaJa jOVSaQ"
     >
       <div
-        class="dropdown--selected dropdown--no-border sc-ifAKCX dIQjbB"
+        class="dropdown--selected dropdown--no-border sc-ifAKCX iEvNXJ"
       >
         Selected Option: 
       </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am removing the DropDownOption width constraint of 60%.

<!-- Why are these changes necessary? -->

**Why**: I am removing this constraint, so DropDownOption label visibility is increased.

<!-- How were these changes implemented? -->

**How**: I am removing the DropDownOption width constraint of 60%.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
