### PR TITLE
fix(LazyLoad): Correct url when image is resized on the client

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -403,28 +403,28 @@ span: 6
 span: 6
 rows:
   - Prop: onChange
-    Type: string
-    Default: top
-    Notes: Can be top or left
+    Type: function
+    Default: "null"
+    Notes: Invoked with an array of updatedSelections when one or more option(s) is selected by the user
   - Prop: variant
-    Type: string
+    Type: number
     Default: 0
     Notes: One of 0 (with border) or 1 (without border)
   - Prop: value
-    Type: string
-    Default: N/A
-    Notes: Specifies initial values
+    Type: array
+    Default: []
+    Notes: Specifies array of initial string values
   - Prop: valueOverride
-    Type: string
-    Default: N/A
-    Notes: Specifies values that override internal state
+    Type: array
+    Default: "null"
+    Notes: Specifies array of string values that override internal state
   - Prop: label
     Type: string
-    Default: N/A
+    Default: ""
     Notes: Visible with selected option.
   - Prop: placeholder
     Type: string
-    Default: N/A
+    Default: ""
     Notes: Visible instead of selected option. Overrides label. Supported in both variants.
   - Prop: isOpen
     Type: boolean
@@ -440,11 +440,11 @@ rows:
     Notes: Used to override inclusion of a KeyboardProvider to handle keydown events
   - Prop: shouldOpenDownward
     Type: boolean
-    Default: 'false'
+    Default: 'true'
     Notes: Used to ensure that the DropDownGroup always opens downward
   - Prop: size
     Type: small or large
-    Default: large
+    Default: "large"
     Notes: Defines size
 ```
 
@@ -460,13 +460,21 @@ rows:
     Default: N/A
     Notes: Required
   - Prop: index
-    Type: string
+    Type: number
     Default: N/A
     Notes: Required
   - Prop: className
     Type: string
     Default: ""
     Notes: Passed to StyledDropDownItem
+  - Prop: onClick
+    Type: function
+    Default: "null"
+    Notes: Invoked with the synthetic event object when the DropDownOption is clicked
+  - Prop: ...props
+    Type: any
+    Default:
+    Notes: Passes through any other props to underlying DropDownInput
 ```
 
 ```react

--- a/src/components/Backdrop/__tests__/index.spec.js
+++ b/src/components/Backdrop/__tests__/index.spec.js
@@ -5,6 +5,8 @@ import { ESCAPE } from "../../../utils/keyCharCodes";
 
 import Backdrop from "../index";
 
+let win;
+
 describe("<Backdrop />", () => {
   const childRef = {
     current: {
@@ -13,7 +15,12 @@ describe("<Backdrop />", () => {
   };
 
   beforeEach(() => {
-    process.browser = true;
+    if (!win) win = global.window;
+    global.window = null;
+  });
+
+  afterEach(() => {
+    global.window = win;
   });
 
   it("renders correctly with an overlay", () => {

--- a/src/components/Backdrop/index.js
+++ b/src/components/Backdrop/index.js
@@ -63,7 +63,7 @@ export default class Backdrop extends Component {
   };
 
   attachListeners = () => {
-    if (process.browser) {
+    if (typeof window === "object") {
       document.addEventListener("click", this.handleOutsideClick);
       document.addEventListener("keydown", this.onKeyPress);
       this.hasListeners = true;
@@ -71,7 +71,7 @@ export default class Backdrop extends Component {
   };
 
   detachListeners = () => {
-    if (process.browser) {
+    if (typeof window === "object") {
       document.removeEventListener("click", this.handleOutsideClick);
       document.removeEventListener("keydown", this.onKeyPress);
       this.hasListeners = false;

--- a/src/components/LazyLoader/helpers.js
+++ b/src/components/LazyLoader/helpers.js
@@ -2,10 +2,10 @@ import { PLACEHOLDER_IMAGE } from "./constants";
 import createParams from "../../utils/createParams";
 
 /* istanbul ignore next */
-const Url = process.browser ? global.window.URL : require("url");
+const Url = typeof window === "object" ? global.window.URL : require("url");
 
 export const resize = ({ src = "", ...params }) => {
-  const isBrowser = process.browser;
+  const isBrowser = typeof window === "object";
 
   try {
     const { host, pathname } = isBrowser ? new Url(src) : Url.parse(src);

--- a/src/components/LazyLoader/helpers.js
+++ b/src/components/LazyLoader/helpers.js
@@ -5,14 +5,16 @@ import createParams from "../../utils/createParams";
 const Url = process.browser ? global.window.URL : require("url");
 
 export const resize = ({ src = "", ...params }) => {
+  const isBrowser = process.browser;
+
   try {
-    const { host, pathname } = process.browser ? new Url(src) : Url.parse(src);
+    const { host, pathname } = isBrowser ? new Url(src) : Url.parse(src);
 
     if (!host) {
       return src;
     }
 
-    const url = `https://${host}/${pathname}`;
+    const url = `https://${host}${isBrowser ? "" : "/"}${pathname}`;
     const fit = params.width && params.height ? { fit: "crop" } : {};
     const resizeSrc = `${url}${createParams({ ...params, ...fit })}`;
     return resizeSrc;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am fixing the url when image is resized on the client.

<!-- Why are these changes necessary? -->

**Why**: The url was created incorrectly when the window.URL API was used on the client.

<!-- How were these changes implemented? -->

**How**: I am only adding a slash to separate the host and pathname variables on the server.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
