### PR TITLE
fix(ListRow): fix markup for ListRow options link

### DIFF
--- a/catalog/pages/list_row/index.md
+++ b/catalog/pages/list_row/index.md
@@ -100,7 +100,13 @@ responsive: true
 ---
 <ListContainer>
   <ListRow
-    rowItem={listItems[0]}
+    rowItem={{
+        ...listItems[0],
+        variant: "withLink",
+        linkTitle: "Ticket Options Available",
+        linkUrl: "",
+        linkSubTitle: "on Partner Site"
+    }}
     index={0}
     onOverflowClick={() => alert('Overflow Clicked')}
     onExpandItem={({index}) => alert(`Expand ${index}`)}

--- a/src/components/List/RowContent.js
+++ b/src/components/List/RowContent.js
@@ -16,6 +16,7 @@ import RowToggler, { IconButton } from "./RowToggler";
 import { rowDataShape } from "./shape";
 import constants from "../../theme/constants";
 import RowOptionsLink from "./RowOptionsLink";
+import { ROW_DATE_SMALL_WIDTH, ROW_DATE_MEDIUM_WIDTH } from "./constants";
 
 const RowWrapper = styled.div`
   background-color: ${colors.white.base};
@@ -61,11 +62,10 @@ const LinkWrapper = styled.a`
     props.rowVariant === "withLink" ? "1px" : spacing.cozy};
   border-radius: 2px;
 
