### PR TITLE
fix(KeyboardNavigationProvider): fix focus position when selected value was changed from outside the component

### DIFF
--- a/src/components/KeyboardNavigation/Provider.js
+++ b/src/components/KeyboardNavigation/Provider.js
@@ -5,6 +5,11 @@ import { ARROWUP, ARROWDOWN, SPACEBAR } from "../../utils/keyCharCodes";
 
 const { forEach } = React.Children;
 
+const getSelectedChild = (children, selectedValue) =>
+  React.Children.toArray(children).find(
+    thisArg => thisArg.props.value === selectedValue
+  );
+
 export default class KeyBoardProvider extends React.Component {
   static propTypes = {
     children(props, propName, componentName) {
@@ -35,18 +40,28 @@ export default class KeyBoardProvider extends React.Component {
   };
 
   static getDerivedStateFromProps(props, state) {
-    if (!props.selected || props.selected.length === 0) return null;
+    const { selected, children } = props;
+
+    if (!selected || !selected.length) return null;
+
+    const selectedValue = selected[selected.length - 1];
 
     if (state.firstUpdate === true) {
-      const childrenArray = React.Children.toArray(props.children);
+      const selectedChild = getSelectedChild(children, selectedValue);
 
-      const valueOfSelected = props.selected[0];
-      const selectedChild = childrenArray.find(
-        thisArg => thisArg.props.value === valueOfSelected
-      );
       return {
-        focused: selectedChild.props.index,
-        firstUpdate: false
+        focused: selectedChild ? selectedChild.props.index : 0,
+        firstUpdate: false,
+        prevSelectedValue: selectedValue
+      };
+    }
+
+    if (selectedValue !== state.prevSelectedValue) {
+      const selectedChild = getSelectedChild(children, selectedValue);
+
+      return {
+        focused: selectedChild ? selectedChild.props.index : 0,
+        prevSelectedValue: selectedValue
       };
     }
 
@@ -118,7 +133,8 @@ export default class KeyBoardProvider extends React.Component {
     focused: 0,
     focusSelected: this.onClick,
     word: "",
-    firstUpdate: true
+    firstUpdate: true,
+    prevSelectedValue: ""
   };
   /* eslint-enable */
 

--- a/src/components/KeyboardNavigation/__tests__/Provider.spec.js
+++ b/src/components/KeyboardNavigation/__tests__/Provider.spec.js
@@ -16,26 +16,45 @@ const TesingConsumers = (
   </Consumer>
 );
 
+const createTestElement = () => (
+  <Provider role="option">
+    <TesingConsumers datatestid="button0" index={0}>
+      Testing1
+    </TesingConsumers>
+    <TesingConsumers datatestid="button1" index={1}>
+      Testing2
+    </TesingConsumers>
+    <TesingConsumers datatestid="button2" index={2}>
+      Testing3
+    </TesingConsumers>
+    <TesingConsumers datatestid="button3" index={3}>
+      Testing4
+    </TesingConsumers>
+  </Provider>
+);
+
+const createTestElementSelected = (selected = []) => (
+  <Provider selected={selected} role="option">
+    <TesingConsumers value="button0" datatestid="button0" index={0}>
+      Testing1
+    </TesingConsumers>
+    <TesingConsumers value="button1" datatestid="button1" index={1}>
+      Testing2
+    </TesingConsumers>
+    <TesingConsumers value="button2" datatestid="button2" index={2}>
+      Testing3
+    </TesingConsumers>
+    <TesingConsumers value="button3" datatestid="button3" index={3}>
+      Testing4
+    </TesingConsumers>
+  </Provider>
+);
+
 describe("KeyBoardProvider", () => {
   afterEach(cleanup);
 
   it("Up outside range of number of Children ", () => {
-    const { getByTestId, container } = renderIntoDocument(
-      <Provider role="option">
-        <TesingConsumers datatestid="button0" index={0}>
-          Testing1
-        </TesingConsumers>
-        <TesingConsumers datatestid="button1" index={1}>
-          Testing2
-        </TesingConsumers>
-        <TesingConsumers datatestid="button2" index={2}>
-          Testing3
-        </TesingConsumers>
-        <TesingConsumers datatestid="button3" index={3}>
-          Testing4
-        </TesingConsumers>
-      </Provider>
-    );
+    const { getByTestId, container } = renderIntoDocument(createTestElement());
 
     fireEvent.keyDown(getByTestId("button0"), { keyCode: 38 });
 
@@ -43,22 +62,7 @@ describe("KeyBoardProvider", () => {
   });
 
   it("Up within range of number of Children", () => {
-    const { getByTestId, container } = renderIntoDocument(
-      <Provider role="option">
-        <TesingConsumers datatestid="button0" index={0}>
-          Testing1
-        </TesingConsumers>
-        <TesingConsumers datatestid="button1" index={1}>
-          Testing2
-        </TesingConsumers>
-        <TesingConsumers datatestid="button2" index={2}>
-          Testing3
-        </TesingConsumers>
-        <TesingConsumers datatestid="button3" index={3}>
-          Testing4
-        </TesingConsumers>
-      </Provider>
-    );
+    const { getByTestId, container } = renderIntoDocument(createTestElement());
 
     fireEvent.keyDown(getByTestId("button0"), { keyCode: 38 });
     fireEvent.keyDown(getByTestId("button0"), { keyCode: 38 });
@@ -67,22 +71,7 @@ describe("KeyBoardProvider", () => {
   });
 
   it("Down within range of number of Children", () => {
-    const { getByTestId, container } = renderIntoDocument(
-      <Provider role="option">
-        <TesingConsumers datatestid="button0" index={0}>
-          Testing1
-        </TesingConsumers>
-        <TesingConsumers datatestid="button1" index={1}>
-          Testing2
-        </TesingConsumers>
-        <TesingConsumers datatestid="button2" index={2}>
-          Testing3
-        </TesingConsumers>
-        <TesingConsumers datatestid="button3" index={3}>
-          Testing4
-        </TesingConsumers>
-      </Provider>
-    );
+    const { getByTestId, container } = renderIntoDocument(createTestElement());
 
     fireEvent.keyDown(getByTestId("button0"), { keyCode: 40 });
 
@@ -90,22 +79,7 @@ describe("KeyBoardProvider", () => {
   });
 
   it("Down outside range of number of Children ", () => {
-    const { getByTestId, container } = renderIntoDocument(
-      <Provider role="option">
-        <TesingConsumers datatestid="button0" index={0}>
-          Testing1
-        </TesingConsumers>
-        <TesingConsumers datatestid="button1" index={1}>
-          Testing2
-        </TesingConsumers>
-        <TesingConsumers datatestid="button2" index={2}>
-          Testing3
-        </TesingConsumers>
-        <TesingConsumers datatestid="button3" index={3}>
-          Testing4
-        </TesingConsumers>
-      </Provider>
-    );
+    const { getByTestId, container } = renderIntoDocument(createTestElement());
 
     fireEvent.keyDown(getByTestId("button0"), { keyCode: 40 });
     fireEvent.keyDown(getByTestId("button0"), { keyCode: 40 });
@@ -115,25 +89,43 @@ describe("KeyBoardProvider", () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
   it("Down outside range of number of Children ", () => {
-    const { getByTestId, container } = renderIntoDocument(
-      <Provider role="option">
-        <TesingConsumers datatestid="button0" index={0}>
-          Testing1
-        </TesingConsumers>
-        <TesingConsumers datatestid="button1" index={1}>
-          Testing2
-        </TesingConsumers>
-        <TesingConsumers datatestid="button2" index={2}>
-          Testing3
-        </TesingConsumers>
-        <TesingConsumers datatestid="button3" index={3}>
-          Testing4
-        </TesingConsumers>
-      </Provider>
-    );
+    const { getByTestId, container } = renderIntoDocument(createTestElement());
 
     fireEvent.keyDown(getByTestId("button0"), { keyCode: 3 });
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("Change focus position when 'selected' prop was changed from outside ", () => {
+    const { getByTestId, container, rerender } = renderIntoDocument(
+      createTestElementSelected(["button0"])
+    );
+
+    fireEvent.keyDown(getByTestId("button0"), { keyCode: 40 });
+
+    rerender(createTestElementSelected(["button3"]));
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("Set default focus position when 'selected' prop is invalid on the first update ", () => {
+    const { container } = renderIntoDocument(
+      createTestElementSelected(["nonexistent-value"])
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("Reset focus position when 'selected' prop was changed from outside ", () => {
+    const { getByTestId, container, rerender } = renderIntoDocument(
+      createTestElementSelected(["button0"])
+    );
+
+    fireEvent.keyDown(getByTestId("button0"), { keyCode: 40 });
+
+    rerender(createTestElementSelected(["nonexistent-value"]));
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/KeyboardNavigation/__tests__/__snapshots__/Provider.spec.js.snap
+++ b/src/components/KeyboardNavigation/__tests__/__snapshots__/Provider.spec.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`KeyBoardProvider Change focus position when 'selected' prop was changed from outside  1`] = `
+<div
+  role="option"
+>
+  <div
+    data-isfocues="false"
+    data-testid="button0"
+  >
+    Testing1
+  </div>
+  <div
+    data-isfocues="false"
+    data-testid="button1"
+  >
+    Testing2
+  </div>
+  <div
+    data-isfocues="false"
+    data-testid="button2"
+  >
+    Testing3
+  </div>
+  <div
+    data-isfocues="true"
+    data-testid="button3"
+  >
+    Testing4
+  </div>
+</div>
+`;
+
 exports[`KeyBoardProvider Down outside range of number of Children  1`] = `
 <div
   role="option"
@@ -74,6 +105,68 @@ exports[`KeyBoardProvider Down within range of number of Children 1`] = `
   </div>
   <div
     data-isfocues="true"
+    data-testid="button1"
+  >
+    Testing2
+  </div>
+  <div
+    data-isfocues="false"
+    data-testid="button2"
+  >
+    Testing3
+  </div>
+  <div
+    data-isfocues="false"
+    data-testid="button3"
+  >
+    Testing4
+  </div>
+</div>
+`;
+
+exports[`KeyBoardProvider Reset focus position when 'selected' prop was changed from outside  1`] = `
+<div
+  role="option"
+>
+  <div
+    data-isfocues="true"
+    data-testid="button0"
+  >
+    Testing1
+  </div>
+  <div
+    data-isfocues="false"
+    data-testid="button1"
+  >
+    Testing2
+  </div>
+  <div
+    data-isfocues="false"
+    data-testid="button2"
+  >
+    Testing3
+  </div>
+  <div
+    data-isfocues="false"
+    data-testid="button3"
+  >
+    Testing4
+  </div>
+</div>
+`;
+
+exports[`KeyBoardProvider Set default focus position when 'selected' prop is invalid on the first update  1`] = `
+<div
+  role="option"
+>
+  <div
+    data-isfocues="true"
+    data-testid="button0"
+  >
+    Testing1
+  </div>
+  <div
+    data-isfocues="false"
     data-testid="button1"
   >
     Testing2


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Bugfix for the KeyboardNavigationProvider component that fixes a focus position when `selected` prop value was changed from outside the component.

<!-- Why are these changes necessary? -->

**Why**: To update the focus position along with updating the selected item.

<!-- How were these changes implemented? -->

**How**:
*src/components/KeyboardNavigation/Provider*:
The previously selected value is now stored in the state, so we can determine if the value of the `selected` prop was changed before updating the component.
Updated `getDerivedStateFromProps` hook which is now also responsible for adjusting the focus position.

*src/components/KeyboardNavigation/__tests__/Provider.spec*:
Added additional tests to increase test covarage.
Reduced the amount of duplicated code.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
