### PR TITLE
fix(Modal): Modal container z-index doesn't work in Safari

### DIFF
--- a/src/components/List/Modal.js
+++ b/src/components/List/Modal.js
@@ -11,6 +11,7 @@ import Column from "../Grid/Column";
 import Row from "../Grid/Row";
 
 const ModalContainer = styled(Column)`
+  position: relative;
   background-color: ${colors.white.base};
   border-radius: ${constants.borderRadius.large};
   box-shadow: 0 16px 16px 0 rgba(0, 0, 0, 0.06), 0 0 16px 0 rgba(0, 0, 0, 0.12);

--- a/src/components/List/__tests__/__snapshots__/Modal.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Modal.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Modal /> removes the Modal on clicking cancel button 1`] = `"<div class=\\"sc-EHOje dvafpF sc-bxivhb hsWovD\\" role=\\"dialog\\" aria-modal=\\"true\\"><div class=\\"sc-gzVnrw cNQmjb sc-ifAKCX cLRflb\\"><button class=\\"button--close sc-htpNat efRhEq\\" size=\\"45\\" aria-label=\\"Close Modal\\" role=\\"button\\"><svg viewBox=\\"0 0 12 12\\" width=\\"12\\" height=\\"12\\" fill=\\"rgba(38, 38, 38, 1)\\"><path d=\\"M6.563 6.203l4.523 4.516a.384.384 0 0 1 .117.281c0 .11-.039.203-.117.281a.378.378 0 0 1-.137.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.136-.09L6 6.766 1.484 11.28a.378.378 0 0 1-.136.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.137-.09A.384.384 0 0 1 .797 11c0-.11.039-.203.117-.281l4.524-4.516L.913 1.68a.384.384 0 0 1-.117-.282c0-.109.039-.203.117-.28A.388.388 0 0 1 1.2 1c.112 0 .207.04.285.117L6 5.633l4.516-4.516A.388.388 0 0 1 10.8 1c.112 0 .207.04.285.117a.384.384 0 0 1 .117.281c0 .11-.039.204-.117.282L6.562 6.203z\\"></path></svg></button></div><div class=\\"sc-bZQynM jpIupZ\\"><div>Europe</div><div>Africa</div><div>Asias</div></div></div>"`;
+exports[`<Modal /> removes the Modal on clicking cancel button 1`] = `"<div class=\\"sc-EHOje kOBERI sc-bxivhb hsWovD\\" role=\\"dialog\\" aria-modal=\\"true\\"><div class=\\"sc-gzVnrw cNQmjb sc-ifAKCX cLRflb\\"><button class=\\"button--close sc-htpNat efRhEq\\" size=\\"45\\" aria-label=\\"Close Modal\\" role=\\"button\\"><svg viewBox=\\"0 0 12 12\\" width=\\"12\\" height=\\"12\\" fill=\\"rgba(38, 38, 38, 1)\\"><path d=\\"M6.563 6.203l4.523 4.516a.384.384 0 0 1 .117.281c0 .11-.039.203-.117.281a.378.378 0 0 1-.137.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.136-.09L6 6.766 1.484 11.28a.378.378 0 0 1-.136.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.137-.09A.384.384 0 0 1 .797 11c0-.11.039-.203.117-.281l4.524-4.516L.913 1.68a.384.384 0 0 1-.117-.282c0-.109.039-.203.117-.28A.388.388 0 0 1 1.2 1c.112 0 .207.04.285.117L6 5.633l4.516-4.516A.388.388 0 0 1 10.8 1c.112 0 .207.04.285.117a.384.384 0 0 1 .117.281c0 .11-.039.204-.117.282L6.562 6.203z\\"></path></svg></button></div><div class=\\"sc-bZQynM jpIupZ\\"><div>Europe</div><div>Africa</div><div>Asias</div></div></div>"`;
 
 exports[`<Modal /> renders Modal correctly 1`] = `
 <div
   aria-modal="true"
-  class="sc-EHOje dvafpF sc-bxivhb hsWovD"
+  class="sc-EHOje kOBERI sc-bxivhb hsWovD"
   role="dialog"
 >
   <div
@@ -45,4 +45,4 @@ exports[`<Modal /> renders Modal correctly 1`] = `
 </div>
 `;
 
-exports[`<Modal /> should not display the cancel button 1`] = `"<div class=\\"sc-EHOje dvafpF sc-bxivhb hsWovD\\" role=\\"dialog\\" aria-modal=\\"true\\"><div class=\\"sc-bZQynM jpIupZ\\"><div>Europe</div><div>Africa</div><div>Asias</div></div></div>"`;
+exports[`<Modal /> should not display the cancel button 1`] = `"<div class=\\"sc-EHOje kOBERI sc-bxivhb hsWovD\\" role=\\"dialog\\" aria-modal=\\"true\\"><div class=\\"sc-bZQynM jpIupZ\\"><div>Europe</div><div>Africa</div><div>Asias</div></div></div>"`;


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix modal container z-index in Safari
<!-- Why are these changes necessary? -->

**Why**:
The modal container has 'z-index' property but it  works only when 'position' is 'relative', 'absolute' or 'fixed' (by the specification and in Safari)
<!-- How were these changes implemented? -->

**How**:
Added `position: relative` for the modal container
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
