### PR TITLE
feat(DropDownKeyboard) Add withKeyboardProvider prop to disable inclusion of KeyboardProvider

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -395,6 +395,10 @@ rows:
     Type: boolean
     Default: true
     Notes: Used to override ability to use keyboard to focus on drop down option
+  - Prop: withKeyboardProvider
+    Type: boolean
+    Default: true
+    Notes: Used to override inclusion of a KeyboardProvider to handle keydown events
   - Prop: placeholder
     Type: string
     Default: N/A

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -194,6 +194,7 @@ class DropDownGroup extends React.Component {
       variant,
       isOpen: isOpenProp,
       keywordSearch,
+      withKeyboardProvider,
       ...props
     } = this.props;
     const { isOpen: isOpenState } = this.state;
@@ -250,13 +251,17 @@ class DropDownGroup extends React.Component {
                 })}
               >
                 <DropDownProvider value={{ ...this.state, isOpen }}>
-                  <StyledKeyboardProvider
-                    role="listbox"
-                    keywordSearch={keywordSearch}
-                    selected={selected}
-                  >
-                    {children}
-                  </StyledKeyboardProvider>
+                  {withKeyboardProvider ? (
+                    <StyledKeyboardProvider
+                      role="listbox"
+                      keywordSearch={keywordSearch}
+                      selected={selected}
+                    >
+                      {children}
+                    </StyledKeyboardProvider>
+                  ) : (
+                    children
+                  )}
                 </DropDownProvider>
               </StyledChildWrapper>
             </StyledGroupWrapper>
@@ -275,7 +280,8 @@ DropDownGroup.propTypes = {
   variant: PropTypes.number,
   label: PropTypes.string,
   isOpen: PropTypes.bool,
-  keywordSearch: PropTypes.bool
+  keywordSearch: PropTypes.bool,
+  withKeyboardProvider: PropTypes.bool
 };
 
 DropDownGroup.defaultProps = {
@@ -285,6 +291,7 @@ DropDownGroup.defaultProps = {
   variant: 0,
   label: "Sort By:",
   isOpen: false,
-  keywordSearch: true
+  keywordSearch: true,
+  withKeyboardProvider: true
 };
 export default DropDownGroup;

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -43,6 +43,12 @@ describe("DropDownGroup", () => {
     ).toMatchSnapshot();
   });
 
+  it("renders input correctly when the withKeyboardProvider prop with a value of false is passed", () => {
+    expect(
+      renderComponent({ withKeyboardProvider: false }).container.firstChild
+    ).toMatchSnapshot();
+  });
+
   it("Should open the drop down onClick", () => {
     const { container, getByTestId } = renderComponent();
 

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -706,6 +706,71 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
 </div>
 `;
 
+exports[`DropDownGroup renders input correctly when the withKeyboardProvider prop with a value of false is passed 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div>
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    class="sc-htpNat dEypGd"
+    data-testid="test-dropContainer"
+    label="Sort By:"
+    placeholder=""
+    tabindex="0"
+  >
+    <label
+      class="dropdown--border sc-bdVaJa jOVSaQ"
+    >
+      <div
+        class="dropdown--selected dropdown--border sc-ifAKCX dIQjbB"
+      />
+      <svg
+        class="sc-bxivhb bfTkLM"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items sc-bwzfXH bNMXLY"
+    >
+      <span
+        class="sc-bZQynM kUhPug"
+        data-testid="test-dropDownOptionOne"
+        tabindex="-1"
+        value="ValueOne"
+      >
+        Option One
+      </span>
+      <span
+        class="sc-bZQynM kUhPug"
+        data-testid="test-dropDownOptionTwo"
+        tabindex="-1"
+        value="ValueTwo"
+      >
+        Second Option
+      </span>
+      <span
+        class="sc-bZQynM kUhPug"
+        data-testid="test-dropDownOptionThree"
+        tabindex="-1"
+        value="ValueThree"
+      >
+        Option Three
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DropDownGroup renders variant 0 with a placeholder prop 1`] = `
 <div
   data-testid="test-outSideComponent"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am adding the withKeyboardProvider prop to disable inclusion of KeyboardProvider.

<!-- Why are these changes necessary? -->

**Why**: These changes are necessary to disable all KeyboardProvider functionality applied to the DropDownGroup when desired.

<!-- How were these changes implemented? -->

**How**: I am adding the withKeyboardProvider prop to disable inclusion of KeyboardProvider.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
