### PR TITLE
fix(AdaptiveModal): fix content height setting

### DIFF
--- a/src/components/Modal/__tests__/helper.spec.js
+++ b/src/components/Modal/__tests__/helper.spec.js
@@ -17,7 +17,7 @@ const TEST_1 = [
       clientHeight: 200
     }
   },
-  140
+  "140px"
 ];
 
 const TEST_2 = [
@@ -29,7 +29,7 @@ const TEST_2 = [
       clientHeight: 200
     }
   },
-  180
+  "180px"
 ];
 
 const TEST_3 = [
@@ -41,7 +41,7 @@ const TEST_3 = [
       clientHeight: 200
     }
   },
-  160
+  "160px"
 ];
 
 const TEST_4 = [
@@ -50,7 +50,7 @@ const TEST_4 = [
       clientHeight: 200
     }
   },
-  200
+  "200px"
 ];
 
 describe("getContentHeight", () => {

--- a/src/components/Modal/helper.js
+++ b/src/components/Modal/helper.js
@@ -5,7 +5,9 @@ export const getContentHeight = ({ actionBar, bottomActionBar, container }) => {
     ? bottomActionBar.clientHeight
     : 0;
 
-  return container.clientHeight - actionBarHeight - bottomActionBarHeight;
+  return `${container.clientHeight -
+    actionBarHeight -
+    bottomActionBarHeight}px`;
 };
 
 export const getActionBarShadow = ({ content }) => Boolean(content.scrollTop);


### PR DESCRIPTION
**What**: Setting modal content height has been fixed. 

**Why**: Without `px` it does not work. But it is correctly work in catalog. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
