### PR TITLE
fix(PopOver): on enter callback misplaced

### DIFF
--- a/src/components/PopOver/index.js
+++ b/src/components/PopOver/index.js
@@ -281,12 +281,9 @@ class PopOver extends Component {
         key="popover-animation"
         timeout={300}
         classNames="open"
+        onEnter={this.popoverEnter}
       >
-        <StyledPopOver
-          innerRef={this.myRef}
-          isVisible={isVisible}
-          onEnter={this.popoverEnter}
-        >
+        <StyledPopOver innerRef={this.myRef} isVisible={isVisible}>
           {children}
         </StyledPopOver>
       </CSSTransition>


### PR DESCRIPTION
**What**:

PopOver onEnter callback was passed to the component instead of passing it to CSSTransition group.

**Why**:

The callback should be passed to CSSTransition in order to calculate position when PopOver enter animation is started.

**How**:

Pass the callback to CSSTransition.

**Checklist**:

* [n/a] Documentation
* [n/a] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->