### PR TITLE
feat(SaveData): Add saveData to DeviceConnection context and DisplayOn

### DIFF
--- a/catalog/pages/device_connection/index.md
+++ b/catalog/pages/device_connection/index.md
@@ -1,6 +1,6 @@
 ### DeviceConnectionProvider
 
-Analyzes the user's network connection and listens for changes.
+Analyzes the user's network connection and data usage preferences while listening for changes.
 
 ### Props
 
@@ -21,7 +21,7 @@ Receives a render prop containing the DeviceConnectionProvider's state when the 
 
 ### DisplayOn
 
-Returns children when the connection speed prop(s) passed match the user's connection speed when the DeviceConnectionProvider is above it in the React DOM hierarchy.
+Returns children when the connection speed/data usage preference prop(s) passed match the user's connection speed or data usage preferences when the DeviceConnectionProvider is above it in the React DOM hierarchy.
 
 ### Props
 
@@ -40,6 +40,9 @@ rows:
   - Prop: connslow2g
     Type: Boolean
     Default: false
+  - Prop: saveData
+    Type: Boolean
+    Default: null
   - Prop: children
     Type: Node
     Default:

--- a/src/components/DeviceConnection/DisplayOn.js
+++ b/src/components/DeviceConnection/DisplayOn.js
@@ -8,12 +8,14 @@ import {
   prefixedDeviceConnectionDefaultProps
 } from "./shape";
 
