### PR TITLE
fix(DropDown): Correct value and valueOverride types

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -403,28 +403,28 @@ span: 6
 span: 6
 rows:
   - Prop: onChange
-    Type: string
-    Default: top
-    Notes: Can be top or left
+    Type: function
+    Default: "null"
+    Notes: Invoked with an array of updatedSelections when one or more option(s) is selected by the user
   - Prop: variant
-    Type: string
+    Type: number
     Default: 0
     Notes: One of 0 (with border) or 1 (without border)
   - Prop: value
-    Type: string
-    Default: N/A
-    Notes: Specifies initial values
+    Type: array
+    Default: []
+    Notes: Specifies array of initial string values
   - Prop: valueOverride
-    Type: string
-    Default: N/A
-    Notes: Specifies values that override internal state
+    Type: array
+    Default: "null"
+    Notes: Specifies array of string values that override internal state
   - Prop: label
     Type: string
-    Default: N/A
+    Default: ""
     Notes: Visible with selected option.
   - Prop: placeholder
     Type: string
-    Default: N/A
+    Default: ""
     Notes: Visible instead of selected option. Overrides label. Supported in both variants.
   - Prop: isOpen
     Type: boolean
@@ -440,11 +440,11 @@ rows:
     Notes: Used to override inclusion of a KeyboardProvider to handle keydown events
   - Prop: shouldOpenDownward
     Type: boolean
-    Default: 'false'
+    Default: 'true'
     Notes: Used to ensure that the DropDownGroup always opens downward
   - Prop: size
     Type: small or large
-    Default: large
+    Default: "large"
     Notes: Defines size
 ```
 
@@ -460,13 +460,21 @@ rows:
     Default: N/A
     Notes: Required
   - Prop: index
-    Type: string
+    Type: number
     Default: N/A
     Notes: Required
   - Prop: className
     Type: string
     Default: ""
     Notes: Passed to StyledDropDownItem
+  - Prop: onClick
+    Type: function
+    Default: "null"
+    Notes: Invoked with the synthetic event object when the DropDownOption is clicked
+  - Prop: ...props
+    Type: any
+    Default:
+    Notes: Passes through any other props to underlying DropDownInput
 ```
 
 ```react


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am correcting the types of the value and valueOverride props for the `DropDownGroup` component in the catalog docs

<!-- Why are these changes necessary? -->

**Why**: These changes are necessary to ensure our docs are up to date

<!-- How were these changes implemented? -->

**How**: I am correcting the types of the value and valueOverride props for the `DropDownGroup` component in the catalog docs

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [N/A] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
