### PR TITLE
fix(DropDownInput): DropDownInput should be automatically focused only when DropDown is opened

### DIFF
--- a/src/components/Input/DropDown/Context.js
+++ b/src/components/Input/DropDown/Context.js
@@ -1,6 +1,6 @@
 import React from "react";
 
 export const { Provider, Consumer } = React.createContext({
-  isOpen: null,
+  isOpen: false,
   onClose: null
 });

--- a/src/components/Input/DropDown/DropDownInput.js
+++ b/src/components/Input/DropDown/DropDownInput.js
@@ -54,6 +54,7 @@ class DropDownInput extends React.Component {
     value: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
     children: PropTypes.node.isRequired,
+    isOpen: PropTypes.bool.isRequired,
     isFocused: PropTypes.bool.isRequired,
     isSelected: PropTypes.bool.isRequired,
     className: PropTypes.string
@@ -64,7 +65,11 @@ class DropDownInput extends React.Component {
   };
 
   componentDidUpdate() {
-    if (this.props.isFocused && this.SelectedElement.current) {
+    if (
+      this.props.isOpen &&
+      this.props.isFocused &&
+      this.SelectedElement.current
+    ) {
       this.SelectedElement.current.focus();
     }
   }

--- a/src/components/Input/__tests__/DropDownInput.spec.js
+++ b/src/components/Input/__tests__/DropDownInput.spec.js
@@ -9,7 +9,9 @@ describe("<DropDownInput />", () => {
     value: "rock",
     children: "Rock & Roll",
     index: 0,
-    isSelected: false
+    isSelected: false,
+    isFocused: false,
+    isOpen: false
   };
 
   const render = (Component, props) => {


### PR DESCRIPTION
…y when DropDown is opened

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Bugfix for the DropDownInput component that prevents unnecessary autofocus on every component update.

<!-- Why are these changes necessary? -->

**How**:
*src/components/Input/DropDown/DropDownInput*:
A condition in `componentDidUpdate` was modified.

*src/components/Input/DropDown/Context*:
Default value of `isOpen` flag was replaced by `false` to remove proptype warning when running tests.

*src/components/Input/__tests__/DropDownInput.spec*:
Added `isOpen` and `isFocused` props that are passed to the component. That change removes proptype warnings when running tests and do not affect the snapshots.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
