### PR TITLE
Fix prop types warnings in DayTile

### DIFF
--- a/src/components/CalendarView/DayTileDate.js
+++ b/src/components/CalendarView/DayTileDate.js
@@ -18,9 +18,9 @@ const DayTileDateContainer = styled.div`
 const DayTileDateText = styled(Text).attrs({
   size: "kilo",
   weight: "semiBold",
-  className: ({ accent }) =>
+  className: ({ isAccent }) =>
     classnames("day-tile-date__text", {
-      "day-tile-date__text--accent": accent
+      "day-tile-date__text--accent": isAccent
     })
 })`
   color: ${getThemeValue("gray02")};
@@ -32,7 +32,7 @@ const DayTileDateText = styled(Text).attrs({
 
 const DayTileDate = ({ children, accent }) => (
   <DayTileDateContainer>
-    <DayTileDateText accent={accent}>{children}</DayTileDateText>
+    <DayTileDateText isAccent={accent}>{children}</DayTileDateText>
   </DayTileDateContainer>
 );
 

--- a/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
@@ -360,7 +360,7 @@ exports[`CalendarView should render without errors 1`] = `
       className="c2"
     >
       <div
-        className="text text--dark day-tile-date__text day-tile-date__text--accent c3 c4"
+        className="text text--dark text--primary day-tile-date__text day-tile-date__text--accent c3 c4"
         disabled={false}
         size={
           Object {

--- a/src/components/Icons/__tests__/Warning.spec.js
+++ b/src/components/Icons/__tests__/Warning.spec.js
@@ -8,9 +8,7 @@ describe("<WarningIcon />", () => {
 
   it("renders correctly", () => {
     const component = renderer.create(
-      <WarningIcon width={36} height={36}>
-        {children}
-      </WarningIcon>
+      <WarningIcon size={36}>{children}</WarningIcon>
     );
 
     expect(component.toJSON()).toMatchSnapshot();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixed prop-types warnings in DayTileDate and WarningIcon
<!-- Why are these changes necessary? -->

**Why**:

Distracting
<!-- How were these changes implemented? -->

**How**:

There's a name collision with Text and I renamed the prop. WarningIcon's test was passing wrong props
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
