### PR TITLE
fix(DropDown): block page scroll when dropdown is not scrollable

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -31,11 +31,13 @@ class DropDownGroup extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     const { isOpen } = this.state;
-    // disables scroll when dropdown is open
-    document.addEventListener("wheel", this.disableScroll);
     // scroll dropdown to top after opening
     if (!this.props.isOpen && isOpen && isOpen !== prevState.isOpen) {
       this.styledChildWrapper.current.scrollTop = 0;
+      // disables scroll when dropdown is open
+      document.addEventListener("wheel", this.disableScroll);
+    } else {
+      document.removeEventListener("wheel", this.disableScroll);
     }
   }
 
@@ -118,7 +120,16 @@ class DropDownGroup extends React.Component {
   };
 
   disableScroll = e => {
-    if (this.state.isOpen && !this.groupWrapper.current.contains(e.target)) {
+    const dropdownHeight = this.styledChildWrapper.current.clientHeight;
+    const optionsHeight = this.optionsContainer.current.clientHeight;
+    const isScrollable = optionsHeight > dropdownHeight;
+    // disable scroll when a user scrolls outside of dropdown or
+    // withing a dropdown and it is not scrollable
+    if (
+      this.state.isOpen &&
+      (!this.groupWrapper.current.contains(e.target) ||
+        (this.groupWrapper.current.contains(e.target) && !isScrollable))
+    ) {
       this.stopInteraction(e);
     }
   };


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Page scroll should be allowed only when the dropdown is scrollable and a user scrolls within a drop-down.
<!-- Why are these changes necessary? -->

**Why**:
UAT feedback
<!-- How were these changes implemented? -->

**How**:
Additional check added.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
