### PR TITLE
feat(ResponsiveImage): Add support for children prop

### DIFF
--- a/catalog/pages/images/index.md
+++ b/catalog/pages/images/index.md
@@ -27,6 +27,10 @@ rows:
     Type: number
     Default: 1
     Notes: Measured in pixels
+  - Prop: children
+    Type: node
+    Default: null
+    Notes: ResponsiveImage only
 ```
 
 ### Image with loader prop

--- a/src/components/Image/Responsive.js
+++ b/src/components/Image/Responsive.js
@@ -4,10 +4,19 @@ import PropTypes from "prop-types";
 import StyledResponsiveImage from "./Responsive.styles";
 import StyledImageSeo from "./Seo.styles";
 
-const ResponsiveImage = ({ loader, src, alt, height, width, ...props }) =>
+const ResponsiveImage = ({
+  loader,
+  src,
+  alt,
+  height,
+  width,
+  children,
+  ...props
+}) =>
   loader || (
     <StyledResponsiveImage image={src} height={height} width={width} {...props}>
       <StyledImageSeo src={src} alt={alt} height={height} width={width} />
+      {children}
     </StyledResponsiveImage>
   );
 
@@ -16,16 +25,17 @@ ResponsiveImage.propTypes = {
   src: PropTypes.string,
   alt: PropTypes.string,
   height: PropTypes.number,
-  width: PropTypes.number
+  width: PropTypes.number,
+  children: PropTypes.node
 };
 
 ResponsiveImage.defaultProps = {
   loader: null,
   src: "",
   alt: "",
-  ratio: 100,
   height: 1,
-  width: 1
+  width: 1,
+  children: null
 };
 
 export default ResponsiveImage;

--- a/src/components/Image/__tests__/Responsive.spec.js
+++ b/src/components/Image/__tests__/Responsive.spec.js
@@ -23,4 +23,14 @@ describe("ResponsiveImage", () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it("should render correctly when a children prop is passed", () => {
+    const component = renderer.create(
+      <ResponsiveImage {...PROPS}>
+        <title>Responsive Image</title>
+      </ResponsiveImage>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/components/Image/__tests__/__snapshots__/Responsive.spec.js.snap
+++ b/src/components/Image/__tests__/__snapshots__/Responsive.spec.js.snap
@@ -17,3 +17,22 @@ exports[`ResponsiveImage should render correctly 1`] = `
   />
 </div>
 `;
+
+exports[`ResponsiveImage should render correctly when a children prop is passed 1`] = `
+<div
+  className="image image--responsive eFUxCO"
+  height={9}
+  width={16}
+>
+  <img
+    alt="Test Kitten"
+    className="image image--seo image--hidden eEqoji"
+    height={9}
+    src="https://placekitten.com/g/826/465"
+    width={16}
+  />
+  <title>
+    Responsive Image
+  </title>
+</div>
+`;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am adding a `children` prop to the `ResponsiveImage` component.

<!-- Why are these changes necessary? -->

**Why**: This change is necessary to easily overlay `children` on top of the `ResponsiveImage` component.

<!-- How were these changes implemented? -->

**How**: I am adding a `children` prop to the `ResponsiveImage` component.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
