### PR TITLE
fix(LazyLoader): Correct returned url when resize is invoked on the server; update tests

### DIFF
--- a/src/components/LazyLoader/__tests__/__snapshots__/helpers.spec.js.snap
+++ b/src/components/LazyLoader/__tests__/__snapshots__/helpers.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resize should return a URL with a valid width and an invalid height param appended 1`] = `"https://ticketmaster.com/assets/test.jpg?width=100"`;
+
+exports[`resize should return a URL with an invalid width and a valid height param appended 1`] = `"https://ticketmaster.com/assets/test.jpg?height=100"`;
+
+exports[`resize should return a URL with valid width and height params appended 1`] = `"https://ticketmaster.com/assets/test.jpg?width=100&height=100&fit=crop"`;
+
+exports[`resize should return src if an error occurs 1`] = `null`;
+
+exports[`resize should return src when src does not contain a host 1`] = `"/assets/test.jpg"`;

--- a/src/components/LazyLoader/__tests__/helpers.spec.js
+++ b/src/components/LazyLoader/__tests__/helpers.spec.js
@@ -38,10 +38,7 @@ describe("resize", () => {
     const src = "https://ticketmaster.com/assets/test.jpg";
 
     const url = resize({ src, ...mockParams });
-    expect(url.startsWith(`${src}?`));
-    expect(url.includes("width=100"));
-    expect(url.includes("height=100"));
-    expect(url.includes("fit=crop"));
+    expect(url).toMatchSnapshot();
   });
 
   it("should return a URL with a valid width and an invalid height param appended", () => {
@@ -51,8 +48,7 @@ describe("resize", () => {
     };
 
     const url = resize({ src, ...params });
-    expect(url.startsWith(`${src}?`));
-    expect(url.includes("width=100"));
+    expect(url).toMatchSnapshot();
   });
 
   it("should return a URL with an invalid width and a valid height param appended", () => {
@@ -62,20 +58,19 @@ describe("resize", () => {
     };
 
     const url = resize({ src, ...params });
-    expect(url.startsWith(`${src}?`));
-    expect(url.includes("height=100"));
+    expect(url).toMatchSnapshot();
   });
 
   it("should return src when src does not contain a host", () => {
     const src = "/assets/test.jpg";
 
-    expect(resize({ src })).toEqual(src);
+    expect(resize({ src })).toMatchSnapshot();
   });
 
   it("should return src if an error occurs", () => {
     const src = null;
 
-    expect(resize({ src })).toEqual(src);
+    expect(resize({ src })).toMatchSnapshot();
   });
 });
 

--- a/src/components/LazyLoader/helpers.js
+++ b/src/components/LazyLoader/helpers.js
@@ -5,16 +5,15 @@ import createParams from "../../utils/createParams";
 const Url = typeof window === "object" ? global.window.URL : require("url");
 
 export const resize = ({ src = "", ...params }) => {
-  const isBrowser = typeof window === "object";
-
   try {
-    const { host, pathname } = isBrowser ? new Url(src) : Url.parse(src);
+    const { host, pathname } =
+      typeof window === "object" ? new Url(src) : Url.parse(src);
 
     if (!host) {
       return src;
     }
 
-    const url = `https://${host}${isBrowser ? "" : "/"}${pathname}`;
+    const url = `https://${host}${pathname}`;
     const fit = params.width && params.height ? { fit: "crop" } : {};
     const resizeSrc = `${url}${createParams({ ...params, ...fit })}`;
     return resizeSrc;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Correct returned url when resize is invoked on the server; update tests

<!-- Why are these changes necessary? -->

**Why**: I am making this change to ensure that the url is correct

<!-- How were these changes implemented? -->

**How**: Correct returned url when resize is invoked on the server; update tests

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
