### PR TITLE
feat(ImageCard): extend component API

### DIFF
--- a/catalog/pages/image_card/index.md
+++ b/catalog/pages/image_card/index.md
@@ -8,9 +8,9 @@ Displays an image in a card with additional content support
 span: 6
 rows:
   - Prop: type
-    Type: full | half
-    Default: full
-    Notes: Sets the type of image card displayed
+    Type: string
+    Default: "'full'"
+    Notes: Sets the type of image card displayed. Possible values are `full`, `half`
   - Prop: src
     Type: string
     Default:
@@ -23,11 +23,33 @@ rows:
     Type: string
     Default:
     Notes: Title text for image
+  - Prop: cardTitle
+    Type: ImageCard.Title, ReactElement
+    Default: "null"
+    Notes: Title of the card
+  - Prop: cardSubtitle
+    Type: ImageCard.SubTitle, ReactElement
+    Default: "null"
+    Notes: Subtitle of the card
+  - Prop: overlayProps
+    Type: object
+    Default: "{ }"
+    Notes: Properties applied to the `Overlay` element
+  - Prop: containerProps
+    Type: object
+    Default: "{ }"
+    Notes: Properties applied to the `Container` element
+  - Prop: captionContainerProps
+    Type: object
+    Default: "{ }"
+    Notes: Properties applied to the `CaptionContainer` element
   - Prop: children
     Type: ImageCard.Title, ImageCard.SubTitle, ReactElement
-    Default:
-    Notes: In order the first two children are wrapped in a caption,
-           the remaining elements are added as additional content under the image
+    Default: "null"
+    Notes: Elements that will be placed under the image. NOTE that in case when
+            `cardTitle` and `cardSubitle` prop values are NOT provided,
+            the first two children will be wrapped in a caption and the remaining elements
+            will be placed under the image.
 ```
 
 ```react
@@ -38,39 +60,45 @@ responsive: true
         <Row>
             <Column medium={4}>
                 <Spacing bottom={{small: "moderate"}}>
-                    <ImageCard src="https://placekitten.com/g/512/288">
-                        <ImageCard.Title>Title</ImageCard.Title>
-                        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-                    </ImageCard>
+                    <ImageCard
+                        src="https://placekitten.com/g/512/288"
+                        cardTitle={<ImageCard.Title>Title</ImageCard.Title>}
+                        cardSubtitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    />
                 </Spacing>
             </Column>
             <Column small={6} medium={4}>
                 <Spacing bottom={{small: "moderate"}}>
-                    <ImageCard src="https://placekitten.com/g/512/288" />
+                    <ImageCard src="https://placekitten.com/g/512/288"/>
                 </Spacing>
             </Column>
             <Column small={6} medium={4}>
                 <Spacing bottom={{small: "moderate"}}>
-                    <ImageCard src="https://placekitten.com/g/512/288">
-                        <ImageCard.Title>Title</ImageCard.Title>
-                        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-                    </ImageCard>
+                    <ImageCard
+                        src="https://placekitten.com/g/512/288"
+                        cardTitle={<ImageCard.Title>Title</ImageCard.Title>}
+                        cardSubtitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    />
                 </Spacing>
             </Column>
             <Column medium={6}>
                 <Spacing bottom={{small: "moderate"}}>
-                    <ImageCard src="https://placekitten.com/g/512/288">
-                        <ImageCard.Title>Title</ImageCard.Title>
-                        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
+                    <ImageCard
+                        src="https://placekitten.com/g/512/288"
+                        cardTitle={<ImageCard.Title>Title</ImageCard.Title>}
+                        cardSubtitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    >
                         <div>Additional Content</div>
                     </ImageCard>
                 </Spacing>
             </Column>
             <Column medium={6}>
                 <Spacing bottom={{small: "moderate"}}>
