### PR TITLE
feat(LoaderRing): add possibility to use small LoaderRing

### DIFF
--- a/src/components/LoaderRing/LoaderRing.js
+++ b/src/components/LoaderRing/LoaderRing.js
@@ -1,6 +1,26 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styled, { keyframes } from "styled-components";
+
 import { themes } from "../../theme";
+import { LOADER_RING_SIZES } from "./constants";
+
+const SIZES = {
+  [LOADER_RING_SIZES.small]: {
+    borderWidth: "2px",
+    marginValue: "4px",
+    outerRingLength: "48px",
+    middleRingLength: "36px",
+    innerRingLength: "24px"
+  },
+  [LOADER_RING_SIZES.regular]: {
+    borderWidth: "3px",
+    marginValue: "7px",
+    outerRingLength: "80px",
+    middleRingLength: "60px",
+    innerRingLength: "40px"
+  }
+};
 
 const Rotate = keyframes`
   from {
@@ -12,6 +32,8 @@ const Rotate = keyframes`
 `;
 
 const LoadingContainer = styled.div`
+  display: ${({ display }) => display};
+
   > div {
     box-sizing: border-box;
     display: block;
@@ -32,10 +54,11 @@ const LoadingContainer = styled.div`
 
 const OuterRing = styled(LoadingContainer)`
   > div {
-    width: 80px;
-    height: 80px;
+    width: ${({ size }) => SIZES[size].outerRingLength};
+    height: ${({ size }) => SIZES[size].outerRingLength};
     margin: 0px;
-    border: 3px solid ${themes.global.accent01.dark};
+    border: ${({ size }) => SIZES[size].borderWidth} solid
+      ${themes.global.accent01.dark};
     border-color: ${themes.global.accent01.dark} transparent transparent
       transparent;
   }
@@ -43,11 +66,12 @@ const OuterRing = styled(LoadingContainer)`
 
 const MiddleRing = styled(LoadingContainer)`
   > div {
-    width: 60px;
-    height: 60px;
-    margin-top: 7px;
-    margin-left: 7px;
-    border: 3px solid ${themes.global.accent03.light};
+    width: ${({ size }) => SIZES[size].middleRingLength};
+    height: ${({ size }) => SIZES[size].middleRingLength};
+    margin-top: ${({ size }) => SIZES[size].marginValue};
+    margin-left: ${({ size }) => SIZES[size].marginValue};
+    border: ${({ size }) => SIZES[size].borderWidth} solid
+      ${themes.global.accent03.light};
     border-color: ${themes.global.accent03.light} transparent transparent
       transparent;
   }
@@ -55,26 +79,27 @@ const MiddleRing = styled(LoadingContainer)`
 
 const InnerRing = styled(LoadingContainer)`
   > div {
-    width: 40px;
-    height: 40px;
-    margin-top: 7px;
-    margin-left: 7px;
-    border: 3px solid ${themes.global.brand};
+    width: ${({ size }) => SIZES[size].innerRingLength};
+    height: ${({ size }) => SIZES[size].innerRingLength};
+    margin-top: ${({ size }) => SIZES[size].marginValue};
+    margin-left: ${({ size }) => SIZES[size].marginValue};
+    border: ${({ size }) => SIZES[size].borderWidth} solid
+      ${themes.global.brand};
     border-color: ${themes.global.brand} transparent transparent transparent;
   }
 `;
 
-const LoaderRing = () => (
+const LoaderRing = props => (
   <React.Fragment>
-    <OuterRing>
+    <OuterRing {...props}>
       <div />
       <div />
       <div />
-      <MiddleRing>
+      <MiddleRing {...props}>
         <div />
         <div />
         <div />
-        <InnerRing>
+        <InnerRing {...props}>
           <div />
           <div />
           <div />
@@ -85,5 +110,15 @@ const LoaderRing = () => (
 );
 
 LoaderRing.displayName = "LoaderRing";
+
+LoaderRing.propTypes = {
+  size: PropTypes.oneOf(LOADER_RING_SIZES),
+  display: PropTypes.oneOf(["block", "inline-block"])
+};
+
+LoaderRing.defaultProps = {
+  size: LOADER_RING_SIZES.regular,
+  display: "block"
+};
 
 export default LoaderRing;

--- a/src/components/LoaderRing/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/LoaderRing/__tests__/__snapshots__/index.spec.js.snap
@@ -2,19 +2,25 @@
 
 exports[`<LoaderRing /> renders LoaderRing correctly 1`] = `
 <div
-  className="jOJVgJ"
+  className="dZzHdk"
+  display="block"
+  size="regular"
 >
   <div />
   <div />
   <div />
   <div
-    className="bHXeYW"
+    className="gMBTTJ"
+    display="block"
+    size="regular"
   >
     <div />
     <div />
     <div />
     <div
-      className="drIuox"
+      className="jESAEz"
+      display="block"
+      size="regular"
     >
       <div />
       <div />

--- a/src/components/LoaderRing/constants.js
+++ b/src/components/LoaderRing/constants.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const LOADER_RING_SIZES = {
+  small: "small",
+  regular: "regular"
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Extended LoaderRing so it can be used with regular (80px) and small (48px) sizes.

**Why**:
In next-renderer almost in all places old loader is much smaller than regular (80px) LoaderRing. So it would be useful to support small size in Aurora.

**How**:
Added `size` prop so we can specify the size of LoaderRing. Supported values: `small` and `regular`.

Also added `display` prop which allows us to position Loader in center (if `inline-block` value passed).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
