### PR TITLE
fix(DropDownGroup): always use the label prop passed to the DropDownGroup, regardless of the variant prop passed

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -421,7 +421,7 @@ rows:
   - Prop: label
     Type: string
     Default: N/A
-    Notes: Visible with selected option. Supported only in variant 1
+    Notes: Visible with selected option.
   - Prop: placeholder
     Type: string
     Default: N/A
@@ -476,7 +476,7 @@ span: 6
     <Container>
         <Row>
             <Column medium={4}>
-                <DropDownGroup size="small" variant={0} placeholder="Select an option" label="blah">
+                <DropDownGroup size="small" variant={0} placeholder="Select an option" label="Selected:">
                     <DropDownOption value="0" index={0}>Option One One One One</DropDownOption>
                     <DropDownOption value="1" index={1}>Option Two</DropDownOption>
                     <DropDownOption value="2" index={2}>Option Three</DropDownOption>

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -150,18 +150,14 @@ class DropDownGroup extends React.Component {
     }
   };
 
-  displayLabel = (selected, variant) => {
+  displayLabel = selected => {
     const { placeholder, label } = this.props;
 
     if (placeholder.length > 0 && selected.length === 0) {
       return placeholder;
     }
 
-    if (variant === 0 && selected.length > 0) {
-      return this.getCurrentSelection(selected[0]);
-    }
-
-    if (variant === 1 && label.length > 0) {
+    if (selected.length > 0 && label.length > 0) {
       return (
         <Fragment>
           {label} {this.getCurrentSelection(selected[0])}
@@ -274,7 +270,7 @@ class DropDownGroup extends React.Component {
                             "dropdown__text--disabled": disabled
                           })}
                         >
-                          {this.displayLabel(selected, variant)}
+                          {this.displayLabel(selected)}
                         </StyledSelectedText>
 
                         <StyledChevron

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -413,17 +413,17 @@ describe("DropDownGroup", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it("should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing falsy values is passed to each DropDownOption", () => {
+  it("should render the correct label when label prop is passed, and when an array of children containing falsy values is passed to each DropDownOption", () => {
     const { container } = renderTestComponentTwo({ value: ["date"] });
     expect(container).toMatchSnapshot();
   });
 
-  it("should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing string values is passed to each DropDownOption", () => {
+  it("should render the correct label when label prop is passed, and when an array of children containing string values is passed to each DropDownOption", () => {
     const { container } = renderTestComponentTwo({ value: ["distance"] });
     expect(container).toMatchSnapshot();
   });
 
-  it("should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption", () => {
+  it("should render the correct label when label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption", () => {
     const { container } = renderTestComponentTwo({ value: ["price"] });
     expect(container).toMatchSnapshot();
   });

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -1416,10 +1416,7 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
       </span>
       <div
         class="sc-EHOje vdlIp"
-      >
-        Selected Option:
-         
-      </div>
+      />
       <svg
         class="dropdown--no-border sc-ifAKCX bGhIY"
         fill="currentColor"
@@ -1641,7 +1638,7 @@ exports[`DropDownGroup should disable scroll when dropdown is open 1`] = `
 </div>
 `;
 
-exports[`DropDownGroup should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing falsy values is passed to each DropDownOption 1`] = `
+exports[`DropDownGroup should render the correct label when label prop is passed, and when an array of children containing falsy values is passed to each DropDownOption 1`] = `
 <div>
   <div
     aria-haspopup="listbox"
@@ -1721,7 +1718,7 @@ exports[`DropDownGroup should render the correct label when variant equals 1, a 
 </div>
 `;
 
-exports[`DropDownGroup should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption 1`] = `
+exports[`DropDownGroup should render the correct label when label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption 1`] = `
 <div>
   <div
     aria-haspopup="listbox"
@@ -1804,7 +1801,7 @@ exports[`DropDownGroup should render the correct label when variant equals 1, a 
 </div>
 `;
 
-exports[`DropDownGroup should render the correct label when variant equals 1, a label prop is passed, and when an array of children containing string values is passed to each DropDownOption 1`] = `
+exports[`DropDownGroup should render the correct label when label prop is passed, and when an array of children containing string values is passed to each DropDownOption 1`] = `
 <div>
   <div
     aria-haspopup="listbox"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Always use the label prop passed to the DropDownGroup, regardless of the variant prop passed.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Could you please check the changes since tests coverage slightly decreased. 