### PR TITLE
fix(DropDown): Render StyledKeyboardProvider with underlying div element when withKeyboardProvider prop equals false

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -147,6 +147,9 @@ class DropDownGroup extends React.Component {
       "_"
     )}`;
     const onClickListener = disabled ? {} : { onClick: this.onClick };
+    const ChildrenWrapper = withKeyboardProvider
+      ? StyledKeyboardProvider
+      : StyledKeyboardProvider.withComponent("div");
 
     return (
       <SelectionProvider
@@ -156,96 +159,97 @@ class DropDownGroup extends React.Component {
         valueOverride={valueOverride}
       >
         <SelectionConsumer>
-          {({ selected }) => (
-            <Transition in={openUpward} timeout={this.ANIMATION_TIMEOUT}>
-              {state => {
-                // keep dropdown--open-upward className until collapse animation is finished (.3s)
-                const hasOpenUpwardClass = state !== "exited";
+          {({ selected }) => {
+            const keyboardProviderProps = withKeyboardProvider
+              ? { keywordSearch, selected }
+              : {};
 
-                return (
-                  <StyledGroupWrapper
-                    {...props}
-                    className={classNames({
-                      "dropdown--open-upward": hasOpenUpwardClass,
-                      "dropdown--disabled": disabled
-                    })}
-                    tabIndex={disabled ? -1 : 0}
-                    aria-haspopup="listbox"
-                    aria-labelledby={hiddenLabelId}
-                    onKeyDown={this.onKeyDown}
-                    innerRef={this.thisComponent}
-                  >
-                    <StyledGroup
-                      {...onClickListener}
-                      onMouseDown={this.onMouseDown} // disable focus on click
-                      className={classNames(`dropdown--${size}`, {
-                        "dropdown--active": isOpen,
-                        "dropdown--border": variant === 0,
-                        "dropdown--no-border": variant === 1,
-                        "dropdown__label--disabled": disabled
+            return (
+              <Transition in={openUpward} timeout={this.ANIMATION_TIMEOUT}>
+                {state => {
+                  // keep dropdown--open-upward className until collapse animation is finished (.3s)
+                  const hasOpenUpwardClass = state !== "exited";
+
+                  return (
+                    <StyledGroupWrapper
+                      {...props}
+                      className={classNames({
+                        "dropdown--open-upward": hasOpenUpwardClass,
+                        "dropdown--disabled": disabled
                       })}
-                      innerRef={this.styledGroup}
+                      tabIndex={disabled ? -1 : 0}
+                      aria-haspopup="listbox"
+                      aria-labelledby={hiddenLabelId}
+                      onKeyDown={this.onKeyDown}
+                      innerRef={this.thisComponent}
                     >
-                      {/* HiddenLabel is required for correct screen readers 
-                          readings when an option is selected */}
-                      <HiddenLabel id={hiddenLabelId}>
-                        {placeholder || label}
-                      </HiddenLabel>
-                      <StyledSelectedText
-                        className={classNames({
-                          "dropdown__text--disabled": disabled
-                        })}
-                      >
-                        {this.displayLabel(selected, variant)}
-                      </StyledSelectedText>
-
-                      <StyledChevron
-                        className={classNames({
-                          "dropdown__icon--hide": isOpen,
+                      <StyledGroup
+                        {...onClickListener}
+                        onMouseDown={this.onMouseDown} // disable focus on click
+                        className={classNames(`dropdown--${size}`, {
+                          "dropdown--active": isOpen,
+                          "dropdown--border": variant === 0,
                           "dropdown--no-border": variant === 1,
-                          "dropdown__chevron--disabled": disabled
+                          "dropdown__label--disabled": disabled
                         })}
-                        direction="down"
-                        size={12}
-                      />
-                    </StyledGroup>
-                    <Transition in={isOpen} timeout={this.ANIMATION_TIMEOUT}>
-                      {wrapperState => (
-                        <StyledChildWrapper
-                          className={classNames(
-                            "dropdown__items",
-                            `dropdown__items--${size}`,
-                            {
-                              "dropdown--clicked": isOpen,
-                              "dropdown--overflow": wrapperState === "entered"
-                            }
-                          )}
+                        innerRef={this.styledGroup}
+                      >
+                        {/* HiddenLabel is required for correct screen readers 
+                          readings when an option is selected */}
+                        <HiddenLabel id={hiddenLabelId}>
+                          {placeholder || label}
+                        </HiddenLabel>
+                        <StyledSelectedText
+                          className={classNames({
+                            "dropdown__text--disabled": disabled
+                          })}
                         >
-                          <DropDownProvider value={{ ...this.state, isOpen }}>
-                            {/* this div is required to decide which way to open a dropdown */}
-                            <div ref={this.optionsContainer}>
-                              {withKeyboardProvider ? (
-                                <StyledKeyboardProvider
+                          {this.displayLabel(selected, variant)}
+                        </StyledSelectedText>
+
+                        <StyledChevron
+                          className={classNames({
+                            "dropdown__icon--hide": isOpen,
+                            "dropdown--no-border": variant === 1,
+                            "dropdown__chevron--disabled": disabled
+                          })}
+                          direction="down"
+                          size={12}
+                        />
+                      </StyledGroup>
+                      <Transition in={isOpen} timeout={this.ANIMATION_TIMEOUT}>
+                        {wrapperState => (
+                          <StyledChildWrapper
+                            className={classNames(
+                              "dropdown__items",
+                              `dropdown__items--${size}`,
+                              {
+                                "dropdown--clicked": isOpen,
+                                "dropdown--overflow": wrapperState === "entered"
+                              }
+                            )}
+                          >
+                            <DropDownProvider value={{ ...this.state, isOpen }}>
+                              {/* this div is required to decide which way to open a dropdown */}
+                              <div ref={this.optionsContainer}>
+                                <ChildrenWrapper
                                   role="listbox"
                                   aria-labelledby={hiddenLabelId}
-                                  keywordSearch={keywordSearch}
-                                  selected={selected}
+                                  {...keyboardProviderProps}
                                 >
                                   {children}
-                                </StyledKeyboardProvider>
-                              ) : (
-                                children
-                              )}
-                            </div>
-                          </DropDownProvider>
-                        </StyledChildWrapper>
-                      )}
-                    </Transition>
-                  </StyledGroupWrapper>
-                );
-              }}
-            </Transition>
-          )}
+                                </ChildrenWrapper>
+                              </div>
+                            </DropDownProvider>
+                          </StyledChildWrapper>
+                        )}
+                      </Transition>
+                    </StyledGroupWrapper>
+                  );
+                }}
+              </Transition>
+            );
+          }}
         </SelectionConsumer>
       </SelectionProvider>
     );

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -1088,33 +1088,39 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
     >
       <div>
-        <span
-          class="sc-gzVnrw iJMNFP"
-          data-testid="test-dropDownOptionOne"
-          role="option"
-          tabindex="-1"
-          value="ValueOne"
+        <div
+          aria-labelledby="hidden-label__"
+          class="sc-htoDjs dQowVh"
+          role="listbox"
         >
-          Option One
-        </span>
-        <span
-          class="sc-gzVnrw iJMNFP"
-          data-testid="test-dropDownOptionTwo"
-          role="option"
-          tabindex="-1"
-          value="ValueTwo"
-        >
-          Second Option
-        </span>
-        <span
-          class="sc-gzVnrw iJMNFP"
-          data-testid="test-dropDownOptionThree"
-          role="option"
-          tabindex="-1"
-          value="ValueThree"
-        >
-          Option Three
-        </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionOne"
+            role="option"
+            tabindex="-1"
+            value="ValueOne"
+          >
+            Option One
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionTwo"
+            role="option"
+            tabindex="-1"
+            value="ValueTwo"
+          >
+            Second Option
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionThree"
+            role="option"
+            tabindex="-1"
+            value="ValueThree"
+          >
+            Option Three
+          </span>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Rather than omitting the `KeyboardProvider` from the `DropDownGroup` when the `withKeyboardProvider` prop equals `false`, the `KeyboardProvider` will be rendered with an underlying `div` element.

<!-- Why are these changes necessary? -->

**Why**: This change is necessary to ensure that the correct styling is applied to the `DropDownGroup` `children` when the `withKeyboardProvider` prop equals `false`.

<!-- How were these changes implemented? -->

**How**: Rather than omitting the `KeyboardProvider` from the `DropDownGroup` when the `withKeyboardProvider` prop equals `false`, the `KeyboardProvider` will be rendered with an underlying `div` element.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