-  margin: 12px 0 ${props => (props.rowVariant === "withLink" ? "25px" : "12px")}
-    0;
+  margin: 12px 0 ${props => (props.rowVariant === "withLink" ? "0" : "12px")} 0;
   ${mediumAndUp`
     margin: 18px 0
-      ${props => (props.rowVariant === "withLink" ? "25px" : "18px")}
+      ${props => (props.rowVariant === "withLink" ? "0" : "18px")}
       0;
     &:hover {
       background-color: ${colors.azure.light};
@@ -76,13 +76,13 @@ const LinkWrapper = styled.a`
 
 const DateWrapper = styled.div`
   width: 61.6%;
-  max-width: 101px;
+  max-width: ${ROW_DATE_SMALL_WIDTH};
 
   ${smallAndUp`
     width: 31.1%;
   `} ${mediumAndUp`
     width: 26.8%;
-    max-width: 116px;
+    max-width: ${ROW_DATE_MEDIUM_WIDTH};
   `};
 
   ${largeAndUp`
@@ -361,16 +361,6 @@ const ListRowContent = ({
               {isOpen && onExpandShow === "title" ? title : subTitle}
             </MultilineText>
           </ContentColumn>
-
-          <RowOptionsLink
-            variant={variant}
-            isOpen={isOpen}
-            url={linkUrl}
-            index={index}
-            onClick={onOverflowClick}
-          >
-            {linkTitle}
-          </RowOptionsLink>
         </ContentRow>
 
         <DesktopContainer>
@@ -405,6 +395,16 @@ const ListRowContent = ({
         </IconButton>
       </MobileContainer>
     </ListContainer>
+
+    <RowOptionsLink
+      variant={variant}
+      isOpen={isOpen}
+      url={linkUrl}
+      index={index}
+      onClick={onOverflowClick}
+    >
+      {linkTitle}
+    </RowOptionsLink>
 
     <OverflowDesktopContainer
       className={classnames({

--- a/src/components/List/RowOptionsLink.js
+++ b/src/components/List/RowOptionsLink.js
@@ -3,16 +3,26 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import classnames from "classnames";
 
-import { Column } from "../Grid";
+import { Column, Row } from "../Grid";
 import { Link } from "../Text";
 import { mediumAndUp } from "../../theme/mediaQueries";
 import constants from "../../theme/constants";
+import spacing from "../../theme/spacing";
 
-const OptionsContent = styled(Column)`
+import {
+  CHEVRON_ICON_PADDING,
+  CHEVRON_ICON_SIZE,
+  ROW_DATE_MEDIUM_WIDTH,
+  ROW_DATE_SMALL_WIDTH
+} from "./constants";
+
+const Content = styled(Row)`
   width: 100%;
-  position: absolute;
-  left: 0;
-  top: 100%;
+  padding-left: ${ROW_DATE_SMALL_WIDTH};
+  padding-bottom: ${spacing.cozy};
+  ${mediumAndUp`
+    padding-left: calc(${CHEVRON_ICON_SIZE}px + ${CHEVRON_ICON_PADDING} + ${CHEVRON_ICON_PADDING} + ${ROW_DATE_MEDIUM_WIDTH});
+  `};
 `;
 
 const MobileLink = styled(Link)`
@@ -38,26 +48,28 @@ const DesktopLink = styled(Link)`
 
 const RowOptionsLink = ({ variant, isOpen, url, index, onClick, children }) =>
   variant === "withLink" && (
-    <OptionsContent>
-      <MobileLink
-        linkUrl={url}
-        data-index={index}
-        onClick={onClick}
-        className="link--row-options"
-      >
-        {children}
-      </MobileLink>
-      <DesktopLink
-        href={url}
-        data-index={index}
-        className={classnames({
-          "link--row-options": !url.length,
-          "link--hidden": isOpen
-        })}
-      >
-        {children}
-      </DesktopLink>
-    </OptionsContent>
+    <Content>
+      <Column>
+        <MobileLink
+          linkUrl={url}
+          data-index={index}
+          onClick={onClick}
+          className="link--row-options"
+        >
+          {children}
+        </MobileLink>
+        <DesktopLink
+          href={url}
+          data-index={index}
+          className={classnames({
+            "link--row-options": !url.length,
+            "link--hidden": isOpen
+          })}
+        >
+          {children}
+        </DesktopLink>
+      </Column>
+    </Content>
   );
 
 RowOptionsLink.defaultProps = {

--- a/src/components/List/RowToggler.js
+++ b/src/components/List/RowToggler.js
@@ -5,16 +5,14 @@ import classnames from "classnames";
 
 import colors from "../../theme/colors";
 import spacing from "../../theme/spacing";
-import { mediumAndUp } from "../../theme/mediaQueries";
+import {mediumAndUp} from "../../theme/mediaQueries";
 
 import ChevronIcon from "../Icons/Chevron";
-
-const CHEVRON_ICON_SIZE = 15;
-const CHEVRON_ICON_PADDING = spacing.moderate;
+import { CHEVRON_ICON_PADDING, CHEVRON_ICON_SIZE } from "./constants";
 
 export const IconButton = styled.button.attrs({
-  role: "button",
-  type: "button"
+  role: 'button',
+  type: 'button',
 })`
   border: 0;
   padding: 0 ${CHEVRON_ICON_PADDING};

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -32,7 +32,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -441,7 +441,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -850,7 +850,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -1259,7 +1259,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -1676,7 +1676,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -2085,7 +2085,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -2494,7 +2494,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="Acheter des Billets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -2903,7 +2903,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -3320,7 +3320,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -3729,7 +3729,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -4138,7 +4138,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -4547,7 +4547,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -4964,7 +4964,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -5373,7 +5373,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -5782,7 +5782,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="Acheter des Billets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -6191,7 +6191,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -6609,7 +6609,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -6857,7 +6857,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -7266,7 +7266,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -7675,7 +7675,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -8084,7 +8084,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -8500,7 +8500,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -8909,7 +8909,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -9318,7 +9318,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -9727,7 +9727,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -10144,7 +10144,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -10553,7 +10553,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -10962,7 +10962,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="Acheter des Billets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -11371,7 +11371,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac dgaDq"
+          class="link__wrapper sc-jhAzac edtqEH"
           href="/"
           role="link"
         >
@@ -11788,7 +11788,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -11915,7 +11915,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -12042,7 +12042,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >
@@ -12169,7 +12169,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac dgaDq"
+        class="link__wrapper sc-jhAzac edtqEH"
         href="/"
         role="link"
       >

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -777,7 +777,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   flex: 0 0 100%;
 }
 
-.c20 {
+.c25 {
   font-size: 14px;
   font-weight: 400;
   line-height: 1.5;
@@ -797,18 +797,18 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   cursor: pointer;
 }
 
-.c20:focus,
-.c20:active,
-.c20:visited,
-.c20:hover {
+.c25:focus,
+.c25:active,
+.c25:visited,
+.c25:hover {
   color: rgba(2,108,223,1);
 }
 
-.c20:hover {
+.c25:hover {
   color: #0150a7;
 }
 
-.c22 {
+.c27 {
   font-size: 14px;
   font-weight: 400;
   line-height: 1.5;
@@ -821,14 +821,14 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   cursor: pointer;
 }
 
-.c22:focus,
-.c22:active,
-.c22:visited,
-.c22:hover {
+.c27:focus,
+.c27:active,
+.c27:visited,
+.c27:hover {
   color: rgba(2,108,223,1);
 }
 
-.c22:hover {
+.c27:hover {
   color: #0150a7;
 }
 
@@ -856,7 +856,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   color: rgba(38,38,38,1);
 }
 
-.c26 {
+.c21 {
   font-size: 12px;
   font-weight: 400;
   line-height: 1.5;
@@ -893,18 +893,17 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   display: none;
 }
 
-.c18 {
+.c23 {
   width: 100%;
-  position: absolute;
-  left: 0;
-  top: 100%;
+  padding-left: 101px;
+  padding-bottom: 8px;
 }
 
-.c19 {
+.c24 {
   display: inline-block;
 }
 
-.c21 {
+.c26 {
   display: none;
 }
 
@@ -944,7 +943,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   padding-top: 8px;
   padding-bottom: 1px;
   border-radius: 2px;
-  margin: 12px 0 25px 0;
+  margin: 12px 0 0 0;
 }
 
 .c6 {
@@ -956,7 +955,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   display: none;
 }
 
-.c24 {
+.c19 {
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -994,23 +993,23 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   padding: 18px 0;
 }
 
-.c24:focus {
+.c19:focus {
   outline: none;
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c24:hover {
+.c19:hover {
   background-color: #0150a7;
 }
 
-.c24:active {
+.c19:active {
   -webkit-transform: scale(0.98,0.98) translate(0,1px);
   -ms-transform: scale(0.98,0.98) translate(0,1px);
   transform: scale(0.98,0.98) translate(0,1px);
   background-color: #013670;
 }
 
-.c24:disabled {
+.c19:disabled {
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
@@ -1025,14 +1024,14 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   overflow: hidden;
 }
 
-.c23 {
+.c18 {
   display: none;
   padding-left: 8px;
   padding-right: 8px;
   position: relative;
 }
 
-.c27 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1058,7 +1057,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   line-height: 1.2;
 }
 
-.c25 {
+.c20 {
   width: 100%;
   position: absolute;
   left: 0;
@@ -1154,25 +1153,25 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c20 {
+  .c25 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c20 {
+  .c25 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c22 {
+  .c27 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c22 {
+  .c27 {
     font-size: 14px;
   }
 }
@@ -1214,13 +1213,13 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c26 {
+  .c21 {
     font-size: 12px;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c26 {
+  .c21 {
     font-size: 12px;
   }
 }
@@ -1244,13 +1243,19 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c19 {
+  .c23 {
+    padding-left: calc(15px + 16px + 16px + 116px);
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c24 {
     display: none;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c21 {
+  .c26 {
     display: inline-block;
     opacity: 1;
     line-height: 1.5;
@@ -1258,7 +1263,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
     transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955) 0.2s;
   }
 
-  .c21.link--hidden {
+  .c26.link--hidden {
     opacity: 0;
     -webkit-transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
     transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
@@ -1287,7 +1292,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 
 @media screen and (min-width:768px) {
   .c5 {
-    margin: 18px 0 25px 0;
+    margin: 18px 0 0 0;
   }
 
   .c5:hover {
@@ -1371,7 +1376,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c23 {
+  .c18 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1388,7 +1393,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c27 {
+  .c22 {
     display: none;
   }
 }
@@ -1563,51 +1568,13 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
               KABOO 3-Day Pass
             </div>
           </div>
-          <div
-            className="c18 c13"
-          >
-            <button
-              className="link--row-options c19 c20"
-              data-index={0}
-              href={null}
-              onClick={[Function]}
-              rel="_self"
-              size={
-                Object {
-                  "large": "hecto",
-                  "medium": "hecto",
-                  "small": "hecto",
-                }
-              }
-              target=""
-            >
-              Ticket Options Available
-            </button>
-            <span
-              className="link--row-options c21 c22"
-              data-index={0}
-              href=""
-              onClick={null}
-              rel="_self"
-              size={
-                Object {
-                  "large": "hecto",
-                  "medium": "hecto",
-                  "small": "hecto",
-                }
-              }
-              target=""
-            >
-              Ticket Options Available
-            </span>
-          </div>
         </div>
         <div
-          className="c23"
+          className="c18"
         >
           <span
             aria-label="See Tickets"
-            className="c24"
+            className="c19"
             role="button"
             size="regular"
             width="102px"
@@ -1615,10 +1582,10 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
             See Tickets
           </span>
           <div
-            className="c25"
+            className="c20"
           >
             <div
-              className="text text--dark text--secondary c8 c26"
+              className="text text--dark text--secondary c8 c21"
               disabled={false}
               size={
                 Object {
@@ -1634,7 +1601,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
         </div>
       </a>
       <div
-        className="c27"
+        className="c22"
       >
         <button
           aria-label="More Info"
@@ -1655,6 +1622,48 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
             />
           </svg>
         </button>
+      </div>
+    </div>
+    <div
+      className="c23 c11"
+    >
+      <div
+        className="c13"
+      >
+        <button
+          className="link--row-options c24 c25"
+          data-index={0}
+          href={null}
+          onClick={[Function]}
+          rel="_self"
+          size={
+            Object {
+              "large": "hecto",
+              "medium": "hecto",
+              "small": "hecto",
+            }
+          }
+          target=""
+        >
+          Ticket Options Available
+        </button>
+        <span
+          className="link--row-options c26 c27"
+          data-index={0}
+          href=""
+          onClick={null}
+          rel="_self"
+          size={
+            Object {
+              "large": "hecto",
+              "medium": "hecto",
+              "small": "hecto",
+            }
+          }
+          target=""
+        >
+          Ticket Options Available
+        </span>
       </div>
     </div>
     <div
@@ -1712,7 +1721,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   flex: 0 0 100%;
 }
 
-.c22 {
+.c27 {
   font-size: 14px;
   font-weight: 400;
   line-height: 1.5;
@@ -1724,18 +1733,18 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   transition: color 0.3s ease;
 }
 
-.c22:focus,
-.c22:active,
-.c22:visited,
-.c22:hover {
+.c27:focus,
+.c27:active,
+.c27:visited,
+.c27:hover {
   color: rgba(2,108,223,1);
 }
 
-.c22:hover {
+.c27:hover {
   color: #0150a7;
 }
 
-.c20 {
+.c25 {
   font-size: 14px;
   font-weight: 400;
   line-height: 1.5;
@@ -1755,14 +1764,14 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   cursor: pointer;
 }
 
-.c20:focus,
-.c20:active,
-.c20:visited,
-.c20:hover {
+.c25:focus,
+.c25:active,
+.c25:visited,
+.c25:hover {
   color: rgba(2,108,223,1);
 }
 
-.c20:hover {
+.c25:hover {
   color: #0150a7;
 }
 
@@ -1790,7 +1799,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   color: rgba(38,38,38,1);
 }
 
-.c26 {
+.c21 {
   font-size: 12px;
   font-weight: 400;
   line-height: 1.5;
@@ -1827,18 +1836,17 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   display: none;
 }
 
-.c18 {
+.c23 {
   width: 100%;
-  position: absolute;
-  left: 0;
-  top: 100%;
+  padding-left: 101px;
+  padding-bottom: 8px;
 }
 
-.c19 {
+.c24 {
   display: inline-block;
 }
 
-.c21 {
+.c26 {
   display: none;
 }
 
@@ -1878,7 +1886,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   padding-top: 8px;
   padding-bottom: 1px;
   border-radius: 2px;
-  margin: 12px 0 25px 0;
+  margin: 12px 0 0 0;
 }
 
 .c6 {
@@ -1890,7 +1898,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   display: none;
 }
 
-.c24 {
+.c19 {
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -1928,23 +1936,23 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   padding: 18px 0;
 }
 
-.c24:focus {
+.c19:focus {
   outline: none;
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c24:hover {
+.c19:hover {
   background-color: #0150a7;
 }
 
-.c24:active {
+.c19:active {
   -webkit-transform: scale(0.98,0.98) translate(0,1px);
   -ms-transform: scale(0.98,0.98) translate(0,1px);
   transform: scale(0.98,0.98) translate(0,1px);
   background-color: #013670;
 }
 
-.c24:disabled {
+.c19:disabled {
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
@@ -1959,14 +1967,14 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   overflow: hidden;
 }
 
-.c23 {
+.c18 {
   display: none;
   padding-left: 8px;
   padding-right: 8px;
   position: relative;
 }
 
-.c27 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1992,7 +2000,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   line-height: 1.2;
 }
 
-.c25 {
+.c20 {
   width: 100%;
   position: absolute;
   left: 0;
@@ -2088,25 +2096,25 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c22 {
+  .c27 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c22 {
+  .c27 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c20 {
+  .c25 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c20 {
+  .c25 {
     font-size: 14px;
   }
 }
@@ -2148,13 +2156,13 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c26 {
+  .c21 {
     font-size: 12px;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c26 {
+  .c21 {
     font-size: 12px;
   }
 }
@@ -2178,13 +2186,19 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c19 {
+  .c23 {
+    padding-left: calc(15px + 16px + 16px + 116px);
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c24 {
     display: none;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c21 {
+  .c26 {
     display: inline-block;
     opacity: 1;
     line-height: 1.5;
@@ -2192,7 +2206,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
     transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955) 0.2s;
   }
 
-  .c21.link--hidden {
+  .c26.link--hidden {
     opacity: 0;
     -webkit-transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
     transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
@@ -2221,7 +2235,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 
 @media screen and (min-width:768px) {
   .c5 {
-    margin: 18px 0 25px 0;
+    margin: 18px 0 0 0;
   }
 
   .c5:hover {
@@ -2305,7 +2319,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c23 {
+  .c18 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2322,7 +2336,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c27 {
+  .c22 {
     display: none;
   }
 }
@@ -2497,51 +2511,13 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
               KABOO 3-Day Pass
             </div>
           </div>
-          <div
-            className="c18 c13"
-          >
-            <button
-              className="link--row-options c19 c20"
-              data-index={0}
-              href={null}
-              onClick={[Function]}
-              rel="_self"
-              size={
-                Object {
-                  "large": "hecto",
-                  "medium": "hecto",
-                  "small": "hecto",
-                }
-              }
-              target=""
-            >
-              Ticket options available
-            </button>
-            <a
-              className="c21 c22"
-              data-index={0}
-              href="/"
-              onClick={null}
-              rel="_self"
-              size={
-                Object {
-                  "large": "hecto",
-                  "medium": "hecto",
-                  "small": "hecto",
-                }
-              }
-              target=""
-            >
-              Ticket options available
-            </a>
-          </div>
         </div>
         <div
-          className="c23"
+          className="c18"
         >
           <span
             aria-label="See Tickets"
-            className="c24"
+            className="c19"
             role="button"
             size="regular"
             width="102px"
@@ -2549,10 +2525,10 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
             See Tickets
           </span>
           <div
-            className="c25"
+            className="c20"
           >
             <div
-              className="text text--dark text--secondary c8 c26"
+              className="text text--dark text--secondary c8 c21"
               disabled={false}
               size={
                 Object {
@@ -2568,7 +2544,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
         </div>
       </a>
       <div
-        className="c27"
+        className="c22"
       >
         <button
           aria-label="More Info"
@@ -2589,6 +2565,48 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
             />
           </svg>
         </button>
+      </div>
+    </div>
+    <div
+      className="c23 c11"
+    >
+      <div
+        className="c13"
+      >
+        <button
+          className="link--row-options c24 c25"
+          data-index={0}
+          href={null}
+          onClick={[Function]}
+          rel="_self"
+          size={
+            Object {
+              "large": "hecto",
+              "medium": "hecto",
+              "small": "hecto",
+            }
+          }
+          target=""
+        >
+          Ticket options available
+        </button>
+        <a
+          className="c26 c27"
+          data-index={0}
+          href="/"
+          onClick={null}
+          rel="_self"
+          size={
+            Object {
+              "large": "hecto",
+              "medium": "hecto",
+              "small": "hecto",
+            }
+          }
+          target=""
+        >
+          Ticket options available
+        </a>
       </div>
     </div>
     <div

--- a/src/components/List/__tests__/__snapshots__/RowOptionsLink.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/RowOptionsLink.spec.js.snap
@@ -2,6 +2,33 @@
 
 exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
+.c1 .c1 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c2 {
   box-sizing: border-box;
   padding-right: 8px;
   padding-left: 8px;
@@ -11,7 +38,7 @@ exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
   flex: 0 0 100%;
 }
 
-.c3 {
+.c4 {
   font-size: 14px;
   font-weight: 400;
   line-height: 1.5;
@@ -31,18 +58,18 @@ exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
   cursor: pointer;
 }
 
-.c3:focus,
-.c3:active,
-.c3:visited,
-.c3:hover {
+.c4:focus,
+.c4:active,
+.c4:visited,
+.c4:hover {
   color: rgba(2,108,223,1);
 }
 
-.c3:hover {
+.c4:hover {
   color: #0150a7;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
   font-weight: 400;
   line-height: 1.5;
@@ -55,34 +82,40 @@ exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
   cursor: pointer;
 }
 
-.c5:focus,
-.c5:active,
-.c5:visited,
-.c5:hover {
+.c6:focus,
+.c6:active,
+.c6:visited,
+.c6:hover {
   color: rgba(2,108,223,1);
 }
 
-.c5:hover {
+.c6:hover {
   color: #0150a7;
 }
 
 .c0 {
   width: 100%;
-  position: absolute;
-  left: 0;
-  top: 100%;
+  padding-left: 101px;
+  padding-bottom: 8px;
 }
 
-.c2 {
+.c3 {
   display: inline-block;
 }
 
-.c4 {
+.c5 {
   display: none;
 }
 
 @media screen and (min-width:768px) {
   .c1 {
+    margin-left: -12px;
+    margin-right: -12px;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c2 {
     padding-right: 12px;
     padding-left: 12px;
     max-width: 100%;
@@ -94,7 +127,7 @@ exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
 }
 
 @media screen and (min-width:1024px) {
-  .c1 {
+  .c2 {
     max-width: 100%;
     display: block;
     -webkit-flex: 0 0 100%;
@@ -104,7 +137,7 @@ exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
 }
 
 @media screen and (min-width:1440px) {
-  .c1 {
+  .c2 {
     max-width: 100%;
     display: block;
     -webkit-flex: 0 0 100%;
@@ -114,37 +147,43 @@ exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c3 {
+  .c4 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c3 {
+  .c4 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c5 {
+  .c6 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c5 {
+  .c6 {
     font-size: 14px;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c2 {
+  .c0 {
+    padding-left: calc(15px + 16px + 16px + 116px);
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
     display: none;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c4 {
+  .c5 {
     display: inline-block;
     opacity: 1;
     line-height: 1.5;
@@ -152,7 +191,7 @@ exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
     transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955) 0.2s;
   }
 
-  .c4.link--hidden {
+  .c5.link--hidden {
     opacity: 0;
     -webkit-transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
     transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
@@ -162,35 +201,39 @@ exports[`<RowOptionsLink /> renders RowOptionsLink 1`] = `
 <div
   className="c0 c1"
 >
-  <button
-    className="link--row-options c2 c3"
-    data-index={0}
-    href={null}
-    onClick={[Function]}
-    rel="_self"
-    size={
-      Object {
-        "large": "hecto",
-        "medium": "hecto",
-        "small": "hecto",
+  <div
+    className="c2"
+  >
+    <button
+      className="link--row-options c3 c4"
+      data-index={0}
+      href={null}
+      onClick={[Function]}
+      rel="_self"
+      size={
+        Object {
+          "large": "hecto",
+          "medium": "hecto",
+          "small": "hecto",
+        }
       }
-    }
-    target=""
-  />
-  <span
-    className="link--row-options c4 c5"
-    data-index={0}
-    href=""
-    onClick={null}
-    rel="_self"
-    size={
-      Object {
-        "large": "hecto",
-        "medium": "hecto",
-        "small": "hecto",
+      target=""
+    />
+    <span
+      className="link--row-options c5 c6"
+      data-index={0}
+      href=""
+      onClick={null}
+      rel="_self"
+      size={
+        Object {
+          "large": "hecto",
+          "medium": "hecto",
+          "small": "hecto",
+        }
       }
-    }
-    target=""
-  />
+      target=""
+    />
+  </div>
 </div>
 `;

--- a/src/components/List/constants.js
+++ b/src/components/List/constants.js
@@ -1,0 +1,6 @@
+import spacing from "../../theme/spacing";
+
+export const ROW_DATE_SMALL_WIDTH = "101px";
+export const ROW_DATE_MEDIUM_WIDTH = "116px";
+export const CHEVRON_ICON_SIZE = 15;
+export const CHEVRON_ICON_PADDING = spacing.moderate;


### PR DESCRIPTION
**What**: ListRow markup has been changed to separate RowContent ListContainer click and options link click. OptionsLink was a child of RowContent ListContainer.  OptionsLink have been moved to ListContainer parent. Styles for ListRow has been adjusted.

**Why**: Click on options link invoke navigation to link of row content. Click on options link should only expand row details.

**How**: Change markup.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
