### PR TITLE
fix(DropDownLabel): Add support for correct label when DropDownOption children is an array

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { Transition } from "react-transition-group";
@@ -76,15 +76,13 @@ class DropDownGroup extends React.Component {
   };
 
   getCurrentSelection = value => {
-    const [label = ""] = React.Children.toArray(this.props.children).filter(
+    const selectedItem = React.Children.toArray(this.props.children).find(
       c => c.props.value === value
     );
 
-    if (label) {
-      return label.props.children;
-    }
-    return label;
+    return selectedItem && selectedItem.props.children;
   };
+
   closeDropdown = () => {
     this.setState(() => ({
       // set openUpward to false when closing the dropdown, otherwise check position
@@ -164,7 +162,11 @@ class DropDownGroup extends React.Component {
     }
 
     if (variant === 1 && label.length > 0) {
-      return `${label} ${this.getCurrentSelection(selected[0])}`;
+      return (
+        <Fragment>
+          {label} {this.getCurrentSelection(selected[0])}
+        </Fragment>
+      );
     }
 
     return this.getCurrentSelection(selected[0]);

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -11,65 +11,116 @@ import DropDownGroup from "../DropDown/DropDownGroup";
 import DropDownOption from "../DropDown/DropDownOption";
 
 describe("DropDownGroup", () => {
+  function renderTestComponentOne(props = {}) {
+    return renderIntoDocument(
+      <div data-testid="test-outSideComponent">
+        <div data-testid="something">something</div>
+        <DropDownGroup {...props} data-testid="test-dropContainer">
+          <DropDownOption
+            data-testid="test-dropDownOptionOne"
+            value="ValueOne"
+            index={0}
+          >
+            Option One
+          </DropDownOption>
+          <DropDownOption
+            data-testid="test-dropDownOptionTwo"
+            value="ValueTwo"
+            index={1}
+          >
+            Second Option
+          </DropDownOption>
+          <DropDownOption
+            data-testid="test-dropDownOptionThree"
+            value="ValueThree"
+            index={2}
+          >
+            Option Three
+          </DropDownOption>
+        </DropDownGroup>
+      </div>
+    );
+  }
+
+  function renderTestComponentTwo(props = {}) {
+    return renderIntoDocument(
+      <DropDownGroup {...props} variant={1} label="Sort By:">
+        <DropDownOption value="date" index={0}>
+          {"Date"}
+          {null}
+        </DropDownOption>
+        <DropDownOption value="distance" index={1}>
+          {"Distance - "}
+          {"Closest"}
+        </DropDownOption>
+        <DropDownOption value="price" index={2}>
+          {"Price "}
+          {<span>On sale</span>}
+        </DropDownOption>
+      </DropDownGroup>
+    );
+  }
+
   afterEach(cleanup);
 
   it("renders default dropdown", () => {
-    expect(renderComponent().container.firstChild).toMatchSnapshot();
+    expect(renderTestComponentOne().container.firstChild).toMatchSnapshot();
   });
 
   it("renders default dropdown that should always open downwards", () => {
     expect(
-      renderComponent({ shouldOpenDownward: true }).container.firstChild
+      renderTestComponentOne({ shouldOpenDownward: true }).container.firstChild
     ).toMatchSnapshot();
   });
 
   it("renders small dropdown", () => {
     expect(
-      renderComponent({ size: "small" }).container.firstChild
+      renderTestComponentOne({ size: "small" }).container.firstChild
     ).toMatchSnapshot();
   });
 
   it("renders variant 0 with a placeholder prop", () => {
     expect(
-      renderComponent({ placeholder: "Select An Option", variant: 1 }).container
-        .firstChild
+      renderTestComponentOne({ placeholder: "Select An Option", variant: 1 })
+        .container.firstChild
     ).toMatchSnapshot();
   });
 
   it("renders variant 1 with a label prop", () => {
     expect(
-      renderComponent({ label: "Selected Option:", variant: 1 }).container
-        .firstChild
+      renderTestComponentOne({ label: "Selected Option:", variant: 1 })
+        .container.firstChild
     ).toMatchSnapshot();
   });
 
   it("renders input correctly when the isOpen prop with a value of true is passed", () => {
     expect(
-      renderComponent({ isOpen: true }).container.firstChild
+      renderTestComponentOne({ isOpen: true }).container.firstChild
     ).toMatchSnapshot();
   });
 
   it("renders input correctly when the keywordSearch prop with a value of false is passed", () => {
     expect(
-      renderComponent({ keywordSearch: false }).container.firstChild
+      renderTestComponentOne({ keywordSearch: false }).container.firstChild
     ).toMatchSnapshot();
   });
 
   it("renders input correctly when the withKeyboardProvider prop with a value of false is passed", () => {
     expect(
-      renderComponent({ withKeyboardProvider: false }).container.firstChild
+      renderTestComponentOne({ withKeyboardProvider: false }).container
+        .firstChild
     ).toMatchSnapshot();
   });
 
   it("Should open the drop down onClick", () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.click(getByTestId("test-dropContainer"));
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it("Should close the drop down on click outside", () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.click(getByTestId("test-dropContainer"));
     fireEvent.click(getByTestId("something"));
@@ -78,13 +129,13 @@ describe("DropDownGroup", () => {
   });
 
   it("Should not focus onClick", () => {
-    const { container } = renderComponent({ disabled: true });
+    const { container } = renderTestComponentOne({ disabled: true });
     fireEvent.mouseDown(container.querySelector("label"));
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it("Escape key should close the drop down", () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "Escape",
@@ -95,7 +146,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Arrow key up should open the drop down", () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "ArrowUp",
@@ -106,7 +157,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Arrow down arrow should open the drop down", () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "ArrowDown",
@@ -117,7 +168,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Click outside should close the dropdown", () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.click(getByTestId("test-dropContainer"));
     fireEvent.click(getByTestId("test-outSideComponent"));
@@ -125,7 +176,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Click outside should not close the dropdown when the isOpen prop equals true", () => {
-    const { container, getByTestId } = renderComponent({ isOpen: true });
+    const { container, getByTestId } = renderTestComponentOne({ isOpen: true });
 
     fireEvent.click(getByTestId("test-dropDownOptionOne"));
     fireEvent.click(getByTestId("test-outSideComponent"));
@@ -135,7 +186,7 @@ describe("DropDownGroup", () => {
 
   it("Space bar should select and close dropdown", () => {
     const onChange = jest.fn();
-    const { container, getByTestId } = renderComponent({ onChange });
+    const { container, getByTestId } = renderTestComponentOne({ onChange });
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "ArrowDown",
@@ -155,7 +206,7 @@ describe("DropDownGroup", () => {
 
   it("Space bar should select and not close dropdown when the isOpen prop equals true", () => {
     const onChange = jest.fn();
-    const { container, getByTestId } = renderComponent({
+    const { container, getByTestId } = renderTestComponentOne({
       onChange,
       isOpen: true
     });
@@ -177,7 +228,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Should remove event listener when unmount", () => {
-    const { container, unmount } = renderComponent();
+    const { container, unmount } = renderTestComponentOne();
 
     unmount();
     expect(container.innerHTML).toMatchSnapshot();
@@ -185,7 +236,7 @@ describe("DropDownGroup", () => {
 
   it("Should invoke an onChange handler option selected", () => {
     const onChange = jest.fn();
-    const { getByTestId } = renderComponent({ onChange });
+    const { getByTestId } = renderTestComponentOne({ onChange });
 
     Simulate.click(getByTestId("test-dropContainer"));
     Simulate.click(getByTestId("test-dropDownOptionOne"));
@@ -194,7 +245,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Should invoke an onChange handler when passed value to group", () => {
-    const { queryAllByText } = renderComponent({
+    const { queryAllByText } = renderTestComponentOne({
       value: ["ValueOne"]
     });
 
@@ -203,7 +254,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Selecting options after passing in values", () => {
-    const { queryAllByText, getByTestId } = renderComponent({
+    const { queryAllByText, getByTestId } = renderTestComponentOne({
       value: ["ValueOne"]
     });
 
@@ -233,7 +284,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Pressing tab when the dropdown is open", () => {
-    const { getByTestId } = renderComponent();
+    const { getByTestId } = renderTestComponentOne();
     const preventDefault = jest.fn();
 
     fireEvent.click(getByTestId("test-dropDownOptionOne"));
@@ -250,7 +301,7 @@ describe("DropDownGroup", () => {
   });
 
   it("Should select options based on typed input", () => {
-    const { queryAllByText, getByTestId } = renderComponent();
+    const { queryAllByText, getByTestId } = renderTestComponentOne();
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "ArrowDown",
@@ -279,7 +330,9 @@ describe("DropDownGroup", () => {
 
   it("if entered texted doesn't not match then select the option that matched previously", () => {
     const onChange = jest.fn();
-    const { queryAllByText, getByTestId } = renderComponent({ onChange });
+    const { queryAllByText, getByTestId } = renderTestComponentOne({
+      onChange
+    });
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "ArrowDown",
@@ -315,7 +368,7 @@ describe("DropDownGroup", () => {
 
   it("should NOT disable TAB key when the dropdown is NOT open", () => {
     const preventDefault = jest.fn();
-    const { getByTestId } = renderComponent();
+    const { getByTestId } = renderTestComponentOne();
 
     Simulate.keyDown(getByTestId("test-dropDownOptionOne"), {
       key: "",
@@ -329,7 +382,7 @@ describe("DropDownGroup", () => {
 
   it("should disable TAB key when the dropdown is open", () => {
     const preventDefault = jest.fn();
-    const { getByTestId } = renderComponent();
+    const { getByTestId } = renderTestComponentOne();
     fireEvent.click(getByTestId("test-dropDownOptionOne"));
 
     Simulate.keyDown(getByTestId("test-dropDownOptionOne"), {
@@ -343,7 +396,7 @@ describe("DropDownGroup", () => {
   });
 
   it("should disable scroll when dropdown is open", () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.click(getByTestId("test-dropDownOptionOne"));
     fireEvent.wheel(getByTestId("test-outSideComponent"));
@@ -352,7 +405,7 @@ describe("DropDownGroup", () => {
   });
 
   it("should allow scroll inside the dropdown when it is open", () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.click(getByTestId("test-dropDownOptionOne"));
     fireEvent.wheel(getByTestId("test-dropDownOptionOne"));
@@ -360,36 +413,20 @@ describe("DropDownGroup", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  function renderComponent(props = {}) {
-    return renderIntoDocument(
-      <div data-testid="test-outSideComponent">
-        <div data-testid="something">something</div>
-        <DropDownGroup {...props} data-testid="test-dropContainer">
-          <DropDownOption
-            data-testid="test-dropDownOptionOne"
-            value="ValueOne"
-            index={0}
-          >
-            Option One
-          </DropDownOption>
-          <DropDownOption
-            data-testid="test-dropDownOptionTwo"
-            value="ValueTwo"
-            index={1}
-          >
-            Second Option
-          </DropDownOption>
-          <DropDownOption
-            data-testid="test-dropDownOptionThree"
-            value="ValueThree"
-            index={2}
-          >
-            Option Three
-          </DropDownOption>
-        </DropDownGroup>
-      </div>
-    );
-  }
+  it("should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing falsy values is passed to each DropDownOption", () => {
+    const { container } = renderTestComponentTwo({ value: ["date"] });
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing string values is passed to each DropDownOption", () => {
+    const { container } = renderTestComponentTwo({ value: ["distance"] });
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption", () => {
+    const { container } = renderTestComponentTwo({ value: ["price"] });
+    expect(container).toMatchSnapshot();
+  });
 });
 
 describe("DropDownOption", () => {

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -1417,7 +1417,8 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
       <div
         class="sc-EHOje vdlIp"
       >
-        Selected Option: 
+        Selected Option:
+         
       </div>
       <svg
         class="dropdown--no-border sc-ifAKCX bGhIY"
@@ -1632,6 +1633,250 @@ exports[`DropDownGroup should disable scroll when dropdown is open 1`] = `
             value="ValueThree"
           >
             Option Three
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing falsy values is passed to each DropDownOption 1`] = `
+<div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__Sort_By:"
+    class="sc-bxivhb pBoyv"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--no-border sc-bdVaJa qKpWB"
+    >
+      <span
+        class="sc-htpNat irkcXP"
+        id="hidden-label__Sort_By:"
+      >
+        Sort By:
+      </span>
+      <div
+        class="sc-EHOje vdlIp"
+      >
+        Sort By:
+         
+        Date
+      </div>
+      <svg
+        class="dropdown--no-border sc-ifAKCX bGhIY"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
+    >
+      <div>
+        <div
+          class="sc-bZQynM koCnbp"
+          role="listbox"
+        >
+          <span
+            class="dropdown__selected sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="date"
+          >
+            Date
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="distance"
+          >
+            Distance - 
+            Closest
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="price"
+          >
+            Price 
+            <span>
+              On sale
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption 1`] = `
+<div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__Sort_By:"
+    class="sc-bxivhb pBoyv"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--no-border sc-bdVaJa qKpWB"
+    >
+      <span
+        class="sc-htpNat irkcXP"
+        id="hidden-label__Sort_By:"
+      >
+        Sort By:
+      </span>
+      <div
+        class="sc-EHOje vdlIp"
+      >
+        Sort By:
+         
+        Price 
+        <span>
+          On sale
+        </span>
+      </div>
+      <svg
+        class="dropdown--no-border sc-ifAKCX bGhIY"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
+    >
+      <div>
+        <div
+          class="sc-bZQynM koCnbp"
+          role="listbox"
+        >
+          <span
+            class="sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="date"
+          >
+            Date
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="distance"
+          >
+            Distance - 
+            Closest
+          </span>
+          <span
+            class="dropdown__selected sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="price"
+          >
+            Price 
+            <span>
+              On sale
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing string values is passed to each DropDownOption 1`] = `
+<div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__Sort_By:"
+    class="sc-bxivhb pBoyv"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--no-border sc-bdVaJa qKpWB"
+    >
+      <span
+        class="sc-htpNat irkcXP"
+        id="hidden-label__Sort_By:"
+      >
+        Sort By:
+      </span>
+      <div
+        class="sc-EHOje vdlIp"
+      >
+        Sort By:
+         
+        Distance - 
+        Closest
+      </div>
+      <svg
+        class="dropdown--no-border sc-ifAKCX bGhIY"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      style="max-height: 0;"
+    >
+      <div>
+        <div
+          class="sc-bZQynM koCnbp"
+          role="listbox"
+        >
+          <span
+            class="sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="date"
+          >
+            Date
+          </span>
+          <span
+            class="dropdown__selected sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="distance"
+          >
+            Distance - 
+            Closest
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            role="option"
+            tabindex="-1"
+            value="price"
+          >
+            Price 
+            <span>
+              On sale
+            </span>
           </span>
         </div>
       </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am adding support for the correct label when DropDownOption children is an array.

<!-- Why are these changes necessary? -->

**Why**: Currently, an array literal is displayed when the DropDownOption is selected, rather displaying than the correct label.

<!-- How were these changes implemented? -->

**How**: These changes are implemented in `DropDownGroup.getCurrentSelection`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
