### PR TITLE
fix(Dropdown): no scroll disabling, fixed max-width, open direction controlled from outside

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -489,12 +489,28 @@ span: 6
                 </DropDownGroup>
             </Column>
             <Column medium={4}>
-                <DropDownGroup variant={0} value={["3"]} placeholder="Select an option" shouldOpenDownward={true}>
+                <DropDownGroup variant={0} value={["3"]} placeholder="Select an option" shouldOpenDownward={false}>
                     <DropDownOption value="0" index={0}>Option One One One One</DropDownOption>
                     <DropDownOption value="1" index={1}>Option Two</DropDownOption>
                     <DropDownOption value="2" index={2}>Option Three</DropDownOption>
                     <DropDownOption value="3" index={3}>Option Four</DropDownOption>
                     <DropDownOption value="4" index={4}>Option Five</DropDownOption>
+                    <DropDownOption value="5" index={5}>Option One One One One</DropDownOption>
+                    <DropDownOption value="6" index={6}>Option Two</DropDownOption>
+                    <DropDownOption value="7" index={7}>Option Three</DropDownOption>
+                    <DropDownOption value="8" index={8}>Option Four</DropDownOption>
+                    <DropDownOption value="9" index={9}>Option Five</DropDownOption>
+                    <DropDownOption value="10" index={10}>Option One One One One</DropDownOption>
+                    <DropDownOption value="11" index={11}>Option Two</DropDownOption>
+                    <DropDownOption value="12" index={12}>Option Three</DropDownOption>
+                    <DropDownOption value="13" index={13}>Option Four</DropDownOption>
+                    <DropDownOption value="14" index={14}>Option Five</DropDownOption>
+                    <DropDownOption value="15" index={15}>Option Five</DropDownOption>
+                    <DropDownOption value="16" index={16}>Option Two</DropDownOption>
+                    <DropDownOption value="17" index={17}>Option Three</DropDownOption>
+                    <DropDownOption value="18" index={18}>Option Four</DropDownOption>
+                    <DropDownOption value="19" index={19}>Option Five</DropDownOption>
+                    <DropDownOption value="20" index={20}>Option Five</DropDownOption>
                 </DropDownGroup>
             </Column>
             <Column medium={4}>

--- a/src/components/Input/DropDown/DropDownGroup.styles.js
+++ b/src/components/Input/DropDown/DropDownGroup.styles.js
@@ -75,7 +75,6 @@ export const StyledChildWrapper = styled.div`
   box-shadow: ${DROP_DOWN_SHADOW};
   min-width: 100%;
   box-sizing: border-box;
-  overscroll-behavior: contain;
 
   flex-direction: column;
   flex: 1;
@@ -95,7 +94,7 @@ export const StyledChildWrapper = styled.div`
     padding-top: 4px;
     padding-bottom: 8px;
     border-width: 1px;
-    max-height: 300px;
+    max-height: 606px;
 
     transition: max-height 0.3s ${constants.easing.easeInOutQuad},
       border-width 0s, padding-top 0s, padding-bottom 0s;
