### PR TITLE
fix(SearchComponent): fixes for ref and changes for 'focus' behavior

### DIFF
--- a/src/components/SearchInput/Search.styles.js
+++ b/src/components/SearchInput/Search.styles.js
@@ -9,14 +9,15 @@ import {
 import { SearchIcon } from "../Icons";
 import { themes, typography, constants, spacing } from "../../theme";
 import { cardBoxShadow } from "../../theme/constants";
+import { mediumAndUp } from "../../theme/mediaQueries";
 
 export const SearchContainer = styled.div`
   display: flex;
+  box-sizing: border-box;
   align-items: center;
-  height: ${({ variant, isFocused }) => getSearchHeight(variant, isFocused)};
+  height: ${({ variant }) => getSearchHeight(variant)};
   max-width: 100%;
-  min-width: ${({ isFocused }) =>
-    isFocused ? `calc(${SearchMinWidth} - 2px)` : SearchMinWidth};
+  min-width: ${SearchMinWidth};
   border: ${({ isFocused }) =>
     isFocused ? `1px solid ${themes.global.gray02}` : "none"};
   border-radius: ${constants.borderRadius.small};
@@ -105,9 +106,9 @@ export const Cancel = styled.button`
   padding: 0 ${spacing.moderate} 0 0;
   height: 100%;
 
-  @media screen and ${constants.breakpoints.mediumAndUp} {
+  ${mediumAndUp`
     display: none;
-  }
+  `};
 `;
 
 export const Clear = styled.button`
@@ -118,18 +119,17 @@ export const Clear = styled.button`
   height: 100%;
   width: 44px;
   margin-left: ${spacing.cozy};
-  display: flex;
+  display: ${({ value }) => (value ? "flex" : "none")};
   justify-content: center;
   align-items: center;
   cursor: default;
-  visibility: ${({ value }) => (value ? "visible" : "hidden")};
   color: ${({ isFocused }) =>
     !isFocused ? themes.global.white.base : themes.global.gray02};
 
-  @media screen and ${constants.breakpoints.mediumAndUp} {
+  ${mediumAndUp`
     width: 40px;
     justify-content: left;
-  }
+  `};
 `;
 
 export const SearchSuggest = styled.div`
@@ -146,9 +146,9 @@ export const SearchSuggest = styled.div`
   overflow-y: auto;
   box-sizing: border-box;
 
-  @media screen and ${constants.breakpoints.mediumAndUp} {
+  ${mediumAndUp`
     max-height: ${SuggestMaxHeight};
-  }
+  `};
 `;
 
 SearchSuggest.displayName = "SearchSuggest";

--- a/src/components/SearchInput/__tests__/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__tests__/__snapshots__/SearchInput.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchInput icon only should match snapshot 1`] = `
 <div
-  className="search--container hidden eCubN"
+  className="search--container hidden bzGmuh"
   onBlur={[Function]}
   onFocus={[Function]}
 >
@@ -46,7 +46,7 @@ exports[`SearchInput icon only should match snapshot 1`] = `
   />
   <button
     aria-label="Clear button"
-    className="search--clear-icon eyAPzR"
+    className="search--clear-icon dZmxwx"
     onClick={[Function]}
     value=""
   >
@@ -73,7 +73,7 @@ exports[`SearchInput icon only should match snapshot 1`] = `
   </button>
   <button
     aria-label="Cancel button"
-    className="search--cancel-icon hTwZwm"
+    className="search--cancel-icon cmpmTI"
     onClick={[Function]}
   >
     Cancel
@@ -83,7 +83,7 @@ exports[`SearchInput icon only should match snapshot 1`] = `
 
 exports[`SearchInput large should match snapshot 1`] = `
 <div
-  className="search--container kiWaFZ"
+  className="search--container cOMWqf"
   onBlur={[Function]}
   onFocus={[Function]}
 >
@@ -127,7 +127,7 @@ exports[`SearchInput large should match snapshot 1`] = `
   />
   <button
     aria-label="Clear button"
-    className="search--clear-icon eyAPzR"
+    className="search--clear-icon dZmxwx"
     onClick={[Function]}
     value=""
   >
@@ -154,7 +154,7 @@ exports[`SearchInput large should match snapshot 1`] = `
   </button>
   <button
     aria-label="Cancel button"
-    className="search--cancel-icon hTwZwm"
+    className="search--cancel-icon cmpmTI"
     onClick={[Function]}
   >
     Cancel
@@ -164,7 +164,7 @@ exports[`SearchInput large should match snapshot 1`] = `
 
 exports[`SearchInput small should match snapshot 1`] = `
 <div
-  className="search--container gAMRvB"
+  className="search--container csQJZo"
   onBlur={[Function]}
   onFocus={[Function]}
 >
@@ -208,7 +208,7 @@ exports[`SearchInput small should match snapshot 1`] = `
   />
   <button
     aria-label="Clear button"
-    className="search--clear-icon fFGyfL"
+    className="search--clear-icon eTxgLb"
     onClick={[Function]}
     value="test"
   >
@@ -235,7 +235,7 @@ exports[`SearchInput small should match snapshot 1`] = `
   </button>
   <button
     aria-label="Cancel button"
-    className="search--cancel-icon hTwZwm"
+    className="search--cancel-icon cmpmTI"
     onClick={[Function]}
   >
     Cancel
@@ -245,6 +245,6 @@ exports[`SearchInput small should match snapshot 1`] = `
 
 exports[`SearchSuggest should match snapshot 1`] = `
 <div
-  className="edMyei"
+  className="dsnsZi"
 />
 `;

--- a/src/components/SearchInput/constants.js
+++ b/src/components/SearchInput/constants.js
@@ -4,20 +4,12 @@ export const searchVariants = {
 };
 
 const searchHeight = {
-  small: 36,
-  large: 44
+  small: "36px",
+  large: "44px"
 };
 
-export const getSearchHeight = (variant, isFocused) => {
-  const heightOption = variant === searchVariants.small ? "small" : "large";
-
-  if (isFocused) {
-    // We remove 2 px from the height because when search is focused we add 1px border on top and bottom
-    return `${searchHeight[heightOption] - 2}px`;
-  }
-
-  return `${searchHeight[heightOption]}px`;
-};
+export const getSearchHeight = variant =>
+  searchHeight[variant] || searchHeight.large;
 
 export const SearchMinWidth = "320px";
 

--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -66,24 +66,25 @@ class SearchInput extends Component {
       cancelBtnAreaLabel,
       inputAreaLabel,
       isSuggestOpened,
+      hasBackground,
       ...rest
     } = this.props;
     const { isFocused } = this.state;
-
+    const isStyleForFocusedUsed = !hasBackground || isFocused;
     return (
       <SearchContainer
         variant={variant}
-        isFocused={isFocused}
+        isFocused={isStyleForFocusedUsed}
         isSuggestOpened={isSuggestOpened}
         {...rest}
         className={classNames("search--container", className, {
           hidden: !isInputVisible,
-          "search--container-focused": isFocused
+          "search--container-focused": isStyleForFocusedUsed
         })}
       >
         <StyledSearchIcon
           variant={variant}
-          isFocused={isFocused}
+          isFocused={isStyleForFocusedUsed}
           onClick={searchIconSelect}
           aria-label={searchBtnAreaLabel}
           className="search--search-icon"
@@ -97,11 +98,11 @@ class SearchInput extends Component {
           onChange={onChange}
           onFocus={this.inputFocused}
           onBlur={this.inputBlur}
-          isFocused={isFocused}
-          innerRef={this.inputRef}
+          isFocused={isStyleForFocusedUsed}
+          ref={this.inputRef}
           aria-label={inputAreaLabel}
           className={classNames("search--input", {
-            "search--input-focused": isFocused
+            "search--input-focused": isStyleForFocusedUsed
           })}
         />
         <Clear
@@ -109,12 +110,12 @@ class SearchInput extends Component {
           value={value}
           aria-label={clearBtnAreaLabel}
           className="search--clear-icon"
-          isFocused={isFocused}
+          isFocused={isStyleForFocusedUsed}
         >
           <ClearIcon color="currentColor" />
         </Clear>
         <Cancel
-          isFocused={isFocused}
+          isFocused={isStyleForFocusedUsed}
           onClick={cancelCallback}
           aria-label={cancelBtnAreaLabel}
           className="search--cancel-icon"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 'innerRef' replaced with 'ref', changed condition for applying 'isFocused' style, changes of input's width and height depending on border's presence replaced with 'box-sizing: border-box;'

<!-- Why are these changes necessary? -->

**Why**: The "innerRef" API has been removed in styled-components v4. 'isFocused' can't be changed via 'hasBackground' property on mounted component.

<!-- How were these changes implemented? -->

**How**: 'innerRef' replaced with 'ref', changed condition for applying 'isFocused' style, changes of input's width and height depending on border's presence replaced with 'box-sizing: border-box;'

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
