### PR TITLE
feat(LazyLoad): Add lazy loading support to ResponsiveImage, StaticImage, and HeaderWithImage

### DIFF
--- a/catalog/pages/header/LazyHeaderWithImageExample.js
+++ b/catalog/pages/header/LazyHeaderWithImageExample.js
@@ -1,0 +1,69 @@
+import React, { Fragment } from "react";
+import PropTypes from "prop-types";
+
+import { HeaderWithImage, LazyLoader, Button } from "../../../src";
+
+const LazyHeaderWithImageExample = ({
+  backgroundImage,
+  backgroundImageProps,
+  withUnderlay,
+  withOverlay,
+  withSpotLight,
+  children,
+  height,
+  width
+}) => (
+  <LazyLoader
+    src={backgroundImage}
+    height={height}
+    width={width}
+    style={backgroundImageProps.style || {}}
+  >
+    {({ src: lazySrc, style: lazyStyle, imageRef, load }) => (
+      <Fragment>
+        <HeaderWithImage
+          withUnderlay={withUnderlay}
+          withOverlay={withOverlay}
+          withSpotLight={withSpotLight}
+          backgroundImage={lazySrc}
+          backgroundImageProps={{
+            ...backgroundImageProps,
+            ref: imageRef,
+            style: { ...lazyStyle, ...(backgroundImageProps.style || {}) }
+          }}
+        >
+          {children}
+        </HeaderWithImage>
+        <Button
+          variant="standard"
+          style={{ position: "absolute", bottom: "0px", maxWidth: "400px" }}
+          onClick={() => load(true)}
+        >
+          Load image
+        </Button>
+      </Fragment>
+    )}
+  </LazyLoader>
+);
+
+LazyHeaderWithImageExample.propTypes = {
+  backgroundImage: PropTypes.string,
+  backgroundImageProps: PropTypes.objectOf(PropTypes.any),
+  withOverlay: PropTypes.bool,
+  withUnderlay: PropTypes.bool,
+  withSpotLight: PropTypes.bool,
+  children: PropTypes.node,
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired
+};
+
+LazyHeaderWithImageExample.defaultProps = {
+  backgroundImage: null,
+  backgroundImageProps: {},
+  withOverlay: false,
+  withUnderlay: false,
+  withSpotLight: false,
+  children: null
+};
+
+export default LazyHeaderWithImageExample;

--- a/catalog/pages/header/index.js
+++ b/catalog/pages/header/index.js
@@ -7,6 +7,7 @@ import HeaderWithImage from "../../../src/components/Header/WithImage";
 import ImageCard from "../../../src/components/ImageCard";
 import Breadcrumb from "../../../src/components/Breadcrumbs";
 import Spacing from "../../../src/components/Spacing";
+import LazyHeaderWithImageExample from "./LazyHeaderWithImageExample";
 import { Column, Row } from "../../../src/components/Grid";
 import { RatingBadge } from "../../../src/components/Button";
 import { StarIcon } from "../../../src/components/Icons";
