### PR TITLE
feat(Breadcrumb): Remove schema.org metadata

### DIFF
--- a/catalog/pages/breadcrumbs/index.md
+++ b/catalog/pages/breadcrumbs/index.md
@@ -1,6 +1,6 @@
 ### Breadcrumb
 
-Breadcrumb Component to assist the user in visualizing site navigation hierarchically. Breadcrumb contains relevant metadata to populate the BreadcrumbList Schema.org entity. Please visit the [BreadcrumbList documentation page](https://schema.org/BreadcrumbList) for more details.
+Breadcrumb Component to assist the user in visualizing site navigation hierarchically.
 
 ### Props
 
@@ -23,7 +23,7 @@ rows:
 
 ### Breadcrumb.Item
 
-Breadcrumb.Item Component to serve as children of the Breadcrumb. Breadcrumb.Item contains relevant metadata as props to populate the BreadcrumbList Schema.org entity. Please visit the [BreadcrumbList documentation page](https://schema.org/BreadcrumbList) and view the required props below for more details.
+Breadcrumb.Item Component to serve as children of the Breadcrumb.
 
 ### Props
 

--- a/src/components/Breadcrumbs/Breadcrumb.js
+++ b/src/components/Breadcrumbs/Breadcrumb.js
@@ -9,8 +9,6 @@ const Breadcrumb = ({ children, className, variant, ...props }) => (
     <StyledBreadcrumb
       {...props}
       className={classNames(className, `breadcrumb--${variant}`)}
-      itemScope
-      itemType="http://schema.org/Breadcrumb"
       childrenLen={React.Children.count(children)}
     >
       {children}

--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -28,15 +28,9 @@ const BreadcrumbItem = ({
   primary,
   ...props
 }) => (
-  <li
-    itemProp="itemListElement"
-    itemScope
-    itemType="http://schema.org/ListItem"
-    style={{ whiteSpace: "nowrap" }}
-  >
+  <li style={{ whiteSpace: "nowrap" }}>
     <StyledLink
       {...props}
-      itemProp="item"
       size={size}
       weight={weight}
       variant={variant}
@@ -46,8 +40,6 @@ const BreadcrumbItem = ({
     >
       {children}
     </StyledLink>
-    {children && <meta itemProp="name" content={children} />}
-    {position && <meta itemProp="position" content={position} />}
   </li>
 );
 

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
@@ -11,8 +11,6 @@ exports[`<Breadcrumb /> renders correctly 1`] = `
 >
   <ol
     className="breadcrumb--light bhmjif"
-    itemScope={true}
-    itemType="http://schema.org/Breadcrumb"
   >
     Breadcrumb
     List
@@ -31,8 +29,6 @@ exports[`<Breadcrumb /> should render when empty list passed in 1`] = `
 >
   <ol
     className="breadcrumb--light blNvKQ"
-    itemScope={true}
-    itemType="http://schema.org/Breadcrumb"
   />
 </nav>
 `;

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/BreadcrumbItem.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/BreadcrumbItem.spec.js.snap
@@ -2,9 +2,6 @@
 
 exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] = `
 <li
-  itemProp="itemListElement"
-  itemScope={true}
-  itemType="http://schema.org/ListItem"
   style={
     Object {
       "whiteSpace": "nowrap",
@@ -14,7 +11,6 @@ exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] =
   <a
     className="eOSDpb hCyrKv"
     href="/"
-    itemProp="item"
     onClick={null}
     rel="_self"
     size={
@@ -28,22 +24,11 @@ exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] =
   >
     Home
   </a>
-  <meta
-    content="Home"
-    itemProp="name"
-  />
-  <meta
-    content="1"
-    itemProp="position"
-  />
 </li>
 `;
 
 exports[`<Breadcrumb.Item /> renders correctly when no href prop is passed 1`] = `
 <li
-  itemProp="itemListElement"
-  itemScope={true}
-  itemType="http://schema.org/ListItem"
   style={
     Object {
       "whiteSpace": "nowrap",
@@ -53,7 +38,6 @@ exports[`<Breadcrumb.Item /> renders correctly when no href prop is passed 1`] =
   <span
     className="kXsNXA eZUnXh"
     href={null}
-    itemProp="item"
     onClick={null}
     rel="_self"
     size={
@@ -67,13 +51,5 @@ exports[`<Breadcrumb.Item /> renders correctly when no href prop is passed 1`] =
   >
     Home
   </span>
-  <meta
-    content="Home"
-    itemProp="name"
-  />
-  <meta
-    content="1"
-    itemProp="position"
-  />
 </li>
 `;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am removing schema.org metadata from the Breadcrumb components.

<!-- Why are these changes necessary? -->

**Why**: This removal was requested by the SEO team in favor of using jsonld.

<!-- How were these changes implemented? -->

**How**: I am removing schema.org metadata from the Breadcrumb components.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
