### PR TITLE
fix(Tooltip): add dark variant

### DIFF
--- a/catalog/pages/tooltip/TooltipDemo.js
+++ b/catalog/pages/tooltip/TooltipDemo.js
@@ -1,6 +1,8 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import Tooltip from "../../../src/components/Tooltip";
+import { variants } from "../../../src/components/Tooltip/constants";
 
 const Container = styled.div`
   margin-top: 100px;
@@ -48,6 +50,7 @@ class TooltipDemo extends React.Component {
 
   render() {
     const { isOpened, direction, ...position } = this.state;
+    const { variant } = this.props;
     const tooltip =
       "Some text to be rendered in theeii pop over component. Some text to be rendered in the popover component.";
     return (
@@ -81,6 +84,7 @@ class TooltipDemo extends React.Component {
           isVisible={isOpened}
           position={{ ...position }}
           direction={direction}
+          variant={variant}
         >
           {tooltip}
         </Tooltip>
@@ -88,5 +92,12 @@ class TooltipDemo extends React.Component {
     );
   }
 }
+
+TooltipDemo.propTypes = {
+  variant: PropTypes.oneOf(Object.values(variants))
+};
+TooltipDemo.defaultProps = {
+  variant: "light"
+};
 
 export default TooltipDemo;

--- a/catalog/pages/tooltip/index.md
+++ b/catalog/pages/tooltip/index.md
@@ -15,6 +15,10 @@ rows:
     Type: boolean
     Default: false
     Notes: Show/hide tooltip
+  - Prop: variant
+    Type: one of 'dark', 'light'
+    Default: 'light'
+    Notes: Changes tooltip color scheme
   - Prop: position
     Type: Object
     Default: all props are 0
@@ -23,5 +27,8 @@ rows:
 
 ```react
 ---
-<TooltipDemo />
+<div>
+  <TooltipDemo />
+  <TooltipDemo variant="dark" />
+</div>
 ```

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,10 +1,11 @@
 import ContainerBlock from "../Container/Block.styles";
 import { constants, themes, spacing } from "../../theme";
+import { cardBoxShadow } from "../../theme/constants";
 
 const Card = ContainerBlock.extend`
   border-radius: ${constants.borderRadius.large};
   background-color: ${themes.global.white.base};
-  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.06), 0 0 4px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: ${cardBoxShadow};
   padding: ${spacing.moderate};
   border: none;
 `;

--- a/src/components/PopOver/index.js
+++ b/src/components/PopOver/index.js
@@ -3,12 +3,13 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { CSSTransition } from "react-transition-group";
 import { themes, constants, spacing } from "../../theme";
+import { popContainersBoxShadow } from "../../theme/constants";
 
 const StyledPopOver = styled.div`
   background-color: ${themes.global.white.base};
   border: 1px solid ${themes.global.gray02};
   border-radius: ${constants.borderRadius.large};
-  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: ${popContainersBoxShadow};
   position: absolute;
   max-width: 260px;
   padding: ${spacing.moderate};

--- a/src/components/Tooltip/Tooltip.styles.js
+++ b/src/components/Tooltip/Tooltip.styles.js
@@ -47,15 +47,15 @@ const StyledTooltip = styled.div`
     ${({ direction }) => {
       switch (direction) {
         case directions.top:
-          return "left: calc(50% - 9.5px); bottom: -13px; transform: translateY(-50%) rotate(45deg);";
+          return "left: calc(50% - 6px); bottom: -13px; transform: translateY(-50%) rotate(45deg);";
         case directions.bottom:
-          return "left: calc(50% - 9.5px); top: -1px; transform: translateY(-50%) rotate(-135deg);";
+          return "left: calc(50% - 6px); top: -1px; transform: translateY(-50%) rotate(-135deg);";
         case directions.left:
           return "top: 10px; right: -7px; transform: translateY(0%) rotate(-45deg);";
         case directions.right:
           return "top: 10px; left: -7px; transform: translateY(0%) rotate(135deg);";
         default:
-          return "left: calc(50% - 9.5px); top: -1px; transform: translateY(-50%) rotate(-135deg);";
+          return "left: calc(50% - 6px); top: -1px; transform: translateY(-50%) rotate(-135deg);";
       }
     }};
   }

--- a/src/components/Tooltip/Tooltip.styles.js
+++ b/src/components/Tooltip/Tooltip.styles.js
@@ -1,14 +1,25 @@
 import styled from "styled-components";
 import { themes, constants, spacing, typography } from "../../theme";
+import { popContainersBoxShadow } from "../../theme/constants";
+import { directions, variants } from "./constants";
 
 const StyledTooltip = styled.div`