@@ -21,6 +22,7 @@ export default {
   imports: {
     Header,
     Heading,
+    LazyHeaderWithImageExample,
     HeaderWithImage,
     Column,
     Row,

--- a/catalog/pages/header/index.md
+++ b/catalog/pages/header/index.md
@@ -129,16 +129,18 @@ responsive: true
 </ThemeProvider>
 ```
 
-### Image Header with Underlaid Image Background
+### Lazy Image Header with Underlaid Image Background
 
 ```react
 responsive: true
 ---
 <React.Fragment>
-  <HeaderWithImage
+  <LazyHeaderWithImageExample
     withUnderlay={true}
     backgroundImage="https://beta.tmol.co/s3images/City/losangeles_889.jpg"
     backgroundImageProps={{ deg: { small: "40deg", medium: "39deg", large: "25deg" }, stops: [colors.defaultGradient.from, colors.heliotrope.base ], style: { backgroundPosition: "center" } }}
+    height={350}
+    width={650}
   >
     <Column medium={7} large={8}>
       <Heading level={1}>
@@ -147,12 +149,11 @@ responsive: true
           <Heading.Span>Header</Heading.Span>
       </Heading>
     </Column>
-  </HeaderWithImage>
-  <div>Some other content</div>
+  </LazyHeaderWithImageExample>
 </React.Fragment>
 ```
 
-### Image Header with Underlaid Image Background
+### Image Header with Underlaid Image Background and Spotlight
 
 ```react
 responsive: true

--- a/catalog/pages/images/LazyResponsiveImageExample.js
+++ b/catalog/pages/images/LazyResponsiveImageExample.js
@@ -1,40 +1,11 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 
-import { LazyLoader, Column, Button } from "../../../src";
+import { LazyLoader, ResponsiveImage, Column, Button } from "../../../src";
 
 export const resizeFn = ({ src, width, height }) => `${src}/${width}/${height}`;
 
-export class ImgClass extends Component {
-  static propTypes = {
-    src: PropTypes.string.isRequired,
-    alt: PropTypes.string.isRequired,
-    height: PropTypes.number.isRequired,
-    width: PropTypes.number.isRequired,
-    style: PropTypes.objectOf(PropTypes.string),
-    imageRef: PropTypes.shape({}).isRequired
-  };
-
-  static defaultProps = {
-    style: {}
-  };
-
-  render() {
-    const { src, alt, height, width, style, imageRef } = this.props;
-    return (
-      <img
-        src={src}
-        alt={alt}
-        height={height}
-        width={width}
-        style={style}
-        ref={imageRef}
-      />
-    );
-  }
-}
-
-const LazyImageExample = ({ src, alt, height, width, style }) => (
+const LazyResponsiveImageExample = ({ src, alt, height, width, style }) => (
   <LazyLoader
     src={src}
     height={height}
@@ -44,7 +15,7 @@ const LazyImageExample = ({ src, alt, height, width, style }) => (
   >
     {({ src: lazySrc, style: lazyStyle, imageRef, load }) => (
       <Column style={{ display: "flex", flexDirection: "column" }}>
-        <ImgClass
+        <ResponsiveImage
           className="image--lazy"
           src={lazySrc}
           alt={alt}
@@ -65,7 +36,7 @@ const LazyImageExample = ({ src, alt, height, width, style }) => (
   </LazyLoader>
 );
 
-LazyImageExample.propTypes = {
+LazyResponsiveImageExample.propTypes = {
   src: PropTypes.string.isRequired,
   alt: PropTypes.string.isRequired,
   height: PropTypes.number.isRequired,
@@ -75,8 +46,8 @@ LazyImageExample.propTypes = {
   )
 };
 
-LazyImageExample.defaultProps = {
+LazyResponsiveImageExample.defaultProps = {
   style: null
 };
 
-export default LazyImageExample;
+export default LazyResponsiveImageExample;

--- a/catalog/pages/images/index.js
+++ b/catalog/pages/images/index.js
@@ -3,7 +3,7 @@ import { pageLoader } from "catalog";
 import { ResponsiveImage, StaticImage } from "../../../src/";
 import ThumbnailCircleImage from "../../../src/components/Image/ThumbnailCircle";
 import { Container, Row, Column } from "../../../src/components/Grid";
-import LazyImageExample from "./LazyImageExample";
+import LazyResponsiveImageExample from "./LazyResponsiveImageExample";
 
 export default {
   path: "/images",
@@ -15,7 +15,7 @@ export default {
     Container,
     Row,
     Column,
-    LazyImageExample
+    LazyResponsiveImageExample
   },
   content: pageLoader(() => import("./index.md"))
 };

--- a/catalog/pages/images/index.md
+++ b/catalog/pages/images/index.md
@@ -27,6 +27,10 @@ rows:
     Type: number
     Default: 1
     Notes: Measured in pixels
+  - Prop: imageRef
+    Type: ref
+    Default: "{ current: null }"
+    Notes: React ref to pass to underlying div
   - Prop: children
     Type: node
     Default: null
@@ -118,7 +122,7 @@ rows:
 ### ThumbnailCircleImage Image
 
 ```react
-<ThumbnailCircleImage size={40} src="httpss://placekitten.com/g/512/288" alt="thumbnailCircleImage"/>
+<ThumbnailCircleImage size={40} src="https://placekitten.com/g/512/288" alt="thumbnailCircleImage"/>
 ```
 
 ### LazyLoader
@@ -177,12 +181,12 @@ rows:
     Notes: This argument should be invoked with a value of true when the imageRef is ready to be loaded. For example, you can use an IntersectionObserver to trigger this function once the imageRef enters the user's viewport.
 ```
 
-### Lazy Static Image (1:1)
+### Lazy Responsive Image (1:1)
 
 ```react
 responsive: true
 ---
-<LazyImageExample
+<LazyResponsiveImageExample
     src="https://placekitten.com/g"
     alt="Test Kitten"
     height={400}

--- a/src/components/Gradient/index.js
+++ b/src/components/Gradient/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
@@ -98,27 +98,39 @@ const SpotLightWrapper = styled.div`
   overflow: hidden;
 `;
 
-const Gradient = ({ children, className, stops, deg, ...props }) => {
-  const hasSpotLight = className.includes("gradient--spotlight");
-  const gradientStops = hasSpotLight ? SPOTLIGHT_STOPS : stops;
-  const gradientDeg = hasSpotLight ? SPOTLIGHT_DEG : deg;
-  return (
-    <GradientStyles
-      {...props}
-      stops={gradientStops}
-      deg={gradientDeg}
-      className={className}
-    >
-      {hasSpotLight && (
-        <SpotLightWrapper>
-          <SpotLight />
-          <Angle />
-        </SpotLightWrapper>
-      )}
-      {children}
-    </GradientStyles>
-  );
-};
+class Gradient extends PureComponent {
+  render() {
+    const {
+      children,
+      className,
+      stops,
+      deg,
+      gradientRef,
+      ...props
+    } = this.props;
+
+    const hasSpotLight = className.includes("gradient--spotlight");
+    const gradientStops = hasSpotLight ? SPOTLIGHT_STOPS : stops;
+    const gradientDeg = hasSpotLight ? SPOTLIGHT_DEG : deg;
+    return (
+      <GradientStyles
+        {...props}
+        stops={gradientStops}
+        deg={gradientDeg}
+        className={className}
+        ref={gradientRef}
+      >
+        {hasSpotLight && (
+          <SpotLightWrapper>
+            <SpotLight />
+            <Angle />
+          </SpotLightWrapper>
+        )}
+        {children}
+      </GradientStyles>
+    );
+  }
+}
 
 Gradient.propTypes = {
   children: PropTypes.node,
@@ -128,7 +140,10 @@ Gradient.propTypes = {
     medium: PropTypes.string.isRequired,
     large: PropTypes.string.isRequired
   }),
-  stops: PropTypes.arrayOf(PropTypes.string)
+  stops: PropTypes.arrayOf(PropTypes.string),
+  backgroundImageRef: PropTypes.shape({
+    current: PropTypes.element
+  })
 };
 
 Gradient.defaultProps = {
@@ -139,7 +154,8 @@ Gradient.defaultProps = {
     medium: "80deg",
     large: "81deg"
   },
-  stops: [colors.defaultGradient.from, colors.defaultGradient.to]
+  stops: [colors.defaultGradient.from, colors.defaultGradient.to],
+  backgroundImageRef: { current: null }
 };
 
 export default Gradient;

--- a/src/components/Header/WithImage.js
+++ b/src/components/Header/WithImage.js
@@ -58,6 +58,7 @@ const ImageHeader = ({
 }) => {
   const {
     style: backgroundImageStyle,
+    ref: backgroundImageRef,
     ...otherBackgroundImageProps
   } = backgroundImageProps;
   return (
@@ -68,6 +69,7 @@ const ImageHeader = ({
             ...(backgroundImageStyle || {}),
             backgroundImage: `url(${backgroundImage})`
           }}
+          gradientRef={backgroundImageRef}
           {...otherBackgroundImageProps}
           className={classNames({
             "gradient--overlay": !withSpotLight && withOverlay,

--- a/src/components/Image/Responsive.js
+++ b/src/components/Image/Responsive.js
@@ -1,24 +1,38 @@
-import React from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 
 import StyledResponsiveImage from "./Responsive.styles";
 import StyledImageSeo from "./Seo.styles";
 
-const ResponsiveImage = ({
-  loader,
-  src,
-  alt,
-  height,
-  width,
-  children,
-  ...props
-}) =>
-  loader || (
-    <StyledResponsiveImage image={src} height={height} width={width} {...props}>
-      <StyledImageSeo src={src} alt={alt} height={height} width={width} />
-      {children}
-    </StyledResponsiveImage>
-  );
+class ResponsiveImage extends PureComponent {
+  render() {
+    const {
+      loader,
+      src,
+      alt,
+      height,
+      width,
+      children,
+      imageRef,
+      ...rest
+    } = this.props;
+
+    return (
+      loader || (
+        <StyledResponsiveImage
+          image={src}
+          height={height}
+          width={width}
+          ref={imageRef}
+          {...rest}
+        >
+          <StyledImageSeo src={src} alt={alt} height={height} width={width} />
+          {children}
+        </StyledResponsiveImage>
+      )
+    );
+  }
+}
 
 ResponsiveImage.propTypes = {
   loader: PropTypes.node,
@@ -26,7 +40,10 @@ ResponsiveImage.propTypes = {
   alt: PropTypes.string,
   height: PropTypes.number,
   width: PropTypes.number,
-  children: PropTypes.node
+  children: PropTypes.node,
+  imageRef: PropTypes.shape({
+    current: PropTypes.element
+  })
 };
 
 ResponsiveImage.defaultProps = {
@@ -35,7 +52,8 @@ ResponsiveImage.defaultProps = {
   alt: "",
   height: 1,
   width: 1,
-  children: null
+  children: null,
+  imageRef: { current: null }
 };
 
 export default ResponsiveImage;

--- a/src/components/Image/Static.js
+++ b/src/components/Image/Static.js
@@ -1,25 +1,35 @@
-import React from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 
 import StyledStaticImage from "./Static.styles";
 
-const StaticImage = ({ loader, src, alt, height, width, ...props }) =>
-  loader || (
-    <StyledStaticImage
-      src={src}
-      alt={alt}
-      height={height}
-      width={width}
-      {...props}
-    />
-  );
+class StaticImage extends PureComponent {
+  render() {
+    const { loader, src, alt, height, width, imageRef, ...props } = this.props;
+    return (
+      loader || (
+        <StyledStaticImage
+          src={src}
+          alt={alt}
+          height={height}
+          width={width}
+          ref={imageRef}
+          {...props}
+        />
+      )
+    );
+  }
+}
 
 StaticImage.propTypes = {
   loader: PropTypes.node,
   src: PropTypes.string,
   alt: PropTypes.string,
   height: PropTypes.number,
-  width: PropTypes.number
+  width: PropTypes.number,
+  imageRef: PropTypes.shape({
+    current: PropTypes.element
+  })
 };
 
 StaticImage.defaultProps = {
@@ -27,7 +37,8 @@ StaticImage.defaultProps = {
   src: "",
   alt: "",
   height: 1,
-  width: 1
+  width: 1,
+  imageRef: { current: null }
 };
 
 export default StaticImage;

--- a/src/components/LazyLoader/__mocks__/utils.mocks.js
+++ b/src/components/LazyLoader/__mocks__/utils.mocks.js
@@ -1,10 +1,39 @@
-import React from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { LazyLoader, LazyLoaderProvider, LazyLoaderConsumer } from "../";
-import {
-  ImgClass,
-  resizeFn as testResizeFn
-} from "../../../../catalog/pages/images/LazyImageExample";
+
+export const testResizeFn = ({ src, width, height }) =>
+  `${src}/${width}/${height}`;
+
+export class ImgClass extends Component {
+  static propTypes = {
+    src: PropTypes.string.isRequired,
+    alt: PropTypes.string.isRequired,
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+    style: PropTypes.objectOf(PropTypes.string),
+    imageRef: PropTypes.shape({}).isRequired
+  };
+
+  static defaultProps = {
+    style: {}
+  };
+
+  render() {
+    const { src, alt, height, width, style, imageRef } = this.props;
+    return (
+      <img
+        src={src}
+        alt={alt}
+        height={height}
+        width={width}
+        style={style}
+        ref={imageRef}
+      />
+    );
+  }
+}
 
 export const PROPS = {
   src: "https://placekitten.com/g",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am adding lazy loading support to ResponsiveImage, StaticImage, and HeaderWithImage by converting them to PureComponents due to the need for `ref` access.

<!-- Why are these changes necessary? -->

**Why**: I am making this change to enable us to lazy load image assets displayed by additional components.

<!-- How were these changes implemented? -->

**How**: I am adding lazy loading support to ResponsiveImage, StaticImage, and HeaderWithImage by converting them to PureComponents due to the need for `ref` access.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
