### PR TITLE
fix(Modal): set correct height for the modal content

### DIFF
--- a/catalog/pages/modal/index.md
+++ b/catalog/pages/modal/index.md
@@ -55,7 +55,7 @@ responsive: true
 </DeviceSizeProvider>
 ```
 
-### Modal with custom action bars
+### Modal with custom action bars and long content
 
 ```react
 responsive: true
@@ -74,6 +74,29 @@ responsive: true
         }
     >
         {Array(1000).fill('').map((_, i) => <div key={i}>Text Row {i}</div>)}
+    </Modal>
+</DeviceSizeProvider>
+```
+
+### Modal with custom action bars and short content
+
+```react
+responsive: true
+---
+<DeviceSizeProvider>
+    <Modal
+        actionBar={
+            <div style={{ backgroundColor: 'white' }}>
+                <h1 style={{ padding: 0, margin: 0, fontSize: 16 }}>Demo Modal</h1>
+            </div>
+        }
+        bottomActionBar={
+            <div style={{ backgroundColor: 'white' }}>
+                <Button style={{ width: 'auto' }}>See Tickets</Button>
+            </div>
+        }
+    >
+        {Array(8).fill('').map((_, i) => <div key={i}>Text Row {i}</div>)}
     </Modal>
 </DeviceSizeProvider>
 ```

--- a/src/components/Modal/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Modal/__tests__/__snapshots__/index.spec.js.snap
@@ -9,8 +9,8 @@ exports[`<Modal /> closeModal should close the modal when the request was approv
       class="sc-bwzfXH iqdfeW sc-bdVaJa hPYopS"
     >
       <div
-        class="sc-bxivhb hkfQrY"
-        style="max-height: 100;"
+        class="sc-bxivhb bSaKFF"
+        style="min-height: 100; max-height: 100;"
       >
         <button
           data-testid="close-modal"
@@ -30,8 +30,8 @@ exports[`<Modal /> closeModal should close the modal when there is no onRequestC
       class="sc-bwzfXH iqdfeW sc-bdVaJa hPYopS"
     >
       <div
-        class="sc-bxivhb hkfQrY"
-        style="max-height: 100;"
+        class="sc-bxivhb bSaKFF"
+        style="min-height: 100; max-height: 100;"
       >
         <button
           data-testid="close-modal"
@@ -60,7 +60,7 @@ exports[`<Modal /> render should render with actionBar and bottomActionBar 1`] =
         </div>
       </div>
       <div
-        class="sc-bxivhb hkfQrY"
+        class="sc-bxivhb bSaKFF"
       >
         <div>
           Modal contents
@@ -88,7 +88,7 @@ exports[`<Modal /> render should render without errors and pass extra props 1`] 
       style="width: 210px;"
     >
       <div
-        class="sc-bxivhb hkfQrY"
+        class="sc-bxivhb bSaKFF"
       >
         <div>
           Modal contents
@@ -108,8 +108,8 @@ exports[`<Modal /> should recalculate shadows and content height on props change
       class="sc-bwzfXH iqdfeW sc-bdVaJa hPYopS"
     >
       <div
-        class="sc-bxivhb hkfQrY"
-        style="max-height: 100;"
+        class="sc-bxivhb bSaKFF"
+        style="min-height: 100; max-height: 100;"
       >
         <div>
           Modal contents
@@ -129,8 +129,8 @@ exports[`<Modal /> should set bottom action bar shadow when the content was scro
       class="sc-bwzfXH iqdfeW sc-bdVaJa hPYopS"
     >
       <div
-        class="sc-bxivhb hkfQrY"
-        style="max-height: 100;"
+        class="sc-bxivhb bSaKFF"
+        style="min-height: 100; max-height: 100;"
       >
         <div
           data-testid="content"

--- a/src/components/Modal/__tests__/index.spec.js
+++ b/src/components/Modal/__tests__/index.spec.js
@@ -65,11 +65,30 @@ describe("<Modal />", () => {
     });
   });
 
-  it("it should set the content height based on action bars heights", () => {
+  it("it should set the content `height` based on action bars heights for smaller screens", () => {
     getContentHeight.mockReturnValue(100);
 
     const { getByTestId } = renderIntoDocument(
-      <Modal contentProps={{ "data-testid": "modal-content" }}>
+      <Modal
+        contentProps={{ "data-testid": "modal-content" }}
+        deviceSize={{ isSmall: true }}
+      >
+        <div>Modal contents</div>
+      </Modal>
+    );
+
+    expect(getByTestId("modal-content").style.minHeight).toBe("100");
+    expect(getByTestId("modal-content").style.maxHeight).toBe("100");
+  });
+
+  it("it should set the content `maxHeight` based on action bars heights for larger screens", () => {
+    getContentHeight.mockReturnValue(100);
+
+    const { getByTestId } = renderIntoDocument(
+      <Modal
+        contentProps={{ "data-testid": "modal-content" }}
+        deviceSize={{ isSmall: false, isMedium: true }}
+      >
         <div>Modal contents</div>
       </Modal>
     );

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -126,16 +126,26 @@ class Modal extends React.Component {
   };
 
   updateModalHeight = () => {
+    const {
+      deviceSize: { isSmall }
+    } = this.props;
+
     const actionBar = this.actionBarRef.current;
     const bottomActionBar = this.bottomActionBarRef.current;
     const content = this.contentRef.current;
     const container = this.containerRef.current;
 
-    content.style.maxHeight = getContentHeight({
+    const contentHeight = getContentHeight({
       actionBar,
       bottomActionBar,
       container
     });
+
+    if (isSmall) {
+      content.style.minHeight = contentHeight;
+    }
+
+    content.style.maxHeight = contentHeight;
   };
 
   updateShadows = () => {

--- a/src/components/Modal/index.styles.js
+++ b/src/components/Modal/index.styles.js
@@ -83,7 +83,7 @@ const contentGutters = css`
 
 export const ModalContent = styled.div`
   background-color: ${colors.white.base};
-  overflow-y: scroll;
+  overflow-y: auto;
 
   ${({ gutters }) => (gutters ? contentGutters : "")};
 `;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Set the min-height for the modal content, so the content pushes bototmActionBar to, actually, the bottom of the screen.


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