-  background-color: ${themes.global.white.base};
-  border: 1px solid ${themes.global.gray02};
+  background-color: ${({ variant }) =>
+    variant === variants.dark
+      ? themes.global.darkFill
+      : themes.global.white.base};
+  border: ${({ variant }) =>
+    variant === variants.dark
+      ? `1px solid ${themes.global.darkFill}`
+      : `1px solid ${themes.global.gray02}`};
   border-radius: ${constants.borderRadius.large};
-  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: ${popContainersBoxShadow};
   position: absolute;
   max-width: 260px;
-  color: ${themes.global.gray01};
+  color: ${({ variant }) =>
+    variant === variants.dark
+      ? themes.global.white.base
+      : themes.global.gray01};
   padding: ${spacing.cozy};
   display: ${({ isVisible }) => (isVisible ? "block" : "none")};
   font-size: ${typography.size.uno};
@@ -21,22 +32,27 @@ const StyledTooltip = styled.div`
     transition: opacity 0.1s ${constants.easing.easeInQuad},
       scale 0.1s ${constants.easing.easeInQuad};
     display: ${({ isVisible }) => (isVisible ? "inline-block" : "none")};
-    border-right: 1px solid ${themes.global.gray02};
-    border-bottom: 1px solid ${themes.global.gray02};
+    border-right: ${({ variant }) =>
+      variant === variants.light ? `1px solid ${themes.global.gray02}` : ""};
+    border-bottom: ${({ variant }) =>
+      variant === variants.light ? `1px solid ${themes.global.gray02}` : ""};
     border-top-left-radius: 100%;
     width: 12px;
     height: 12px;
     transform: translateY(-50%) rotate(-135deg);
-    background: ${themes.global.white.base};
+    background-color: ${({ variant }) =>
+      variant === variants.dark
+        ? themes.global.darkFill
+        : themes.global.white.base};
     ${({ direction }) => {
       switch (direction) {
-        case "top":
+        case directions.top:
           return "left: calc(50% - 9.5px); bottom: -13px; transform: translateY(-50%) rotate(45deg);";
-        case "bottom":
+        case directions.bottom:
           return "left: calc(50% - 9.5px); top: -1px; transform: translateY(-50%) rotate(-135deg);";
-        case "left":
+        case directions.left:
           return "top: 10px; right: -7px; transform: translateY(0%) rotate(-45deg);";
-        case "right":
+        case directions.right:
           return "top: 10px; left: -7px; transform: translateY(0%) rotate(135deg);";
         default:
           return "left: calc(50% - 9.5px); top: -1px; transform: translateY(-50%) rotate(-135deg);";

--- a/src/components/Tooltip/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/index.spec.js.snap
@@ -1,5 +1,123 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Tooltip dark should match snapshot 1`] = `
+.c0 {
+  background-color: #1f262d;
+  border: 1px solid #1f262d;
+  border-radius: 4px;
+  box-shadow: 0 4px 4px 0 rgba(0,0,0,0.12);
+  position: absolute;
+  max-width: 260px;
+  color: rgba(255,255,255,1);
+  padding: 8px;
+  display: block;
+  font-size: 12px;
+  -webkit-transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53), -webkit-transform 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
+  -webkit-transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53), transform 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
+  transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53), transform 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
+}
+
+.c0:before {
+  content: "";
+  position: absolute;
+  -webkit-transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53), scale 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
+  transition: opacity 0.1s cubic-bezier(0.55,0.085,0.68,0.53), scale 0.1s cubic-bezier(0.55,0.085,0.68,0.53);
+  display: inline-block;
+  border-top-left-radius: 100%;
+  width: 12px;
+  height: 12px;
+  -webkit-transform: translateY(-50%) rotate(-135deg);
+  -ms-transform: translateY(-50%) rotate(-135deg);
+  transform: translateY(-50%) rotate(-135deg);
+  background-color: #1f262d;
+  left: calc(50% - 9.5px);
+  top: -1px;
+  -webkit-transform: translateY(-50%) rotate(-135deg);
+  -ms-transform: translateY(-50%) rotate(-135deg);
+  transform: translateY(-50%) rotate(-135deg);
+}
+
+.c0.open-enter,
+.c0.open-enter:before {
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  display: block;
+  opacity: 0;
+}
+
+.c0.open-enter {
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), -webkit-transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  -webkit-transform: scale(0.7);
+  -ms-transform: scale(0.7);
+  transform: scale(0.7);
+}
+
+.c0.open-enter-active,
+.c0.open-enter-active:before {
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  display: block;
+  opacity: 1;
+}
+
+.c0.open-enter-active {
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), -webkit-transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c0.open-enter-done,
+.c0.open-enter-active:before {
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  display: block;
+  opacity: 1;
+}
+
+.c0.open-enter-done {
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), -webkit-transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955), transform 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c0.open-exit,
+.c0.open-exit:before {
+  display: block;
+  opacity: 1;
+}
+
+.c0.open-exit {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c0.open-exit-active,
+.c0.open-exit-active:before {
+  display: block;
+  opacity: 0;
+}
+
+.c0.open-exit-active {
+  -webkit-transform: scale(0.7);
+  -ms-transform: scale(0.7);
+  transform: scale(0.7);
+}
+
+<div
+  className="c0"
+  direction="bottom"
+/>
+`;
+
 exports[`Tooltip should match snapshot 1`] = `
 .c0 {
   background-color: rgba(255,255,255,1);
@@ -31,7 +149,7 @@ exports[`Tooltip should match snapshot 1`] = `
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
-  background: rgba(255,255,255,1);
+  background-color: rgba(255,255,255,1);
   left: calc(50% - 9.5px);
   top: -1px;
   -webkit-transform: translateY(-50%) rotate(-135deg);