+export const getConnName = conn => (conn === "saveData" ? conn : `conn${conn}`);
+
 const DisplayOn = props => {
   const { children } = props;
   return (
     <Consumer>
       {val =>
-        CONNECTION_TYPES.find(conn => val[conn] && props[`conn${conn}`])
+        CONNECTION_TYPES.find(conn => val[conn] && props[getConnName(conn)])
           ? children
           : null
       }
@@ -23,9 +25,13 @@ const DisplayOn = props => {
 
 DisplayOn.propTypes = {
   ...prefixedDeviceConnectionProps,
+  saveData: PropTypes.bool,
   children: PropTypes.node.isRequired
 };
 
-DisplayOn.defaultProps = prefixedDeviceConnectionDefaultProps;
+DisplayOn.defaultProps = {
+  ...prefixedDeviceConnectionDefaultProps,
+  saveData: false
+};
 
 export default DisplayOn;

--- a/src/components/DeviceConnection/Provider.js
+++ b/src/components/DeviceConnection/Provider.js
@@ -1,19 +1,25 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
-import { Provider } from "./Context";
+import { Provider } from './Context';
 
-import { deviceConnectionStateShape } from "./shape";
-import { FALSY_CONNECTIONS_STATE } from "./constants";
+import { deviceConnectionStateShape } from './shape';
+import { FALSY_CONNECTIONS_STATE } from './constants';
 
 class DeviceConnectionProvider extends Component {
+  static initialState = {
+    ...FALSY_CONNECTIONS_STATE,
+    '4g': true,
+    isInitialized: false
+  };
+
   static propTypes = {
     children: PropTypes.node.isRequired,
     defaultState: PropTypes.shape(deviceConnectionStateShape)
   };
 
   static defaultProps = {
-    defaultState: false
+    defaultState: null
   };
 
   constructor(props) {
@@ -24,11 +30,15 @@ class DeviceConnectionProvider extends Component {
   }
 
   componentDidMount() {
-    const { effectiveType, type } = global.navigator.connection;
+    const { effectiveType, type, saveData } = global.navigator.connection;
 
     if (effectiveType || type) {
       this.subscribe();
-      this.update({ [effectiveType || type]: true, isInitialized: true });
+      this.update({
+        [effectiveType || type]: true,
+        isInitialized: true,
+        saveData
+      });
     }
   }
 
@@ -42,26 +52,20 @@ class DeviceConnectionProvider extends Component {
 
   /* istanbul ignore next */
   onConnectionChange() {
-    const { effectiveType, type } = global.navigator.connection;
-    this.update({ [effectiveType || type]: true });
+    const { effectiveType, type, saveData } = global.navigator.connection;
+    this.update({ [effectiveType || type]: true, saveData });
   }
-
-  initialState = {
-    ...FALSY_CONNECTIONS_STATE,
-    "4g": true,
-    isInitialized: false
-  };
 
   subscribe() {
     global.navigator.connection.addEventListener(
-      "change",
+      'change',
       this.onConnectionChange
     );
   }
 
   // eslint-disable-next-line
   unsubscribe() {
-    global.navigator.connection.removeEventListener("change");
+    global.navigator.connection.removeEventListener('change');
   }
 
   update(payload) {

--- a/src/components/DeviceConnection/__tests__/DisplayOn.spec.js
+++ b/src/components/DeviceConnection/__tests__/DisplayOn.spec.js
@@ -1,26 +1,46 @@
-import React from "react";
-import { render, cleanup } from "react-testing-library";
+import React from 'react';
+import { render, cleanup } from 'react-testing-library';
 
-import DisplayOn from "../DisplayOn";
+import DisplayOn, { getConnName } from '../DisplayOn';
 
-jest.mock("../Context", () => ({
-  Consumer: ({ children }) => children({ "4g": true })
+jest.mock('../Context', () => ({
+  Consumer: ({ children }) => children({ '4g': true, saveData: true })
 }));
 
-describe("DisplayOn", () => {
+describe('DisplayOn', () => {
   afterEach(() => {
     cleanup();
   });
 
-  it("should return children when the connection prop matches connection state", () => {
+  it('should return children when the connection prop matches connection state', () => {
     const { container } = render(<DisplayOn conn4g>Content</DisplayOn>);
 
     expect(container).toMatchSnapshot();
   });
 
-  it("should return null when the connection prop does not match connection state", () => {
+  it('should return children when the connection prop equals saveData and matches connection state', () => {
+    const { container } = render(
+      <DisplayOn conn3g saveData>
+        Content
+      </DisplayOn>
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should return null when the connection prop does not match connection state', () => {
     const { container } = render(<DisplayOn conn2g>Content</DisplayOn>);
 
     expect(container).toMatchSnapshot();
+  });
+});
+
+describe('getConnName', () => {
+  it('should return saveData when the conn argument equals saveData', () => {
+    expect(getConnName('saveData')).toEqual('saveData');
+  });
+
+  it('should return conn3g when the conn argument equals 3g', () => {
+    expect(getConnName('3g')).toEqual('conn3g');
   });
 });

--- a/src/components/DeviceConnection/__tests__/__snapshots__/DisplayOn.spec.js.snap
+++ b/src/components/DeviceConnection/__tests__/__snapshots__/DisplayOn.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DisplayOn should return children when the connection prop equals saveData and matches connection state 1`] = `
+<div>
+  Content
+</div>
+`;
+
 exports[`DisplayOn should return children when the connection prop matches connection state 1`] = `
 <div>
   Content

--- a/src/components/DeviceConnection/constants.js
+++ b/src/components/DeviceConnection/constants.js
@@ -1,7 +1,8 @@
-export const CONNECTION_TYPES = ["4g", "3g", "2g", "slow-2g"];
+export const CONNECTION_TYPES = ['4g', '3g', '2g', 'slow-2g', 'saveData'];
 export const FALSY_CONNECTIONS_STATE = {
-  "slow-2g": false,
-  "2g": false,
-  "3g": false,
-  "4g": false
+  'slow-2g': false,
+  '2g': false,
+  '3g': false,
+  '4g': false,
+  saveData: false
 };

--- a/src/components/DeviceConnection/shape.js
+++ b/src/components/DeviceConnection/shape.js
@@ -1,21 +1,23 @@
-import PropTypes from "prop-types";
+import PropTypes from 'prop-types';
 
 export const deviceConnectionStateShape = {
-  "slow-2g": PropTypes.bool,
-  "2g": PropTypes.bool,
-  "3g": PropTypes.bool,
-  "4g": PropTypes.bool
+  'slow-2g': PropTypes.bool,
+  '2g': PropTypes.bool,
+  '3g': PropTypes.bool,
+  '4g': PropTypes.bool,
+  saveData: false,
+  isInitialized: false
 };
 
 export const prefixedDeviceConnectionProps = {
-  "connslow-2g": PropTypes.bool,
+  'connslow-2g': PropTypes.bool,
   conn2g: PropTypes.bool,
   conn3g: PropTypes.bool,
   conn4g: PropTypes.bool
 };
 
 export const prefixedDeviceConnectionDefaultProps = {
-  "connslow-2g": false,
+  'connslow-2g': false,
   conn2g: false,
   conn3g: false,
   conn4g: false


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am adding support for the `saveData` API in `navigator.connection` to the `DeviceConnection` context and `DisplayOn` components.

<!-- Why are these changes necessary? -->

**Why**: These changes are necessary to better accommodate the user's data usage preferences when we determine what UI to render.

<!-- How were these changes implemented? -->

**How**: I am adding support for the `saveData` API in `navigator.connection` to the `DeviceConnection` context and `DisplayOn` components.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
