### PR TITLE
fix(LinkCta): fix underline and link sizing

### DIFF
--- a/catalog/pages/links/index.md
+++ b/catalog/pages/links/index.md
@@ -7,11 +7,11 @@
         <Row>
             <Column small={2}/>
             <Column small={3}>
-                <Text size="giga" style={{ textAlign: "center" }}>14px</Text>
+                <Text size="giga" style={{ textAlign: "center" }}>18px</Text>
             </Column>
             <Column small={2}/>
             <Column small={3}>
-                <Text size="giga" style={{ textAlign: "center" }}>16px</Text>
+                <Text size="giga" style={{ textAlign: "center" }}>Uno</Text>
             </Column>
         </Row>
         <Spacing top={{ xSmall: 'comfy' }} />
@@ -20,13 +20,13 @@
                 <Text size="uno" weight="semiBold" style={{ textAlign: "right" }}>LinkCta:</Text>
             </Column>
             <Column small={3} style={{ textAlign: "center" }}>
-                <LinkCta href="http://someurl.com">Read more</LinkCta>
+                <LinkCta size="18px" href="http://someurl.com">Read more</LinkCta>
             </Column>
             <Column small={2}>
                 <Text size="uno" weight="semiBold" style={{ textAlign: "right" }}>LinkCta:</Text>
             </Column>
             <Column small={3} style={{ textAlign: "center" }}>
-                <LinkCta size="large" href="http://someurl.com">Read more</LinkCta>
+                <LinkCta size="uno" href="http://someurl.com">Read more</LinkCta>
             </Column>
         </Row>
         <Spacing top={{ xSmall: 'giant' }} />

--- a/src/components/Text/LinkCta.js
+++ b/src/components/Text/LinkCta.js
@@ -6,15 +6,7 @@ import * as PT from "./PropTypes";
 import { typography } from "../../theme";
 import { getThemeValue } from "../../utils";
 import getRelByTarget from "../../utils/link";
-
-const SIZES = {
-  small: {
-    fontSize: typography.size.hecto
-  },
-  large: {
-    fontSize: typography.size.kilo
-  }
-};
+import { mediumAndUp, largeAndUp } from "../../theme/mediaQueries";
 
 const LinkCtaBase = styled.a`
   text-decoration: none;
@@ -22,15 +14,15 @@ const LinkCtaBase = styled.a`
   transition: text-decoration 0.3s ease;
   transition: transform 0.1s linear;
   font-weight: ${typography.weight.semiBold};
