### PR TITLE
fix(catalog): fix a typo that breaks the catalog typography page

### DIFF
--- a/catalog/pages/typography/index.md
+++ b/catalog/pages/typography/index.md
@@ -97,7 +97,7 @@ const str = "Better is together";
 </Row>
 <Row style={fontSizeRowStyle}>
     <Column medium={2}>Kilo - 16 px</Column>
-    <Column medium={6}}>
+    <Column medium={6}>
         <Text size="kilo">{str}</Text>
     </Column>
 </Row>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
It's a tiny fix for the catalog typography page. The typo breaks the font sizes sections. That's a bit irritating for users checking out the catalog.

<!-- Why are these changes necessary? -->

**Why**:
It's just one line of code that brings back the catalog

<!-- How were these changes implemented? -->

**How**:
Removed an extra closing bracket 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