-                    <ImageCard src="https://placekitten.com/g/512/288">
-                        <ImageCard.Title>Title</ImageCard.Title>
-                        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
+                    <ImageCard
+                        src="https://placekitten.com/g/512/288"
+                        cardTitle={<ImageCard.Title>Title</ImageCard.Title>}
+                        cardSubtitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    >
                         <div>Additional Content</div>
                     </ImageCard>
                 </Spacing>
@@ -92,18 +120,22 @@ responsive: true
         <Row>
             <Column medium={6} large={3}>
                 <Spacing bottom={{small: "moderate"}}>
-                    <ImageCard type="half" src="https://placekitten.com/g/512/288">
-                        <ImageCard.Title>Title</ImageCard.Title>
-                        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-                    </ImageCard>
+                    <ImageCard
+                        type="half"
+                        src="https://placekitten.com/g/512/288"
+                        cardTitle={<ImageCard.Title>Title</ImageCard.Title>}
+                        cardSubtitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    />
                 </Spacing>
             </Column>
             <Column medium={6} large={3}>
                 <Spacing bottom={{small: "moderate"}}>
-                    <ImageCard type="half" src="https://placekitten.com/g/512/288">
-                        <ImageCard.Title>Title</ImageCard.Title>
-                        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-                    </ImageCard>
+                    <ImageCard
+                        type="half"
+                        src="https://placekitten.com/g/512/288"
+                        cardTitle={<ImageCard.Title>Title</ImageCard.Title>}
+                        cardSubtitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    />
                 </Spacing>
             </Column>
         </Row>

--- a/src/components/ImageCard/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/ImageCard/__tests__/__snapshots__/index.spec.js.snap
@@ -1,25 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ImageCard renders card without overlay 1`] = `
-<div
-  className="container-block hXHtmw"
->
-  <div
-    className="igiVqV"
-  >
-    <img
-      alt=""
-      className="fIQgYS"
-      src="http://localhost/img.png"
-      title=""
-    />
-    <div
-      className="iRzHme"
-    />
-  </div>
-</div>
-`;
-
 exports[`ImageCard renders standard card 1`] = `
 <div
   className="container-block hXHtmw"
@@ -46,7 +26,6 @@ exports[`ImageCard renders type = half 1`] = `
 >
   <div
     className="container-block bgkVzE"
-    width="50%"
   >
     <img
       alt=""
@@ -104,6 +83,44 @@ exports[`ImageCard renders type = half 1`] = `
 </div>
 `;
 
+exports[`ImageCard renders with additional content when \`cardTitle\` and \`cardSubtitle\` prop values are not provided (old API support) 1`] = `
+<div
+  className="container-block hXHtmw"
+>
+  <div
+    className="igiVqV"
+  >
+    <img
+      alt=""
+      className="fIQgYS"
+      src="http://localhost/img.png"
+      title=""
+    />
+    <div
+      className="iRzHme"
+    >
+      <div
+        className="dAmSFY"
+      >
+        <span
+          className="jJmwnS"
+        >
+          Title
+        </span>
+        <span
+          className="eKXBpw"
+        >
+          Sub Title
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    Extra content
+  </div>
+</div>
+`;
+
 exports[`ImageCard renders with custom image 1`] = `
 <div
   className="container-block hXHtmw"
@@ -132,8 +149,51 @@ exports[`ImageCard renders with custom image 1`] = `
     </div>
   </div>
   <div>
-    <div>
-      Extra content
+    Extra content
+  </div>
+</div>
+`;
+
+exports[`ImageCard renders with custom props 1`] = `
+<div
+  className="container-block hXHtmw"
+>
+  <div
+    className="igiVqV"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  >
+    <img
+      alt=""
+      className="fIQgYS"
+      src="http://localhost/img.png"
+      title=""
+    />
+    <div
+      className="iRzHme"
+      style={
+        Object {
+          "display": "none",
+        }
+      }
+    >
+      <div
+        className="dAmSFY"
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+      >
+        <span
+          className="jJmwnS"
+        >
+          Title
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -207,9 +267,7 @@ exports[`ImageCard renders with title & subtitle, extra content 1`] = `
     </div>
   </div>
   <div>
-    <div>
-      Extra content
-    </div>
+    Extra content
   </div>
 </div>
 `;

