### PR TITLE
fix(ListRow): fix vertical align of RowToggler

### DIFF
--- a/src/components/List/RowContent.js
+++ b/src/components/List/RowContent.js
@@ -49,6 +49,16 @@ const ListContainer = styled.div`
   background-color: ${colors.white.base};
   align-items: stretch;
   display: flex;
+  padding-top: calc(12px + ${spacing.cozy});
+  padding-bottom: ${props =>
+    props.rowVariant === "withLink" ? "1px" : `calc(12px + ${spacing.cozy})`};
+  ${mediumAndUp`
+    padding-top: calc(18px + ${spacing.cozy});
+    padding-bottom: ${props =>
+      props.rowVariant === "withLink"
+        ? "0"
+        : `calc(18px + ${spacing.cozy})`};   
+  `};
 `;
 
 const LinkWrapper = styled.a`
@@ -57,20 +67,11 @@ const LinkWrapper = styled.a`
   justify-content: horizontal;
   width: 100%;
   cursor: pointer;
-  padding-top: ${spacing.cozy};
-  padding-bottom: ${props =>
-    props.rowVariant === "withLink" ? "1px" : spacing.cozy};
   border-radius: 2px;
-
-  margin: 12px 0 ${props => (props.rowVariant === "withLink" ? "0" : "12px")} 0;
   ${mediumAndUp`
-    margin: 18px 0
-      ${props => (props.rowVariant === "withLink" ? "0" : "18px")}
-      0;
     &:hover {
       background-color: ${colors.azure.light};
     }
-
   `};
 `;
 
@@ -257,7 +258,7 @@ const ListRowContent = ({
     {...rest}
   >
     {/* this class name is for automation purposes please do not remove or modify the name */}
-    <ListContainer className="list__container">
+    <ListContainer className="list__container" rowVariant={variant}>
       <RowToggler
         isOpen={isOpen}
         index={index}
@@ -271,7 +272,6 @@ const ListRowContent = ({
         aria-label={buttonText}
         onClick={onClick}
         href={url}
-        rowVariant={variant}
         // this class name is for automation purposes please do not remove or modify the name
         className="link__wrapper"
       >

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -8,7 +8,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     class="row__wrapper row__wrapper--expanded sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="true"
@@ -32,7 +32,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -417,7 +417,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -441,7 +441,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -826,7 +826,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -850,7 +850,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -1235,7 +1235,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -1259,7 +1259,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -1652,7 +1652,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -1676,7 +1676,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -2061,7 +2061,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -2085,7 +2085,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -2470,7 +2470,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -2494,7 +2494,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="Acheter des Billets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -2879,7 +2879,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -2903,7 +2903,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -3296,7 +3296,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     class="row__wrapper row__wrapper--expanded sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="true"
@@ -3320,7 +3320,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -3705,7 +3705,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -3729,7 +3729,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -4114,7 +4114,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -4138,7 +4138,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -4523,7 +4523,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -4547,7 +4547,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -4940,7 +4940,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -4964,7 +4964,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -5349,7 +5349,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -5373,7 +5373,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -5758,7 +5758,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -5782,7 +5782,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="Acheter des Billets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -6167,7 +6167,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -6191,7 +6191,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -6585,7 +6585,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -6609,7 +6609,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -6833,7 +6833,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -6857,7 +6857,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -7242,7 +7242,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -7266,7 +7266,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -7651,7 +7651,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -7675,7 +7675,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -8060,7 +8060,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -8084,7 +8084,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -8476,7 +8476,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
     class="row__wrapper row__wrapper--expanded sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="true"
@@ -8500,7 +8500,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -8885,7 +8885,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -8909,7 +8909,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -9294,7 +9294,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -9318,7 +9318,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -9703,7 +9703,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -9727,7 +9727,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -10120,7 +10120,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
       class="row__wrapper row__wrapper--expanded sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="true"
@@ -10144,7 +10144,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -10529,7 +10529,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -10553,7 +10553,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -10938,7 +10938,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -10962,7 +10962,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="Acheter des Billets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -11347,7 +11347,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
       class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
     >
       <div
-        class="list__container sc-hzDkRC iblHnN"
+        class="list__container sc-hzDkRC PuXlD"
       >
         <button
           aria-expanded="false"
@@ -11371,7 +11371,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="link__wrapper sc-jhAzac edtqEH"
+          class="link__wrapper sc-jhAzac idJTWM"
           href="/"
           role="link"
         >
@@ -11764,7 +11764,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -11788,7 +11788,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -11891,7 +11891,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -11915,7 +11915,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -12018,7 +12018,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -12042,7 +12042,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="Acheter des Billets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >
@@ -12145,7 +12145,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
     class="row__wrapper row__wrapper--collapsed sc-bRBYWo jAGYvv"
   >
     <div
-      class="list__container sc-hzDkRC iblHnN"
+      class="list__container sc-hzDkRC PuXlD"
     >
       <button
         aria-expanded="false"
@@ -12169,7 +12169,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="link__wrapper sc-jhAzac edtqEH"
+        class="link__wrapper sc-jhAzac idJTWM"
         href="/"
         role="link"
       >

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -121,6 +121,8 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: calc(12px + 8px);
+  padding-bottom: calc(12px + 8px);
 }
 
 .c5 {
@@ -136,10 +138,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
   justify-content: horizontal;
   width: 100%;
   cursor: pointer;
-  padding-top: 8px;
-  padding-bottom: 8px;
   border-radius: 2px;
-  margin: 12px 0 12px 0;
 }
 
 .c6 {
@@ -408,10 +407,13 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c5 {
-    margin: 18px 0 18px 0;
+  .c2 {
+    padding-top: calc(18px + 8px);
+    padding-bottom: calc(18px + 8px);
   }
+}
 
+@media screen and (min-width:768px) {
   .c5:hover {
     background-color: rgba(2,108,223,0.2);
   }
@@ -929,6 +931,8 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: calc(12px + 8px);
+  padding-bottom: 1px;
 }
 
 .c5 {
@@ -944,10 +948,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   justify-content: horizontal;
   width: 100%;
   cursor: pointer;
-  padding-top: 8px;
-  padding-bottom: 1px;
   border-radius: 2px;
-  margin: 12px 0 0 0;
 }
 
 .c6 {
@@ -1295,10 +1296,13 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c5 {
-    margin: 18px 0 0 0;
+  .c2 {
+    padding-top: calc(18px + 8px);
+    padding-bottom: 0;
   }
+}
 
+@media screen and (min-width:768px) {
   .c5:hover {
     background-color: rgba(2,108,223,0.2);
   }
@@ -1874,6 +1878,8 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: calc(12px + 8px);
+  padding-bottom: 1px;
 }
 
 .c5 {
@@ -1889,10 +1895,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   justify-content: horizontal;
   width: 100%;
   cursor: pointer;
-  padding-top: 8px;
-  padding-bottom: 1px;
   border-radius: 2px;
-  margin: 12px 0 0 0;
 }
 
 .c6 {
@@ -2240,10 +2243,13 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c5 {
-    margin: 18px 0 0 0;
+  .c2 {
+    padding-top: calc(18px + 8px);
+    padding-bottom: 0;
   }
+}
 
+@media screen and (min-width:768px) {
   .c5:hover {
     background-color: rgba(2,108,223,0.2);
   }
@@ -2743,6 +2749,8 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  padding-top: calc(12px + 8px);
+  padding-bottom: calc(12px + 8px);
 }
 
 .c5 {
@@ -2758,10 +2766,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
   justify-content: horizontal;
   width: 100%;
   cursor: pointer;
-  padding-top: 8px;
-  padding-bottom: 8px;
   border-radius: 2px;
-  margin: 12px 0 12px 0;
 }
 
 .c6 {
@@ -3030,10 +3035,13 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
 }
 
 @media screen and (min-width:768px) {
-  .c5 {
-    margin: 18px 0 18px 0;
+  .c2 {
+    padding-top: calc(18px + 8px);
+    padding-bottom: calc(18px + 8px);
   }
+}
 
+@media screen and (min-width:768px) {
   .c5:hover {
     background-color: rgba(2,108,223,0.2);
   }


### PR DESCRIPTION
**What**: Vertical position for ListRow toggler has been adjusted for `rowVariant` is `withLink`.
Currently toggler is not aligned. See first item https://code.ticketmaster.com/aurora/#/listRow?a=standard-list-row for desktop.

**How**: Margin and padding have been concatenated and removed from ListRow LinkWrapper to its parent. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