-  font-size: ${({ size }) => SIZES[size].fontSize};
+  font-size: ${({ size }) =>
+    (size.small && typography.size[size.small]) || size.small || "inherit"};
   line-height: ${typography.lineHeight.header};
   color: ${getThemeValue("primary", "base")};
   display: inline-block;
 
   &:focus {
     outline: none;
-    text-decoration-line: underline;
-    text-decoration-style: double;
+    text-decoration: underline;
   }
 
   &:visited {
@@ -45,6 +37,18 @@ const LinkCtaBase = styled.a`
   &:hover {
     color: ${getThemeValue("primary", "medium")};
   }
+
+  ${mediumAndUp`
+    font-size: ${({ size }) =>
+      (size.medium && typography.size[size.medium]) ||
+      size.medium ||
+      "inherit"};
+  `};
+
+  ${largeAndUp`
+    font-size: ${({ size }) =>
+      (size.large && typography.size[size.large]) || size.large || "inherit"};
+  `};
 `;
 
 const LinkCtaButtonBase = LinkCtaBase.withComponent(`button`).extend`
@@ -69,7 +73,14 @@ const getElement = ({ href, onClick }) => {
   return LinkCtaSpanBase;
 };
 
-const LinkCta = ({ href, onClick, children, size, ...props }) => {
+const LinkCta = ({
+  href,
+  onClick,
+  children,
+  size,
+  responsiveSize,
+  ...props
+}) => {
   const { target, rel } = props;
   const Elm = getElement({ href, onClick });
   const validatedRel = getRelByTarget(target, rel);
@@ -77,7 +88,15 @@ const LinkCta = ({ href, onClick, children, size, ...props }) => {
   return (
     <Elm
       {...props}
-      size={size}
+      size={{
+        small: responsiveSize.small || size,
+        medium: responsiveSize.medium || responsiveSize.small || size,
+        large:
+          responsiveSize.large ||
+          responsiveSize.medium ||
+          responsiveSize.small ||
+          size
+      }}
       href={href}
       onClick={onClick}
       rel={validatedRel}
@@ -88,15 +107,21 @@ const LinkCta = ({ href, onClick, children, size, ...props }) => {
 };
 
 LinkCta.propTypes = {
-  size: PropTypes.oneOf(Object.values(PT.LINK_SIZES)),
+  size: PropTypes.string,
+  responsiveSize: PT.responsiveSize,
   children: PropTypes.node.isRequired,
   href: PropTypes.string,
   onClick: PropTypes.func
 };
 
 LinkCta.defaultProps = {
-  size: PT.LINK_SIZES.small,
+  size: null,
   onClick: null,
+  responsiveSize: {
+    small: null,
+    medium: null,
+    large: null
+  },
   href: null
 };
 

--- a/src/components/Text/PropTypes.js
+++ b/src/components/Text/PropTypes.js
@@ -26,8 +26,3 @@ export const responsiveSize = PropTypes.shape({
 });
 
 export const weight = PropTypes.oneOf(["regular", "semiBold"]);
-
-export const LINK_SIZES = {
-  small: "small",
-  large: "large"
-};

--- a/src/components/Text/__tests__/LinkCta.spec.js
+++ b/src/components/Text/__tests__/LinkCta.spec.js
@@ -25,4 +25,16 @@ describe("LinkCta", () => {
       renderer.create(<LinkCta>I am a link</LinkCta>).toJSON() // eslint-disable-line
     ).toMatchSnapshot();
   });
+
+  it("static size from typography", () => {
+    expect(
+      renderer.create(<LinkCta size="normal">I am a link</LinkCta>).toJSON() // eslint-disable-line
+    ).toMatchSnapshot();
+  });
+
+  it("static size as pixels", () => {
+    expect(
+      renderer.create(<LinkCta size="20px">I am a link</LinkCta>).toJSON() // eslint-disable-line
+    ).toMatchSnapshot();
+  });
 });

--- a/src/components/Text/__tests__/__snapshots__/LinkCta.spec.js.snap
+++ b/src/components/Text/__tests__/__snapshots__/LinkCta.spec.js.snap
@@ -12,7 +12,7 @@ exports[`LinkCta renders a button when only onclick is provided 1`] = `
   -webkit-transition: transform 0.1s linear;
   transition: transform 0.1s linear;
   font-weight: 600;
-  font-size: 14px;
+  font-size: inherit;
   line-height: 1.25;
   color: #026cdf;
   display: inline-block;
@@ -28,10 +28,8 @@ exports[`LinkCta renders a button when only onclick is provided 1`] = `
 
 .c0:focus {
   outline: none;
-  -webkit-text-decoration-line: underline;
-  text-decoration-line: underline;
-  -webkit-text-decoration-style: double;
-  text-decoration-style: double;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c0:visited {
@@ -49,12 +47,30 @@ exports[`LinkCta renders a button when only onclick is provided 1`] = `
   color: #0150a7;
 }
 