@@ -151,7 +269,7 @@ exports[`Tooltip should match snapshot when visisble and direction is bottom 1`]
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
-  background: rgba(255,255,255,1);
+  background-color: rgba(255,255,255,1);
   left: calc(50% - 9.5px);
   top: -1px;
   -webkit-transform: translateY(-50%) rotate(-135deg);
@@ -271,7 +389,7 @@ exports[`Tooltip should match snapshot when visisble and direction is invalid 1`
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
-  background: rgba(255,255,255,1);
+  background-color: rgba(255,255,255,1);
   left: calc(50% - 9.5px);
   top: -1px;
   -webkit-transform: translateY(-50%) rotate(-135deg);
@@ -391,7 +509,7 @@ exports[`Tooltip should match snapshot when visisble and direction is left 1`] =
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
-  background: rgba(255,255,255,1);
+  background-color: rgba(255,255,255,1);
   top: 10px;
   right: -7px;
   -webkit-transform: translateY(0%) rotate(-45deg);
@@ -511,7 +629,7 @@ exports[`Tooltip should match snapshot when visisble and direction is right 1`] 
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
-  background: rgba(255,255,255,1);
+  background-color: rgba(255,255,255,1);
   top: 10px;
   left: -7px;
   -webkit-transform: translateY(0%) rotate(135deg);
@@ -631,7 +749,7 @@ exports[`Tooltip should match snapshot when visisble and direction is top 1`] = 
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
-  background: rgba(255,255,255,1);
+  background-color: rgba(255,255,255,1);
   left: calc(50% - 9.5px);
   bottom: -13px;
   -webkit-transform: translateY(-50%) rotate(45deg);

--- a/src/components/Tooltip/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/index.spec.js.snap
@@ -30,7 +30,7 @@ exports[`Tooltip dark should match snapshot 1`] = `
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
   background-color: #1f262d;
-  left: calc(50% - 9.5px);
+  left: calc(50% - 6px);
   top: -1px;
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
@@ -150,7 +150,7 @@ exports[`Tooltip should match snapshot 1`] = `
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
   background-color: rgba(255,255,255,1);
-  left: calc(50% - 9.5px);
+  left: calc(50% - 6px);
   top: -1px;
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
@@ -270,7 +270,7 @@ exports[`Tooltip should match snapshot when visisble and direction is bottom 1`]
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
   background-color: rgba(255,255,255,1);
-  left: calc(50% - 9.5px);
+  left: calc(50% - 6px);
   top: -1px;
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
@@ -390,7 +390,7 @@ exports[`Tooltip should match snapshot when visisble and direction is invalid 1`
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
   background-color: rgba(255,255,255,1);
-  left: calc(50% - 9.5px);
+  left: calc(50% - 6px);
   top: -1px;
   -webkit-transform: translateY(-50%) rotate(-135deg);
   -ms-transform: translateY(-50%) rotate(-135deg);
@@ -750,7 +750,7 @@ exports[`Tooltip should match snapshot when visisble and direction is top 1`] = 
   -ms-transform: translateY(-50%) rotate(-135deg);
   transform: translateY(-50%) rotate(-135deg);
   background-color: rgba(255,255,255,1);
-  left: calc(50% - 9.5px);
+  left: calc(50% - 6px);
   bottom: -13px;
   -webkit-transform: translateY(-50%) rotate(45deg);
   -ms-transform: translateY(-50%) rotate(45deg);

--- a/src/components/Tooltip/__tests__/index.spec.js
+++ b/src/components/Tooltip/__tests__/index.spec.js
@@ -10,6 +10,12 @@ describe("Tooltip", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it("dark should match snapshot", () => {
+    const tree = renderer.create(<Tooltip isVisible variant="dark" />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   it("should match snapshot when visisble and direction is bottom", () => {
     const tree = renderer
       .create(<Tooltip isVisible direction="bottom" />)

--- a/src/components/Tooltip/constants.js
+++ b/src/components/Tooltip/constants.js
@@ -1,0 +1,13 @@
+export const SPACE_FROM_MOUSE = 20;
+
+export const directions = {
+  top: "top",
+  bottom: "bottom",
+  left: "left",
+  right: "right"
+};
+
+export const variants = {
+  dark: "dark",
+  light: "light"
+};

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -2,8 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { CSSTransition } from "react-transition-group";
 import StyledTooltip from "./Tooltip.styles";
-
-const SPACE_FROM_MOUSE = 20;
+import { directions, SPACE_FROM_MOUSE, variants } from "./constants";
 
 class Tooltip extends Component {
   /*
@@ -46,22 +45,22 @@ class Tooltip extends Component {
     const topPosition = elTop - SPACE_FROM_MOUSE - height;
 
     switch (direction) {
-      case "top":
+      case directions.top:
         return {
           x: elHorizontalCenter - width / 2,
           y: topPosition
         };
-      case "bottom":
+      case directions.bottom:
         return {
           x: elHorizontalCenter - width / 2,
           y: bottomPosition
         };
-      case "left":
+      case directions.left:
         return {
           x: elLeft - width - SPACE_FROM_MOUSE,
           y: elTop
         };
-      case "right":
+      case directions.right:
         return {
           x: elRight + SPACE_FROM_MOUSE,
           y: elTop
@@ -127,7 +126,7 @@ class Tooltip extends Component {
       }
     }
 
-    if (Object.keys(size).length) {
+    if (size.width || size.height) {
       this.size = {
         ...this.size,
         ...size
@@ -151,7 +150,7 @@ class Tooltip extends Component {
   };
 
   render() {
-    const { children, isVisible, direction } = this.props;
+    const { children, isVisible, direction, variant } = this.props;
 
     return (
       <CSSTransition
@@ -160,6 +159,7 @@ class Tooltip extends Component {
         timeout={300}
         classNames="open"
         onEnter={this.tooltipEnter}
+        variant={variant}
       >
         <StyledTooltip
           innerRef={this.myRef}
@@ -176,19 +176,21 @@ class Tooltip extends Component {
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   isVisible: PropTypes.bool,
-  direction: PropTypes.oneOf(["top", "bottom", "left", "right"]),
+  direction: PropTypes.oneOf(Object.values(directions)),
   position: PropTypes.shape({
     elHorizontalCenter: PropTypes.number,
     elVerticalCenter: PropTypes.number,
     elTop: PropTypes.number,
     elBottom: PropTypes.number,
     elLeft: PropTypes.number
-  })
+  }),
+  variant: PropTypes.oneOf(Object.values(variants))
 };
 
 Tooltip.defaultProps = {
   isVisible: false,
   direction: "bottom",
+  variant: "light",
   position: {
     elHorizontalCenter: 0,
     elVerticalCenter: 0,

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -150,7 +150,7 @@ class Tooltip extends Component {
   };
 
   render() {
-    const { children, isVisible, direction, variant } = this.props;
+    const { children, isVisible, direction, variant, ...rest } = this.props;
 
     return (
       <CSSTransition
@@ -165,6 +165,7 @@ class Tooltip extends Component {
           innerRef={this.myRef}
           isVisible={isVisible}
           direction={direction}
+          {...rest}
         >
           {children}
         </StyledTooltip>

--- a/src/theme/constants.js
+++ b/src/theme/constants.js
@@ -23,4 +23,8 @@ const constants = {
   }
 };
 
+export const cardBoxShadow =
+  "0 4px 4px 0 rgba(0, 0, 0, 0.06), 0 0 4px 0 rgba(0, 0, 0, 0.12)";
+export const popContainersBoxShadow = "0 4px 4px 0 rgba(0, 0, 0, 0.12)";
+
 export default constants;


### PR DESCRIPTION
**What**:

Add dark variant of tooltip

**Why**:

Support for dark variant was requested

**How**:

Add variant prop, that is 'light' by default. When 'dark' is passed to the prop it changes the tooltip to dark background with white text.

**Checklist**:
* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