@@ -109,6 +108,7 @@ export const StyledChildWrapper = styled.div`
     bottom: 43px;
     border-radius: ${small} ${small} 0 0;
     box-shadow: ${DROP_DOWN_SHADOW};
+
     &.dropdown__items--small {
       bottom: 35px;
     }

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -119,15 +119,6 @@ describe("DropDownGroup", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it("Should close the drop down on click outside", () => {
-    const { container, getByTestId } = renderTestComponentOne();
-
-    fireEvent.click(getByTestId("test-dropContainer"));
-    fireEvent.click(getByTestId("something"));
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
   it("Should not focus onClick", () => {
     const { container } = renderTestComponentOne({ disabled: true });
     fireEvent.mouseDown(container.querySelector("label"));
@@ -156,7 +147,7 @@ describe("DropDownGroup", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it("Arrow down arrow should open the drop down", () => {
+  it("Arrow key down should open the drop down", () => {
     const { container, getByTestId } = renderTestComponentOne();
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
@@ -393,24 +384,6 @@ describe("DropDownGroup", () => {
       preventDefault
     });
     expect(preventDefault).toHaveBeenCalled();
-  });
-
-  it("should disable scroll when dropdown is open", () => {
-    const { container, getByTestId } = renderTestComponentOne();
-
-    fireEvent.click(getByTestId("test-dropDownOptionOne"));
-    fireEvent.wheel(getByTestId("test-outSideComponent"));
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it("should allow scroll inside the dropdown when it is open", () => {
-    const { container, getByTestId } = renderTestComponentOne();
-
-    fireEvent.click(getByTestId("test-dropDownOptionOne"));
-    fireEvent.wheel(getByTestId("test-dropDownOptionOne"));
-
-    expect(container.firstChild).toMatchSnapshot();
   });
 
   it("should render the correct label when label prop is passed, and when an array of children containing falsy values is passed to each DropDownOption", () => {

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
+exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
 <div
   data-testid="test-outSideComponent"
 >
@@ -12,7 +12,7 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="dropdown--open-upward sc-bxivhb pBoyv"
+    class="sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
@@ -39,42 +39,39 @@ exports[`DropDownGroup Arrow down arrow should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
-      style="max-height: -44px;"
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -93,7 +90,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="dropdown--open-upward sc-bxivhb pBoyv"
+    class="sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
@@ -120,42 +117,39 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
-      style="max-height: -44px;"
+      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -201,42 +195,39 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -255,7 +246,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="dropdown--open-upward sc-bxivhb pBoyv"
+    class="sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
@@ -284,42 +275,39 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="dropdown__selected sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="dropdown__selected sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -365,123 +353,39 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
-        >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DropDownGroup Should close the drop down on click outside 1`] = `
-<div
-  data-testid="test-outSideComponent"
->
-  <div
-    data-testid="something"
-  >
-    something
-  </div>
-  <div
-    aria-haspopup="listbox"
-    aria-labelledby="hidden-label__"
-    class="sc-bxivhb pBoyv"
-    data-testid="test-dropContainer"
-    tabindex="0"
-  >
-    <label
-      class="dropdown--large dropdown--border sc-bdVaJa qKpWB"
-    >
-      <span
-        class="sc-htpNat irkcXP"
-        id="hidden-label__"
-      />
       <div
-        class="sc-EHOje vdlIp"
-      />
-      <svg
-        class="sc-ifAKCX bGhIY"
-        fill="currentColor"
-        height="12"
-        viewBox="0 0 15 7"
-        width="12"
+        class="sc-bZQynM koCnbp"
+        role="listbox"
       >
-        <path
-          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
-        />
-      </svg>
-    </label>
-    <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
-    >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -527,42 +431,39 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -608,42 +509,39 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -664,7 +562,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="dropdown--open-upward sc-bxivhb pBoyv"
+    class="sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
@@ -693,42 +591,39 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="dropdown__selected sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="dropdown__selected sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -747,7 +642,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="dropdown--open-upward sc-bxivhb pBoyv"
+    class="sc-bxivhb pBoyv"
     data-testid="test-dropContainer"
     tabindex="0"
   >