--- a/src/components/ImageCard/__tests__/index.spec.js
+++ b/src/components/ImageCard/__tests__/index.spec.js
@@ -4,6 +4,10 @@ import renderer from "react-test-renderer";
 import ImageCard from "../index";
 
 describe("ImageCard", () => {
+  const title = <ImageCard.Title>Title</ImageCard.Title>;
+  const subTitle = <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>;
+  const children = <div>Extra content</div>;
+
   it("renders standard card", () => {
     const component = renderer.create(
       <ImageCard src="http://localhost/img.png" alt="image" title="image" />
@@ -11,20 +15,14 @@ describe("ImageCard", () => {
 
     expect(component.toJSON()).toMatchSnapshot();
   });
-  it("renders card without overlay", () => {
-    const component = renderer.create(
-      <ImageCard src="http://localhost/img.png" withOverlay={false} />
-    );
-
-    expect(component.toJSON()).toMatchSnapshot();
-  });
 
   it("renders with title & subtitle", () => {
     const component = renderer.create(
-      <ImageCard src="http://localhost/img.png">
-        <ImageCard.Title>Title</ImageCard.Title>
-        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-      </ImageCard>
+      <ImageCard
+        src="http://localhost/img.png"
+        cardTitle={title}
+        cardSubtitle={subTitle}
+      />
     );
 
     expect(component.toJSON()).toMatchSnapshot();
@@ -32,10 +30,12 @@ describe("ImageCard", () => {
 
   it("renders with title & subtitle, extra content", () => {
     const component = renderer.create(
-      <ImageCard src="http://localhost/img.png">
-        <ImageCard.Title>Title</ImageCard.Title>
-        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-        <div>Extra content</div>
+      <ImageCard
+        src="http://localhost/img.png"
+        cardTitle={title}
+        cardSubtitle={subTitle}
+      >
+        {children}
       </ImageCard>
     );
 
@@ -45,10 +45,8 @@ describe("ImageCard", () => {
   it("renders with custom image", () => {
     const image = <svg />;
     const component = renderer.create(
-      <ImageCard image={image}>
-        <ImageCard.Title>Title</ImageCard.Title>
-        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-        <div>Extra content</div>
+      <ImageCard image={image} cardTitle={title} cardSubtitle={subTitle}>
+        {children}
       </ImageCard>
     );
     expect(component.toJSON()).toMatchSnapshot();
@@ -56,9 +54,37 @@ describe("ImageCard", () => {
 
   it("renders type = half", () => {
     const component = renderer.create(
-      <ImageCard type="half" src="http://localhost/img.png">
-        <ImageCard.Title>Title</ImageCard.Title>
-        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
+      <ImageCard
+        type="half"
+        src="http://localhost/img.png"
+        cardTitle={title}
+        cardSubtitle={subTitle}
+      />
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it("renders with custom props", () => {
+    const component = renderer.create(
+      <ImageCard
+        src="http://localhost/img.png"
+        cardTitle={title}
+        overlayProps={{ style: { display: "none" } }}
+        containerProps={{ style: { display: "none" } }}
+        captionContainerProps={{ style: { display: "none" } }}
+      />
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it("renders with additional content when `cardTitle` and `cardSubtitle` prop values are not provided (old API support)", () => {
+    const component = renderer.create(
+      <ImageCard src="http://localhost/img.png">
+        {title}
+        {subTitle}
+        {children}
       </ImageCard>
     );
 

--- a/src/components/ImageCard/index.js
+++ b/src/components/ImageCard/index.js
@@ -41,7 +41,7 @@ const CaptionContainer = styled.div`
 `;
 
 const HalfCard = styled(Card)`
-  width: ${props => (props.width ? props.width : "")};
+  width: 50%;
 `;
 
 const Title = styled.span`
@@ -75,19 +75,39 @@ const RowContainer = styled(Container)`
   align-items: center;
 `;
 
-const ImageCard = ({ src, alt, title, children, type, ...props }) => {
-  const [imageTitle, subTitle, ...rest] = Children.toArray(children || []);
+const ImageCard = ({
+  src,
+  alt,
+  title,
+  type,
+  cardTitle,
+  cardSubtitle,
+  overlayProps,
+  containerProps,
+  captionContainerProps,
+  children,
+  ...props
+}) => {
+  let titleToShow = cardTitle;
+  let subtitleToShow = cardSubtitle;
+  let childrenToShow = children;
+  if (!cardTitle && !cardSubtitle) {
+    [titleToShow, subtitleToShow, ...childrenToShow] = Children.toArray(
+      children || []
+    );
+  }
   const img = props.image || <Image src={src} alt={alt} title={title} />;
+
   if (type === "half") {
     return (
       <RowContainer {...props}>
-        <HalfCard width="50%">{img}</HalfCard>
-        <CaptionContainer half>
+        <HalfCard>{img}</HalfCard>
+        <CaptionContainer {...captionContainerProps} half>
           <Title>
-            <Text className="image-card__title--half">{imageTitle}</Text>
+            <Text className="image-card__title--half">{titleToShow}</Text>
           </Title>
           <SubTitle half>
-            <Text className="image-card__subtitle--half">{subTitle}</Text>
+            <Text className="image-card__subtitle--half">{subtitleToShow}</Text>
           </SubTitle>
         </CaptionContainer>
       </RowContainer>
@@ -96,18 +116,18 @@ const ImageCard = ({ src, alt, title, children, type, ...props }) => {
 
   return (
     <Card {...props}>
-      <Container>
+      <Container {...containerProps}>
         {img}
-        <Overlay>
-          {(imageTitle || subTitle) && (
-            <CaptionContainer>
-              {imageTitle}
-              {subTitle}
+        <Overlay {...overlayProps}>
+          {(titleToShow || subtitleToShow) && (
+            <CaptionContainer {...captionContainerProps}>
+              {titleToShow}
+              {subtitleToShow}
             </CaptionContainer>
           )}
         </Overlay>
       </Container>
-      {(rest && rest.length && <div>{rest}</div>) || null}
+      {childrenToShow}
     </Card>
   );
 };
@@ -117,8 +137,13 @@ ImageCard.propTypes = {
   src: PropTypes.string,
   alt: PropTypes.string,
   title: PropTypes.string,
-  children: PropTypes.node,
-  image: PropTypes.element
+  image: PropTypes.element,
+  cardTitle: PropTypes.element,
+  cardSubtitle: PropTypes.element,
+  overlayProps: PropTypes.shape({}),
+  containerProps: PropTypes.shape({}),
+  captionContainerProps: PropTypes.shape({}),
+  children: PropTypes.node
 };
 
 ImageCard.defaultProps = {
@@ -126,8 +151,13 @@ ImageCard.defaultProps = {
   alt: "",
   title: "",
   src: "",
-  children: null,
-  image: null
+  image: null,
+  cardTitle: null,
+  cardSubtitle: null,
+  overlayProps: {},
+  containerProps: {},
+  captionContainerProps: {},
+  children: null
 };
 
 ImageCard.Title = Title;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: extended title/subtitle display logic and added an ability to spread extra properties on internal components

<!-- Why are these changes necessary? -->

**Why**: to increase flexibility and predictability of component rendering

<!-- How were these changes implemented? -->

**How**:
Now the Card's title and subtitle may be specified in a `cardTitle` and `cardSubtitle` properties. In this case, all the children will be placed under the image.

Added `overlayProps`, `containerProps` and `captionContainerProps` props that allow us to spread additional extra properties on `Overlay`, `Container` and `CaptionContainer` components

Updated unit tests and documentation.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
