### PR TITLE
fix(QtySelector): add title for icons

### DIFF
--- a/src/components/Icons/QtySelectorMinus.js
+++ b/src/components/Icons/QtySelectorMinus.js
@@ -1,6 +1,7 @@
 import React from "react";
+import PropTypes from "prop-types";
 
-const QtySelectorMinusIcon = props => (
+const QtySelectorMinusIcon = ({ children, ...props }) => (
   <svg
     {...props}
     xmlns="http://www.w3.org/2000/svg"
@@ -8,6 +9,7 @@ const QtySelectorMinusIcon = props => (
     height="24"
     viewBox="0 0 24 24"
   >
+    {children}
     <g fill="none" fillRule="nonzero">
       <path d="M0 0h24v24H0z" />
       <path
@@ -21,5 +23,13 @@ const QtySelectorMinusIcon = props => (
 );
 
 QtySelectorMinusIcon.displayName = "QtySelectorMinusIcon";
+
+QtySelectorMinusIcon.defaultProps = {
+  children: null
+};
+
+QtySelectorMinusIcon.propTypes = {
+  children: PropTypes.node
+};
 
 export default QtySelectorMinusIcon;

--- a/src/components/Icons/QtySelectorPlus.js
+++ b/src/components/Icons/QtySelectorPlus.js
@@ -1,6 +1,7 @@
 import React from "react";
+import PropTypes from "prop-types";
 
-const QtySelectorPlusIcon = props => (
+const QtySelectorPlusIcon = ({ children, ...props }) => (
   <svg
     {...props}
     xmlns="http://www.w3.org/2000/svg"
@@ -8,6 +9,7 @@ const QtySelectorPlusIcon = props => (
     height="24"
     viewBox="0 0 24 24"
   >
+    {children}
     <g fill="none" fillRule="nonzero">
       <path d="M0 0h24v24H0z" />
       <path
@@ -21,5 +23,13 @@ const QtySelectorPlusIcon = props => (
 );
 
 QtySelectorPlusIcon.displayName = "QtySelectorPlusIcon";
+
+QtySelectorPlusIcon.defaultProps = {
+  children: null
+};
+
+QtySelectorPlusIcon.propTypes = {
+  children: PropTypes.node
+};
 
 export default QtySelectorPlusIcon;


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Title element for svgs
<!-- Why are these changes necessary? -->

**Why**:
Accessibility purpose
<!-- How were these changes implemented? -->

**How**:
Added `children` props to qty selector icons
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