@@ -776,42 +671,39 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="dropdown__selected sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="dropdown__selected sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -857,42 +749,39 @@ exports[`DropDownGroup renders default dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -938,41 +827,39 @@ exports[`DropDownGroup renders default dropdown that should always open downward
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -1018,42 +905,39 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -1099,42 +983,39 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -1180,43 +1061,40 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          aria-labelledby="hidden-label__"
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        aria-labelledby="hidden-label__"
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -1262,42 +1140,39 @@ exports[`DropDownGroup renders small dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--small sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--small sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -1347,42 +1222,39 @@ exports[`DropDownGroup renders variant 0 with a placeholder prop 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -1430,208 +1302,39 @@ exports[`DropDownGroup renders variant 1 with a label prop 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
-        >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DropDownGroup should allow scroll inside the dropdown when it is open 1`] = `
-<div
-  data-testid="test-outSideComponent"
->
-  <div
-    data-testid="something"
-  >
-    something
-  </div>
-  <div
-    aria-haspopup="listbox"
-    aria-labelledby="hidden-label__"
-    class="dropdown--open-upward sc-bxivhb pBoyv"
-    data-testid="test-dropContainer"
-    tabindex="0"
-  >
-    <label
-      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
-    >
-      <span
-        class="sc-htpNat irkcXP"
-        id="hidden-label__"
-      />
       <div
-        class="sc-EHOje vdlIp"
+        class="sc-bZQynM koCnbp"
+        role="listbox"
       >
-        Option One
-      </div>
-      <svg
-        class="dropdown__icon--hide sc-ifAKCX bGhIY"
-        fill="currentColor"
-        height="12"
-        viewBox="0 0 15 7"
-        width="12"
-      >
-        <path
-          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
-        />
-      </svg>
-    </label>
-    <div
-      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
-      style="max-height: -44px;"
-    >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
         >
-          <span
-            class="dropdown__selected sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DropDownGroup should disable scroll when dropdown is open 1`] = `
-<div
-  data-testid="test-outSideComponent"
->
-  <div
-    data-testid="something"
-  >
-    something
-  </div>
-  <div
-    aria-haspopup="listbox"
-    aria-labelledby="hidden-label__"
-    class="dropdown--open-upward sc-bxivhb pBoyv"
-    data-testid="test-dropContainer"
-    tabindex="0"
-  >
-    <label
-      class="dropdown--large dropdown--active dropdown--border sc-bdVaJa qKpWB"
-    >
-      <span
-        class="sc-htpNat irkcXP"
-        id="hidden-label__"
-      />
-      <div
-        class="sc-EHOje vdlIp"
-      >
-        Option One
-      </div>
-      <svg
-        class="dropdown__icon--hide sc-ifAKCX bGhIY"
-        fill="currentColor"
-        height="12"
-        viewBox="0 0 15 7"
-        width="12"
-      >
-        <path
-          d="M13.974.132a.614.614 0 0 0-.762 0L7.17 5.341 1.12.132C.916-.044.563-.037.376.125a.398.398 0 0 0-.167.332c0 .058.012.116.036.17a.385.385 0 0 0 .12.155l6.427 5.54a.568.568 0 0 0 .378.135.568.568 0 0 0 .377-.135l6.427-5.54a.422.422 0 0 0 .156-.325.42.42 0 0 0-.156-.325z"
-        />
-      </svg>
-    </label>
-    <div
-      class="dropdown__items dropdown__items--large dropdown--clicked sc-bwzfXH fpSUnm"
-      style="max-height: -44px;"
-    >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+          Option One
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
         >
-          <span
-            class="dropdown__selected sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionOne"
-            role="option"
-            tabindex="-1"
-            value="ValueOne"
-          >
-            Option One
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionTwo"
-            role="option"
-            tabindex="-1"
-            value="ValueTwo"
-          >
-            Second Option
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            data-testid="test-dropDownOptionThree"
-            role="option"
-            tabindex="-1"
-            value="ValueThree"
-          >
-            Option Three
-          </span>
-        </div>
+          Second Option
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
       </div>
     </div>
   </div>
@@ -1675,43 +1378,40 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="dropdown__selected sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="date"
         >
-          <span
-            class="dropdown__selected sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="date"
-          >
-            Date
+          Date
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="distance"
+        >
+          Distance - 
+          Closest
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="price"
+        >
+          Price 
+          <span>
+            On sale
           </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="distance"
-          >
-            Distance - 
-            Closest
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="price"
-          >
-            Price 
-            <span>
-              On sale
-            </span>
-          </span>
-        </div>
+        </span>
       </div>
     </div>
   </div>
@@ -1758,43 +1458,40 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="date"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="date"
-          >
-            Date
+          Date
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="distance"
+        >
+          Distance - 
+          Closest
+        </span>
+        <span
+          class="dropdown__selected sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="price"
+        >
+          Price 
+          <span>
+            On sale
           </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="distance"
-          >
-            Distance - 
-            Closest
-          </span>
-          <span
-            class="dropdown__selected sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="price"
-          >
-            Price 
-            <span>
-              On sale
-            </span>
-          </span>
-        </div>
+        </span>
       </div>
     </div>
   </div>
@@ -1839,43 +1536,40 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large sc-bwzfXH fpSUnm"
-      style="max-height: 0;"
+      class="dropdown__items dropdown__items--large sc-bwzfXH bOaDnd"
     >
-      <div>
-        <div
-          class="sc-bZQynM koCnbp"
-          role="listbox"
+      <div
+        class="sc-bZQynM koCnbp"
+        role="listbox"
+      >
+        <span
+          class="sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="date"
         >
-          <span
-            class="sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="date"
-          >
-            Date
+          Date
+        </span>
+        <span
+          class="dropdown__selected sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="distance"
+        >
+          Distance - 
+          Closest
+        </span>
+        <span
+          class="sc-gzVnrw iJMNFP"
+          role="option"
+          tabindex="-1"
+          value="price"
+        >
+          Price 
+          <span>
+            On sale
           </span>
-          <span
-            class="dropdown__selected sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="distance"
-          >
-            Distance - 
-            Closest
-          </span>
-          <span
-            class="sc-gzVnrw iJMNFP"
-            role="option"
-            tabindex="-1"
-            value="price"
-          >
-            Price 
-            <span>
-              On sale
-            </span>
-          </span>
-        </div>
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
* user is able to scroll the page when dropdown is open
* make 'open up' or 'open down' configurable, Developers to decide; 'open down' is a default value
* ignore the viewport when determining the size of the dropdown; just follow the rule of max height 606px
* user is able to scroll inside the dropdown; when the last item in the list is reached page scrolls up
<!-- Why are these changes necessary? -->

**Why**:
New requirements.
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
