### PR TITLE
fix(DropDown): behavior update

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -11,7 +11,8 @@ import {
   ARROWUP,
   ARROWDOWN,
   SPACEBAR,
-  ESCAPE
+  ESCAPE,
+  TAB
 } from "../../../utils/keyCharCodes";
 import {
   StyledGroup,
@@ -28,39 +29,49 @@ class DropDownGroup extends React.Component {
     document.addEventListener("click", this.handleOutsideClick);
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { isOpen } = this.state;
+    // disables scroll when dropdown is open
+    document.addEventListener("wheel", this.disableScroll);
+    // scroll dropdown to top after opening
+    if (isOpen && isOpen !== prevState.isOpen) {
+      this.styledChildWrapper.current.scrollTop = 0;
+    }
+  }
+
   componentWillUnmount() {
     document.removeEventListener("click", this.handleOutsideClick);
+    document.removeEventListener("wheel", this.disableScroll);
   }
 
   onClick = () => {
-    const { shouldOpenDownward } = this.props;
-    this.setState(({ isOpen }) => ({
-      // set openUpward to false when closing the dropdown, otherwise check position
-      openUpward: isOpen || shouldOpenDownward ? false : this.checkPosition(),
-      isOpen: !isOpen
-    }));
+    this.toggleDropdown();
   };
 
   onKeyDown = e => {
     const { keyCode } = e;
-    e.preventDefault();
-    if (keyCode === ESCAPE) {
-      this.setState({ isOpen: false });
-      return;
-    }
-    if (keyCode === ARROWUP || keyCode === ARROWDOWN) {
-      this.setState({ isOpen: true });
-      return;
-    }
-    if (keyCode === SPACEBAR) {
-      this.setState(({ isOpen }) => ({ isOpen: !isOpen }));
-    }
-  };
+    const { isOpen } = this.state;
 
-  onMouseDown = e => {
-    e.preventDefault();
-    if (this.props.disabled) {
-      e.stopPropagation();
+    switch (keyCode) {
+      case ESCAPE:
+        this.closeDropdown();
+        break;
+      case TAB:
+        if (isOpen) {
+          e.preventDefault();
+        }
+        break;
+      case ARROWUP:
+      case ARROWDOWN:
+        e.preventDefault();
+        this.openDropdown();
+        break;
+      case SPACEBAR:
+        e.preventDefault();
+        this.toggleDropdown();
+        break;
+      default:
+        break;
     }
   };
 
@@ -74,22 +85,71 @@ class DropDownGroup extends React.Component {
     }
     return label;
   };
-
-  checkPosition = () => {
-    // check if dropdown height is higher than the space underneath it
-    const viewPortHeight = document.documentElement.clientHeight;
-    const { bottom } = this.styledGroup.current.getBoundingClientRect();
-    const spaceToBottom = viewPortHeight - bottom;
-    const ADDITIONAL_SPACE = 54; // according to requirements
-    const optionsHeight = this.optionsContainer.current.offsetHeight;
-    const optionsMaxHeight = optionsHeight > 413 ? 413 : optionsHeight;
-
-    return spaceToBottom <= optionsMaxHeight + ADDITIONAL_SPACE;
+  closeDropdown = () => {
+    this.setState(() => ({
+      // set openUpward to false when closing the dropdown, otherwise check position
+      openUpward: false,
+      isOpen: false,
+      maxDropdownHeight: 0
+    }));
   };
 
+  openDropdown = () => {
+    this.setState(() => {
+      const { shouldOpenDownward } = this.props;
+      const openUpward = this.shouldOpenUpward();
+
+      return {
+        // set openUpward to false when closing the dropdown, otherwise check position
+        openUpward: shouldOpenDownward ? false : openUpward,
+        isOpen: true,
+        maxDropdownHeight:
+          (openUpward
+            ? this.calculateSpaceToTop()
+            : this.calculateSpaceToBottom()) - this.ADDITIONAL_SPACE
+      };
+    });
+  };
+
+  toggleDropdown = () => {
+    if (this.state.isOpen) {
+      this.closeDropdown();
+    } else {
+      this.openDropdown();
+    }
+  };
+
+  disableScroll = e => {
+    if (this.state.isOpen && !this.groupWrapper.current.contains(e.target)) {
+      this.stopInteraction(e);
+    }
+  };
+
+  stopInteraction = e => {
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+  };
+
+  calculateSpaceToTop = () => {
+    const { top } = this.styledGroup.current.getBoundingClientRect();
+    return top;
+  };
+
+  calculateSpaceToBottom = () => {
+    const viewPortHeight = document.documentElement.clientHeight;
+    const { bottom } = this.styledGroup.current.getBoundingClientRect();
+    return viewPortHeight - bottom;
+  };
+
+  // check if dropdown height is higher than the space underneath it
+  shouldOpenUpward = () =>
+    this.calculateSpaceToBottom() <
+    this.DROPDOWN_MIN_HEIGHT + this.ADDITIONAL_SPACE;
+
   handleOutsideClick = e => {
-    if (this.state.isOpen && !this.thisComponent.current.contains(e.target)) {
-      this.setState(() => ({ isOpen: false, openUpward: false }));
+    if (this.state.isOpen && !this.groupWrapper.current.contains(e.target)) {
+      this.closeDropdown();
     }
   };
 
@@ -111,16 +171,20 @@ class DropDownGroup extends React.Component {
     return this.getCurrentSelection(selected[0]);
   };
 
-  thisComponent = React.createRef();
+  groupWrapper = React.createRef();
   optionsContainer = React.createRef();
   styledGroup = React.createRef();
+  styledChildWrapper = React.createRef();
   ANIMATION_TIMEOUT = 300;
+  ADDITIONAL_SPACE = 44;
+  DROPDOWN_MIN_HEIGHT = this.props.size === "small" ? 120 : 135;
 
   /* eslint-disable */
   state = {
     isOpen: false,
     onClose: this.onClick,
-    openUpward: false
+    openUpward: false,
+    maxDropdownHeight: 0
   };
   /* eslint-enable */
 
@@ -138,18 +202,24 @@ class DropDownGroup extends React.Component {
       label,
       disabled,
       size,
+      shouldOpenDownward,
       ...props
     } = this.props;
-    const { isOpen: isOpenState, openUpward } = this.state;
+    const { isOpen: isOpenState, openUpward, maxDropdownHeight } = this.state;
     const isOpen = isOpenProp || isOpenState;
     const hiddenLabelId = `hidden-label__${(placeholder || label).replace(
       / /g,
       "_"
     )}`;
-    const onClickListener = disabled ? {} : { onClick: this.onClick };
+    const onClickListener = disabled
+      ? { onMouseDown: this.stopInteraction }
+      : { onClick: this.onClick };
     const ChildrenWrapper = withKeyboardProvider
       ? StyledKeyboardProvider
       : StyledKeyboardProvider.withComponent("div");
+    const childWrapperStyles = shouldOpenDownward
+      ? {}
+      : { maxHeight: maxDropdownHeight };
 
     return (
       <SelectionProvider
@@ -181,11 +251,10 @@ class DropDownGroup extends React.Component {
                       aria-haspopup="listbox"
                       aria-labelledby={hiddenLabelId}
                       onKeyDown={this.onKeyDown}
-                      innerRef={this.thisComponent}
+                      innerRef={this.groupWrapper}
                     >
                       <StyledGroup
                         {...onClickListener}
-                        onMouseDown={this.onMouseDown} // disable focus on click
                         className={classNames(`dropdown--${size}`, {
                           "dropdown--active": isOpen,
                           "dropdown--border": variant === 0,
@@ -228,6 +297,8 @@ class DropDownGroup extends React.Component {
                                 "dropdown--overflow": wrapperState === "entered"
                               }
                             )}
+                            style={childWrapperStyles}
+                            innerRef={this.styledChildWrapper}
                           >
                             <DropDownProvider value={{ ...this.state, isOpen }}>
                               {/* this div is required to decide which way to open a dropdown */}

--- a/src/components/Input/DropDown/DropDownGroup.styles.js
+++ b/src/components/Input/DropDown/DropDownGroup.styles.js
@@ -39,10 +39,6 @@ export const StyledGroup = styled.label`
     justify-content: flex-end;
   }
 
-  &:focus {
-    border: solid 2px ${getThemeValue("primary", "base")};
-  }
-
   &.dropdown--active {
     margin: 0;
     border: solid 1px ${getThemeValue("gray02")};

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -219,6 +219,23 @@ describe("DropDownGroup", () => {
     expect(optionChoice).toHaveLength(1);
   });
 
+  it("Pressing tab when the dropdown is open", () => {
+    const { getByTestId } = renderComponent();
+    const preventDefault = jest.fn();
+
+    fireEvent.click(getByTestId("test-dropDownOptionOne"));
+
+    Simulate.keyDown(getByTestId("test-dropContainer"), {
+      key: "Tab",
+      keyCode: 9,
+      which: 9,
+      bubbles: true,
+      preventDefault
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
   it("Should select options based on typed input", () => {
     const { queryAllByText, getByTestId } = renderComponent();
 
@@ -281,6 +298,15 @@ describe("DropDownGroup", () => {
 
     const optionChoice = queryAllByText("Option One");
     expect(optionChoice).toHaveLength(2);
+  });
+
+  it("disable scroll when dropdown is open", () => {
+    const { container, getByTestId } = renderComponent();
+
+    fireEvent.click(getByTestId("test-dropDownOptionOne"));
+    fireEvent.wheel(getByTestId("test-outSideComponent"));
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   function renderComponent(props = {}) {

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -12,12 +12,12 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="sc-bxivhb pBoyv"
+    class="dropdown--open-upward sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -40,6 +40,7 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
+      style="max-height: -44px;"
     >
       <div>
         <div
@@ -92,12 +93,12 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="sc-bxivhb pBoyv"
+    class="dropdown--open-upward sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -120,6 +121,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
+      style="max-height: -44px;"
     >
       <div>
         <div
@@ -177,7 +179,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -200,6 +202,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -257,7 +260,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -280,6 +283,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
     </label>
     <div
       class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -337,7 +341,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -360,6 +364,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -417,7 +422,7 @@ exports[`DropDownGroup Should close the drop down on click outside 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -440,6 +445,7 @@ exports[`DropDownGroup Should close the drop down on click outside 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -497,7 +503,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
     tabindex="-1"
   >
     <label
-      class="dropdown--large dropdown--border dropdown__label--disabled sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border dropdown__label--disabled sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -520,6 +526,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -577,7 +584,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -600,6 +607,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -654,12 +662,12 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="sc-bxivhb pBoyv"
+    class="dropdown--open-upward sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -684,6 +692,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -736,12 +745,12 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="sc-bxivhb pBoyv"
+    class="dropdown--open-upward sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -766,6 +775,90 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
     </label>
     <div
       class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
+    >
+      <div>
+        <div
+          class="sc-bZQynM koCnbp"
+          role="listbox"
+        >
+          <span
+            class="dropdown__selected sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionOne"
+            role="option"
+            tabindex="-1"
+            value="ValueOne"
+          >
+            Option One
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionTwo"
+            role="option"
+            tabindex="-1"
+            value="ValueTwo"
+          >
+            Second Option
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionThree"
+            role="option"
+            tabindex="-1"
+            value="ValueThree"
+          >
+            Option Three
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup disable scroll when dropdown is open 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div
+    data-testid="something"
+  >
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__"
+    class="dropdown--open-upward sc-bxivhb pBoyv"
+    data-testid="test-dropContainer"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
+    >
+      <span
+        class="sc-htpNat irkcXP"
+        id="hidden-label__"
+      />
+      <div
+        class="sc-EHOje vdlIp"
+      >
+        Option One
+      </div>
+      <svg
+        class="dropdown__icon--hide sc-ifAKCX bGhIY"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
+      style="max-height: -44px;"
     >
       <div>
         <div
@@ -823,7 +916,7 @@ exports[`DropDownGroup renders default input 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -846,6 +939,7 @@ exports[`DropDownGroup renders default input 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -903,7 +997,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -926,6 +1020,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
     </label>
     <div
       class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -983,7 +1078,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -1006,6 +1101,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -1063,7 +1159,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -1086,6 +1182,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -1144,7 +1241,7 @@ exports[`DropDownGroup renders variant 0 with a placeholder prop 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--no-border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--no-border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -1171,6 +1268,7 @@ exports[`DropDownGroup renders variant 0 with a placeholder prop 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div
@@ -1228,7 +1326,7 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--no-border sc-bdVaJa fGMcWf"
+      class="dropdown--large dropdown--no-border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -1255,6 +1353,7 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
     </label>
     <div
       class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
     >
       <div>
         <div

--- a/src/utils/keyCharCodes.js
+++ b/src/utils/keyCharCodes.js
@@ -2,3 +2,4 @@ export const ARROWUP = 38;
 export const ARROWDOWN = 40;
 export const SPACEBAR = 32;
 export const ESCAPE = 27;
+export const TAB = 9;


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Behavior updates.
Dropdown opens downwards by default. In this case options' max height would be set to space under the dropdown minus 44px. If there's not enough space under the dropdown for three options height then the dropdown would open upwards and its height would be set to space above the dropdown minus 44px.
When dropdown is open scroll is disabled.

**Why**:
Requirements
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
