### PR TITLE
fix(Link): add default value to the Link's context

### DIFF
--- a/src/components/Link/Context.js
+++ b/src/components/Link/Context.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-const { Provider, Consumer } = React.createContext();
+const { Provider, Consumer } = React.createContext({});
 
 export { Provider as LinkListProvider };
 export { Consumer as LinkListConsumer };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adding default value to the Link's context
<!-- Why are these changes necessary? -->

**Why**:

In some cases the LinkListItem renders without a provider, which is not valid case, but happens due to custom renderer implementations not keeping up with changes to the react (eg. `react-apollo`'s `getDataFromTree()`). In such cases the whole tree fails because the component tries to desctructure the value in the context which is `undefined`.
<!-- How were these changes implemented? -->

**How**:

Updated Link's context to initialize with a default value (an empty object)
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
