### PR TITLE
fix(DropDownGroup): add preventGlobalScroll prop

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -446,6 +446,10 @@ rows:
     Type: small or large
     Default: large
     Notes: Defines size
+  - Prop: preventGlobalScroll
+    Type: boolean
+    Default: 'false'
+    Notes: Disable document scrolling when DropDown is opened
 ```
 
 ## Drop Down Option

--- a/src/components/Input/DropDown/DropDownGroup.styles.js
+++ b/src/components/Input/DropDown/DropDownGroup.styles.js
@@ -105,6 +105,10 @@ export const StyledChildWrapper = styled.div`
     overflow-y: auto;
   }
 
+  &.dropdown--hidden {
+    z-index: 0;
+  }
+
   .dropdown--open-upward & {
     bottom: 43px;
     border-radius: ${small} ${small} 0 0;

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -68,9 +68,15 @@ describe("DropDownGroup", () => {
   });
 
   it("renders default dropdown that should always open downwards", () => {
-    expect(
-      renderTestComponentOne({ shouldOpenDownward: true }).container.firstChild
-    ).toMatchSnapshot();
+    const { container, getByTestId } = renderTestComponentOne({
+      shouldOpenDownward: true
+    });
+    fireEvent.keyDown(getByTestId("test-dropContainer"), {
+      key: "ArrowUp",
+      keyCode: 38,
+      which: 38
+    });
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it("renders small dropdown", () => {
@@ -79,17 +85,16 @@ describe("DropDownGroup", () => {
     ).toMatchSnapshot();
   });
 
-  it("renders variant 0 with a placeholder prop", () => {
+  it("renders with a placeholder prop", () => {
     expect(
-      renderTestComponentOne({ placeholder: "Select An Option", variant: 1 })
-        .container.firstChild
+      renderTestComponentOne({ placeholder: "Select An Option" }).container
+        .firstChild
     ).toMatchSnapshot();
   });
 
-  it("renders variant 1 with a label prop", () => {
+  it("renders with a label prop", () => {
     expect(
-      renderTestComponentOne({ label: "Selected Option:", variant: 1 })
-        .container.firstChild
+      renderTestComponentOne({ label: "Selected Option:" }).container.firstChild
     ).toMatchSnapshot();
   });
 
@@ -150,8 +155,8 @@ describe("DropDownGroup", () => {
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "ArrowUp",
-      keyCode: 32,
-      which: 32
+      keyCode: 38,
+      which: 38
     });
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -395,8 +400,10 @@ describe("DropDownGroup", () => {
     expect(preventDefault).toHaveBeenCalled();
   });
 
-  it("should disable scroll when dropdown is open", () => {
-    const { container, getByTestId } = renderTestComponentOne();
+  it("should disable scroll when dropdown is open and preventGlobalScroll prop with a value of true is passed", () => {
+    const { container, getByTestId } = renderTestComponentOne({
+      preventGlobalScroll: true
+    });
 
     fireEvent.click(getByTestId("test-dropDownOptionOne"));
     fireEvent.wheel(getByTestId("test-outSideComponent"));
@@ -426,6 +433,41 @@ describe("DropDownGroup", () => {
   it("should render the correct label when label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption", () => {
     const { container } = renderTestComponentTwo({ value: ["price"] });
     expect(container).toMatchSnapshot();
+  });
+
+  it("should correctly work with touch events", () => {
+    const { container, getByTestId } = renderTestComponentOne({
+      isOpen: false
+    });
+
+    fireEvent.click(getByTestId("test-dropDownOptionOne"));
+    fireEvent.touchMove(getByTestId("test-dropDownOptionOne"), {
+      cancelable: true,
+      touches: [
+        {
+          clientY: 42
+        }
+      ]
+    });
+    fireEvent.touchMove(getByTestId("test-dropDownOptionOne"), {
+      cancelable: false,
+      touches: [
+        {
+          clientY: 777
+        }
+      ]
+    });
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("should correctly work with passive event listeners", () => {
+    const { isPassiveSupported: isDefaultPassiveSupported } = DropDownGroup;
+    DropDownGroup.isPassiveSupported = true;
+    const { container, getByTestId } = renderTestComponentOne();
+    fireEvent.click(getByTestId("test-dropDownOptionOne"));
+    expect(container.firstChild).toMatchSnapshot();
+    DropDownGroup.isPassiveSupported = isDefaultPassiveSupported;
   });
 });
 

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -39,7 +39,7 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bLKcb"
       style="max-height: -44px;"
     >
       <div>
@@ -120,7 +120,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bLKcb"
       style="max-height: -44px;"
     >
       <div>
@@ -201,7 +201,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -284,7 +284,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -365,7 +365,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -446,7 +446,7 @@ exports[`DropDownGroup Should close the drop down on click outside 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -527,7 +527,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -608,7 +608,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -693,7 +693,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -776,7 +776,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -857,7 +857,7 @@ exports[`DropDownGroup renders default dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -916,7 +916,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -926,7 +926,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
         class="sc-EHOje vdlIp"
       />
       <svg
-        class="sc-ifAKCX bGhIY"
+        class="dropdown__icon--hide sc-ifAKCX bGhIY"
         fill="currentColor"
         height="12"
         viewBox="0 0 15 7"
@@ -938,7 +938,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bLKcb"
     >
       <div>
         <div
@@ -1018,7 +1018,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -1099,7 +1099,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -1180,7 +1180,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -1262,7 +1262,7 @@ exports[`DropDownGroup renders small dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--small sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--small dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -1304,92 +1304,7 @@ exports[`DropDownGroup renders small dropdown 1`] = `
 </div>
 `;
 
-exports[`DropDownGroup renders variant 0 with a placeholder prop 1`] = `
-<div
-  data-testid="test-outSideComponent"
->
-  <div
-    data-testid="something"
-  >
-    something
-  </div>
-  <div
-    aria-haspopup="listbox"
-    aria-labelledby="hidden-label__Select_An_Option"
-    class="sc-bxivhb pBoyv"
-    data-testid="test-dropContainer"
-    tabindex="0"
-  >
-    <label
-      class="dropdown--large dropdown--no-border sc-bdVaJa qKpWB"
-    >
-      <span
-        class="sc-htpNat irkcXP"
-        id="hidden-label__Select_An_Option"
-      >
-        Select An Option
-      </span>
-      <div
-        class="sc-EHOje vdlIp"
-      >
-        Select An Option
-      </div>
-      <svg
-        class="dropdown--no-border sc-ifAKCX bGhIY"
-        fill="currentColor"
-        height="12"
-        viewBox="0 0 15 7"
-        width="12"
-      >
-        <path
-          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
-        />
-      </svg>
-    </label>
-    <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
-    >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
-        >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
+exports[`DropDownGroup renders with a label prop 1`] = `
 <div
   data-testid="test-outSideComponent"
 >
@@ -1406,7 +1321,7 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--no-border sc-bdVaJa qKpWB"
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
     >
       <span
         class="sc-htpNat irkcXP"
@@ -1418,7 +1333,7 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
         class="sc-EHOje vdlIp"
       />
       <svg
-        class="dropdown--no-border sc-ifAKCX bGhIY"
+        class="sc-ifAKCX bGhIY"
         fill="currentColor"
         height="12"
         viewBox="0 0 15 7"
@@ -1430,7 +1345,92 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
+      style="max-height: 0;"
+    >
+      <div>
+        <div
+          class="sc-bZQynM koCnbp"
+          role="listbox"
+        >
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionOne"
+            role="option"
+            tabindex="-1"
+            value="ValueOne"
+          >
+            Option One
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionTwo"
+            role="option"
+            tabindex="-1"
+            value="ValueTwo"
+          >
+            Second Option
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionThree"
+            role="option"
+            tabindex="-1"
+            value="ValueThree"
+          >
+            Option Three
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup renders with a placeholder prop 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div
+    data-testid="something"
+  >
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__Select_An_Option"
+    class="sc-bxivhb pBoyv"
+    data-testid="test-dropContainer"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
+    >
+      <span
+        class="sc-htpNat irkcXP"
+        id="hidden-label__Select_An_Option"
+      >
+        Select An Option
+      </span>
+      <div
+        class="sc-EHOje vdlIp"
+      >
+        Select An Option
+      </div>
+      <svg
+        class="sc-ifAKCX bGhIY"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -1513,7 +1513,7 @@ exports[`DropDownGroup should allow scroll inside the dropdown when it is open 1
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bLKcb"
       style="max-height: -44px;"
     >
       <div>
@@ -1555,7 +1555,7 @@ exports[`DropDownGroup should allow scroll inside the dropdown when it is open 1
 </div>
 `;
 
-exports[`DropDownGroup should disable scroll when dropdown is open 1`] = `
+exports[`DropDownGroup should correctly work with passive event listeners 1`] = `
 <div
   data-testid="test-outSideComponent"
 >
@@ -1596,7 +1596,173 @@ exports[`DropDownGroup should disable scroll when dropdown is open 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bLKcb"
+      style="max-height: -44px;"
+    >
+      <div>
+        <div
+          class="sc-bZQynM koCnbp"
+          role="listbox"
+        >
+          <span
+            class="dropdown__selected sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionOne"
+            role="option"
+            tabindex="-1"
+            value="ValueOne"
+          >
+            Option One
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionTwo"
+            role="option"
+            tabindex="-1"
+            value="ValueTwo"
+          >
+            Second Option
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionThree"
+            role="option"
+            tabindex="-1"
+            value="ValueThree"
+          >
+            Option Three
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup should correctly work with touch events 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div
+    data-testid="something"
+  >
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__"
+    class="dropdown--open-upward sc-bxivhb pBoyv"
+    data-testid="test-dropContainer"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
+    >
+      <span
+        class="sc-htpNat irkcXP"
+        id="hidden-label__"
+      />
+      <div
+        class="sc-EHOje vdlIp"
+      >
+        Option One
+      </div>
+      <svg
+        class="dropdown__icon--hide sc-ifAKCX bGhIY"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bLKcb"
+      style="max-height: -44px;"
+    >
+      <div>
+        <div
+          class="sc-bZQynM koCnbp"
+          role="listbox"
+        >
+          <span
+            class="dropdown__selected sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionOne"
+            role="option"
+            tabindex="-1"
+            value="ValueOne"
+          >
+            Option One
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionTwo"
+            role="option"
+            tabindex="-1"
+            value="ValueTwo"
+          >
+            Second Option
+          </span>
+          <span
+            class="sc-gzVnrw iJMNFP"
+            data-testid="test-dropDownOptionThree"
+            role="option"
+            tabindex="-1"
+            value="ValueThree"
+          >
+            Option Three
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup should disable scroll when dropdown is open and preventGlobalScroll prop with a value of true is passed 1`] = `
+<div
+  data-testid="test-outSideComponent"
+>
+  <div
+    data-testid="something"
+  >
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__"
+    class="dropdown--open-upward sc-bxivhb pBoyv"
+    data-testid="test-dropContainer"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
+    >
+      <span
+        class="sc-htpNat irkcXP"
+        id="hidden-label__"
+      />
+      <div
+        class="sc-EHOje vdlIp"
+      >
+        Option One
+      </div>
+      <svg
+        class="dropdown__icon--hide sc-ifAKCX bGhIY"
+        fill="currentColor"
+        height="12"
+        viewBox="0 0 15 7"
+        width="12"
+      >
+        <path
+          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
+        />
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bLKcb"
       style="max-height: -44px;"
     >
       <div>
@@ -1675,7 +1841,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -1758,7 +1924,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>
@@ -1839,7 +2005,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large dropdown--hidden sc-bwzfXH bLKcb"
       style="max-height: 0;"
     >
       <div>

--- a/src/utils/__tests__/checkPassiveEventSupport.spec.js
+++ b/src/utils/__tests__/checkPassiveEventSupport.spec.js
@@ -1,0 +1,40 @@
+import checkPassiveEventSupport from "../checkPassiveEventSupport";
+
+describe("checkPassiveEventSupport", () => {
+  const mockFn = (event, cb, opt) =>
+    typeof opt === "object" && opt !== null ? opt.passive : opt;
+  const mockThrowFn = () => {
+    throw new Error("Test error");
+  };
+
+  beforeEach(() => {
+    global.addEventListener = mockFn;
+    global.removeEventListener = mockFn;
+  });
+
+  it("should return true if passive option is supported", () => {
+    const isPassiveSupported = checkPassiveEventSupport(true);
+    expect(isPassiveSupported).toBe(true);
+  });
+
+  it("should return true if passive option is NOT supported", () => {
+    global.addEventListener = jest.fn();
+    global.removeEventListener = jest.fn();
+    const isPassiveSupported = checkPassiveEventSupport(true);
+    expect(isPassiveSupported).toBe(false);
+  });
+
+  it("should return a cached value", () => {
+    const isPassiveSupported = checkPassiveEventSupport(true);
+    global.addEventListener = jest.fn();
+    global.removeEventListener = jest.fn();
+    const isPassiveSupportedCached = checkPassiveEventSupport();
+    expect(isPassiveSupported).toBe(isPassiveSupportedCached);
+  });
+
+  it("should return false if an error occurred", () => {
+    global.addEventListener = mockThrowFn;
+    const isPassiveSupported = checkPassiveEventSupport(true);
+    expect(isPassiveSupported).toBe(false);
+  });
+});

--- a/src/utils/checkPassiveEventSupport.js
+++ b/src/utils/checkPassiveEventSupport.js
@@ -1,0 +1,33 @@
+// Safely detecting option support. See: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support
+let isPassiveSupported = false;
+let wasAlreadyChecked = false;
+
+const checkPassiveEventSupport = forceCheck => {
+  if (wasAlreadyChecked && !forceCheck) {
+    return isPassiveSupported;
+  }
+
+  if (forceCheck) {
+    isPassiveSupported = false;
+  }
+
+  try {
+    const options = Object.defineProperty({}, "passive", {
+      // eslint-disable-next-line
+      get: function() {
+        isPassiveSupported = true;
+      }
+    });
+
+    window.addEventListener("test", options, options); // eslint-disable-line
+    window.removeEventListener("test", options, options); // eslint-disable-line
+  } catch (err) {
+    isPassiveSupported = false;
+  }
+
+  wasAlreadyChecked = true;
+
+  return isPassiveSupported;
+};
+
+export default checkPassiveEventSupport;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,6 @@
+export {
+  default as checkPassiveEventSupport
+} from "./checkPassiveEventSupport";
 export { default as getThemeValue } from "./getThemeValue";
 export { default as composeEventHandlers } from "./composeEventHandlers";
 export { default as getRelByTarget } from "./link";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: The behavior of blocking the document scroll when DropDown is opened now applies only when `preventGlobalScroll` passed.

<!-- How were these changes implemented? -->

**How**:
Added `preventGlobalScroll` prop.
Added logic to prevent the document scroll only when scrolling within dropdown.
Fixed touch event handling.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
