### PR TITLE
fix(Inputs): checkbox and input styles fix

### DIFF
--- a/src/components/Input/CheckBox/CheckBoxInput.styles.js
+++ b/src/components/Input/CheckBox/CheckBoxInput.styles.js
@@ -29,6 +29,7 @@ export default styled.input.attrs({
 
   &:before {
     content: "";
+    box-sizing: border-box;
     background-color: transparent;
     border-radius: ${constants.borderRadius.small};
     border: 1px solid ${getThemeValue("gray02")};
@@ -71,6 +72,7 @@ export default styled.input.attrs({
 
   &::after {
     content: "";
+    box-sizing: border-box;
     position: absolute;
     top: 50%;
     left: 50%;

--- a/src/components/Input/Input.styles.js
+++ b/src/components/Input/Input.styles.js
@@ -60,6 +60,7 @@ export const FieldInputBox = styled.input.attrs({
 })`
   height: 36px;
   width: 100%;
+  box-sizing: border-box;
   border-radius: ${constants.borderRadius.small};
   background-color: ${getThemeValue("white", "base")};
   border: 1px solid ${getThemeValue("gray02")};

--- a/src/components/Input/__tests__/__snapshots__/CheckBoxGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/CheckBoxGroup.spec.js.snap
@@ -7,7 +7,7 @@ Object {
       class="checkbox--small checkbox__checked sc-gzVnrw jLPzax"
     >
       <input
-        class="sc-bZQynM bOQGeJ"
+        class="sc-bZQynM fYtyTz"
         data-testid="test-checkbox"
         id="something1input"
         name="something"
@@ -83,7 +83,7 @@ Object {
       class="checkbox--small sc-gzVnrw jLPzax"
     >
       <input
-        class="sc-bZQynM bOQGeJ"
+        class="sc-bZQynM fYtyTz"
         data-testid="test-checkbox"
         id="something1input"
         name="something"
@@ -162,7 +162,7 @@ Object {
         class="checkbox--large sc-gzVnrw jLPzax"
       >
         <input
-          class="sc-bZQynM bOQGeJ"
+          class="sc-bZQynM fYtyTz"
           data-testid="test-checkbox"
           id="somethingelseinput"
           name="something"
@@ -242,7 +242,7 @@ Object {
         class="checkbox--large sc-gzVnrw jLPzax"
       >
         <input
-          class="sc-bZQynM bOQGeJ"
+          class="sc-bZQynM fYtyTz"
           data-testid="test-checkbox"
           id="somethingelseinput"
           name="something"
@@ -322,7 +322,7 @@ Object {
         class="checkbox--large sc-gzVnrw jLPzax"
       >
         <input
-          class="sc-bZQynM bOQGeJ"
+          class="sc-bZQynM fYtyTz"
           data-testid="test-checkbox"
           id="somethingelseinput"
           name="something"

--- a/src/components/Input/__tests__/__snapshots__/CheckBoxInput.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/CheckBoxInput.spec.js.snap
@@ -31,6 +31,7 @@ exports[`<CheckBoxInput /> should render the correct markup 1`] = `
 
 .c0:before {
   content: "";
+  box-sizing: border-box;
   background-color: transparent;
   border-radius: 2px;
   border: 1px solid #999999;
@@ -79,6 +80,7 @@ exports[`<CheckBoxInput /> should render the correct markup 1`] = `
 
 .c0::after {
   content: "";
+  box-sizing: border-box;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -155,6 +157,7 @@ exports[`<CheckBoxInput /> should render the correct markup when additional prop
 
 .c0:before {
   content: "";
+  box-sizing: border-box;
   background-color: transparent;
   border-radius: 2px;
   border: 1px solid #999999;
@@ -203,6 +206,7 @@ exports[`<CheckBoxInput /> should render the correct markup when additional prop
 
 .c0::after {
   content: "";
+  box-sizing: border-box;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -279,6 +283,7 @@ exports[`<CheckBoxInput /> should render the correct markup when the disabled pr
 
 .c0:before {
   content: "";
+  box-sizing: border-box;
   background-color: transparent;
   border-radius: 2px;
   border: 1px solid #999999;
@@ -327,6 +332,7 @@ exports[`<CheckBoxInput /> should render the correct markup when the disabled pr
 
 .c0::after {
   content: "";
+  box-sizing: border-box;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -403,6 +409,7 @@ exports[`<CheckBoxInput /> should render the correct markup when the isChecked p
 
 .c0:before {
   content: "";
+  box-sizing: border-box;
   background-color: transparent;
   border-radius: 2px;
   border: 1px solid #999999;
@@ -451,6 +458,7 @@ exports[`<CheckBoxInput /> should render the correct markup when the isChecked p
 
 .c0::after {
   content: "";
+  box-sizing: border-box;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -527,6 +535,7 @@ exports[`<CheckBoxInput /> should render the correct markup when the size prop e
 
 .c0:before {
   content: "";
+  box-sizing: border-box;
   background-color: transparent;
   border-radius: 2px;
   border: 1px solid #999999;
@@ -575,6 +584,7 @@ exports[`<CheckBoxInput /> should render the correct markup when the size prop e
 
 .c0::after {
   content: "";
+  box-sizing: border-box;
   position: absolute;
   top: 50%;
   left: 50%;

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Input renders default input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb hlBmN"
+      class="sc-bxivhb cmIlUT"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -45,7 +45,7 @@ exports[`Input renders disabled input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb hlBmN"
+      class="sc-bxivhb cmIlUT"
       disabled=""
       id="test1firstname__input"
       name="test1"
@@ -76,7 +76,7 @@ exports[`Input renders input with error 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb hlBmN"
+      class="sc-bxivhb cmIlUT"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -108,7 +108,7 @@ exports[`Input renders large input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb hlBmN"
+      class="sc-bxivhb cmIlUT"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -138,7 +138,7 @@ exports[`Input renders left labeled input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb hlBmN"
+      class="sc-bxivhb cmIlUT"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -168,7 +168,7 @@ exports[`Input renders small input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb hlBmN"
+      class="sc-bxivhb cmIlUT"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"
@@ -198,7 +198,7 @@ exports[`Input renders top labeled input 1`] = `
   >
     <input
       aria-labelledby="test1firstname__label"
-      class="sc-bxivhb hlBmN"
+      class="sc-bxivhb cmIlUT"
       id="test1firstname__input"
       name="test1"
       placeholder="test hint"


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
`CheckBoxInput` and `Input` styles fix
<!-- Why are these changes necessary? -->

**Why**:
Incorrect behaviour on websites where `box-sizing: border-box` rule is not set to those elements globally.
<!-- How were these changes implemented? -->

**How**:
`box-sizing: border-box` added
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
