### PR TITLE
fix(ListRowContent): remove 'row--gutterless' class name from ContentRow component

### DIFF
--- a/src/components/List/RowContent.js
+++ b/src/components/List/RowContent.js
@@ -328,7 +328,7 @@ class ListRowContent extends Component {
             </DateWrapper>
 
             {/* this class name is for automation purposes please do not remove or modify the name */}
-            <ContentRow className="row__content row--gutterless">
+            <ContentRow className="row__content">
               {/* this class name is for automation purposes please do not remove or modify the name */}
               <MobileOnlyColumn className="column__mobile-only">
                 <MultilineText

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -51,7 +51,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -460,7 +460,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -869,7 +869,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -1278,7 +1278,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -1695,7 +1695,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -2104,7 +2104,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -2513,7 +2513,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -2922,7 +2922,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -3339,7 +3339,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -3748,7 +3748,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -4157,7 +4157,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -4566,7 +4566,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -4983,7 +4983,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -5392,7 +5392,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -5801,7 +5801,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -6210,7 +6210,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -6628,7 +6628,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -6876,7 +6876,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -7285,7 +7285,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -7694,7 +7694,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -8103,7 +8103,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -8519,7 +8519,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -8928,7 +8928,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -9337,7 +9337,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -9746,7 +9746,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -10162,7 +10162,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -10603,7 +10603,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -11044,7 +11044,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -11485,7 +11485,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -11933,7 +11933,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -12342,7 +12342,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -12751,7 +12751,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -13160,7 +13160,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -13577,7 +13577,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -13986,7 +13986,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -14395,7 +14395,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -14804,7 +14804,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
             </div>
           </div>
           <div
-            class="row__content row--gutterless sc-jbKcbu bDgoQe"
+            class="row__content sc-jbKcbu bDgoQe"
           >
             <div
               class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -15221,7 +15221,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -15348,7 +15348,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -15475,7 +15475,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"
@@ -15602,7 +15602,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
           </div>
         </div>
         <div
-          class="row__content row--gutterless sc-jbKcbu bDgoQe"
+          class="row__content sc-jbKcbu bDgoQe"
         >
           <div
             class="column__mobile-only sc-TOsTZ kvpwzf"

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -78,7 +78,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
           </div>
         </div>
         <div
-          className="row__content row--gutterless jliziJ"
+          className="row__content jliziJ"
         >
           <div
             className="column__mobile-only hwQSiY"
@@ -339,7 +339,7 @@ exports[`<ListRow /> renders List Row with label correctly 1`] = `
           </div>
         </div>
         <div
-          className="row__content row--gutterless jliziJ"
+          className="row__content jliziJ"
         >
           <div
             className="column__mobile-only hwQSiY"
@@ -538,7 +538,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
           </div>
         </div>
         <div
-          className="row__content row--gutterless jliziJ"
+          className="row__content jliziJ"
         >
           <div
             className="column__mobile-only hwQSiY"
@@ -796,7 +796,7 @@ exports[`<ListRow /> renders List Row with styled button 1`] = `
           </div>
         </div>
         <div
-          className="row__content row--gutterless jliziJ"
+          className="row__content jliziJ"
         >
           <div
             className="column__mobile-only hwQSiY"
@@ -995,7 +995,7 @@ exports[`<ListRow /> renders List Row with title correctly when expanded 1`] = `
           </div>
         </div>
         <div
-          className="row__content row--gutterless jliziJ"
+          className="row__content jliziJ"
         >
           <div
             className="column__mobile-only hwQSiY"
@@ -1194,7 +1194,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
           </div>
         </div>
         <div
-          className="row__content row--gutterless jliziJ"
+          className="row__content jliziJ"
         >
           <div
             className="column__mobile-only hwQSiY"
@@ -1452,7 +1452,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
           </div>
         </div>
         <div
-          className="row__content row--gutterless jliziJ"
+          className="row__content jliziJ"
         >
           <div
             className="column__mobile-only hwQSiY"


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: removed 'row--gutterless' class name from `ContentRow` component 

<!-- Why are these changes necessary? -->

**Why**: to prevent style changes when `ListRowContent` is wrapped with enclosure grid `Row` component.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