+@media screen and (min-width:768px) {
+  .c0 {
+    font-size: inherit;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c0 {
+    font-size: inherit;
+  }
+}
+
 <button
   className="c0"
   href={null}
   onClick={[Function]}
   rel={undefined}
-  size="small"
+  size={
+    Object {
+      "large": null,
+      "medium": null,
+      "small": null,
+    }
+  }
 >
   I am a link
 </button>
@@ -72,7 +88,7 @@ exports[`LinkCta renders a default LinkCta 1`] = `
   -webkit-transition: transform 0.1s linear;
   transition: transform 0.1s linear;
   font-weight: 600;
-  font-size: 14px;
+  font-size: inherit;
   line-height: 1.25;
   color: #026cdf;
   display: inline-block;
@@ -80,10 +96,8 @@ exports[`LinkCta renders a default LinkCta 1`] = `
 
 .c0:focus {
   outline: none;
-  -webkit-text-decoration-line: underline;
-  text-decoration-line: underline;
-  -webkit-text-decoration-style: double;
-  text-decoration-style: double;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c0:visited {
@@ -101,12 +115,30 @@ exports[`LinkCta renders a default LinkCta 1`] = `
   color: #0150a7;
 }
 
+@media screen and (min-width:768px) {
+  .c0 {
+    font-size: inherit;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c0 {
+    font-size: inherit;
+  }
+}
+
 <a
   className="c0"
   href="http://localhost/"
   onClick={null}
   rel={undefined}
-  size="small"
+  size={
+    Object {
+      "large": null,
+      "medium": null,
+      "small": null,
+    }
+  }
 >
   I am a link
 </a>
@@ -124,7 +156,7 @@ exports[`LinkCta renders a span when no href or onClick provided 1`] = `
   -webkit-transition: transform 0.1s linear;
   transition: transform 0.1s linear;
   font-weight: 600;
-  font-size: 14px;
+  font-size: inherit;
   line-height: 1.25;
   color: #026cdf;
   display: inline-block;
@@ -133,10 +165,8 @@ exports[`LinkCta renders a span when no href or onClick provided 1`] = `
 
 .c0:focus {
   outline: none;
-  -webkit-text-decoration-line: underline;
-  text-decoration-line: underline;
-  -webkit-text-decoration-style: double;
-  text-decoration-style: double;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c0:visited {
@@ -154,12 +184,168 @@ exports[`LinkCta renders a span when no href or onClick provided 1`] = `
   color: #0150a7;
 }
 
+@media screen and (min-width:768px) {
+  .c0 {
+    font-size: inherit;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c0 {
+    font-size: inherit;
+  }
+}
+
 <span
   className="c0"
   href={null}
   onClick={null}
   rel={undefined}
-  size="small"
+  size={
+    Object {
+      "large": null,
+      "medium": null,
+      "small": null,
+    }
+  }
+>
+  I am a link
+</span>
+`;
+
+exports[`LinkCta static size as pixels 1`] = `
+.c0 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: color 0.3s ease;
+  transition: color 0.3s ease;
+  -webkit-transition: text-decoration 0.3s ease;
+  transition: text-decoration 0.3s ease;
+  -webkit-transition: -webkit-transform 0.1s linear;
+  -webkit-transition: transform 0.1s linear;
+  transition: transform 0.1s linear;
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 1.25;
+  color: #026cdf;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.c0:focus {
+  outline: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:visited {
+  color: #013670;
+}
+
+.c0:active {
+  -webkit-transform: scale(0.98,0.98) translate(0,1px);
+  -ms-transform: scale(0.98,0.98) translate(0,1px);
+  transform: scale(0.98,0.98) translate(0,1px);
+  color: #013670;
+}
+
+.c0:hover {
+  color: #0150a7;
+}
+
+@media screen and (min-width:768px) {
+  .c0 {
+    font-size: 20px;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c0 {
+    font-size: 20px;
+  }
+}
+
+<span
+  className="c0"
+  href={null}
+  onClick={null}
+  rel={undefined}
+  size={
+    Object {
+      "large": "20px",
+      "medium": "20px",
+      "small": "20px",
+    }
+  }
+>
+  I am a link
+</span>
+`;
+
+exports[`LinkCta static size from typography 1`] = `
+.c0 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: color 0.3s ease;
+  transition: color 0.3s ease;
+  -webkit-transition: text-decoration 0.3s ease;
+  transition: text-decoration 0.3s ease;
+  -webkit-transition: -webkit-transform 0.1s linear;
+  -webkit-transition: transform 0.1s linear;
+  transition: transform 0.1s linear;
+  font-weight: 600;
+  font-size: normal;
+  line-height: 1.25;
+  color: #026cdf;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.c0:focus {
+  outline: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:visited {
+  color: #013670;
+}
+
+.c0:active {
+  -webkit-transform: scale(0.98,0.98) translate(0,1px);
+  -ms-transform: scale(0.98,0.98) translate(0,1px);
+  transform: scale(0.98,0.98) translate(0,1px);
+  color: #013670;
+}
+
+.c0:hover {
+  color: #0150a7;
+}
+
+@media screen and (min-width:768px) {
+  .c0 {
+    font-size: normal;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c0 {
+    font-size: normal;
+  }
+}
+
+<span
+  className="c0"
+  href={null}
+  onClick={null}
+  rel={undefined}
+  size={
+    Object {
+      "large": "normal",
+      "medium": "normal",
+      "small": "normal",
+    }
+  }
 >
   I am a link
 </span>


### PR DESCRIPTION
**What**:

LinkCta now uses one line for underline and update sizing approach. By default size is inherited or it uses the value passed to size prop.

**Why**:

Increase flexibility of links

**How**:

Updating sizing of LinksCta

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
