### PR TITLE
fix(LazyLoader): Improve support for non-img elements

### DIFF
--- a/catalog/pages/header/LazyHeaderWithImageExample.js
+++ b/catalog/pages/header/LazyHeaderWithImageExample.js
@@ -18,8 +18,9 @@ const LazyHeaderWithImageExample = ({
     height={height}
     width={width}
     style={backgroundImageProps.style || {}}
+    tag="span"
   >
-    {({ src: lazySrc, style: lazyStyle, imageRef, load }) => (
+    {({ src: lazySrc, style: lazyStyle, imageRef, backgroundRef, load }) => (
       <Fragment>
         <HeaderWithImage
           withUnderlay={withUnderlay}
@@ -28,7 +29,8 @@ const LazyHeaderWithImageExample = ({
           backgroundImage={lazySrc}
           backgroundImageProps={{
             ...backgroundImageProps,
-            ref: imageRef,
+            imageRef,
+            backgroundRef,
             style: { ...lazyStyle, ...(backgroundImageProps.style || {}) }
           }}
         >

--- a/catalog/pages/images/LazyResponsiveImageExample.js
+++ b/catalog/pages/images/LazyResponsiveImageExample.js
@@ -12,8 +12,9 @@ const LazyResponsiveImageExample = ({ src, alt, height, width, style }) => (
     width={width}
     style={style}
     resizeFn={resizeFn}
+    tag="div"
   >
-    {({ src: lazySrc, style: lazyStyle, imageRef, load }) => (
+    {({ src: lazySrc, style: lazyStyle, imageRef, backgroundRef, load }) => (
       <Column style={{ display: "flex", flexDirection: "column" }}>
         <ResponsiveImage
           className="image--lazy"
@@ -23,6 +24,7 @@ const LazyResponsiveImageExample = ({ src, alt, height, width, style }) => (
           width={width}
           style={lazyStyle}
           imageRef={imageRef}
+          backgroundRef={backgroundRef}
         />
         <Button
           variant="standard"

--- a/catalog/pages/images/index.md
+++ b/catalog/pages/images/index.md
@@ -152,12 +152,16 @@ rows:
     Type: Object
     Default: '{}'
     Notes: Optional
+  - Prop: tag
+    Type: string
+    Default: img
+    Notes: Type of the visible element used to display the lazy-loaded asset. If the tag is not an `img`, then the user must pass the imageRef prop to an img element and the backgroundRef to the element referenced by this prop.
   - Prop: resizeFn
     Type: Function({ src, height, width }) => String
     Default: resize function
     Notes: The default resize function appends computed width, height, and fit query parameters depending on the user's device resolution.
   - Prop: children
-    Type: Function({ src, style, imageRef, load }) => Node
+    Type: Function({ src, style, imageRef, backgroundRef, load }) => Node
     Default: ''
     Notes: This function will be invoked with the  LazyLoaderProvider's state, which is provided to the LazyLoaderConsumer.
 ```
@@ -169,13 +173,16 @@ span: 6
 rows:
   - Prop: src
     Type: String
-    Notes: Initially, this argument will be a low res version of the src prop passed to the LazyLoader. Once the load argument is invoked with a value of true, a high res version of the src prop will be computed and assigned to the imageRef. This high res src will be in the correct srcset, src, or backgroundImage format depending on the element type of the imageRef and the user's browser.
+    Notes: Initially, this argument will be a low res version of the src prop passed to the LazyLoader. Once the load argument is invoked with a value of true, a high res version of the src prop will be computed and assigned to the imageRef and/or backgroundRef. This high res src will be in the correct srcset, src, or backgroundImage format depending on the element type of the ref(s) and the user's browser.
   - Prop: style
     Type: Object
-    Notes: Prior to loading, this style argument will be composed of the style prop merged with blur styles. Once the load argument is invoked with a value of true, the filter style attribute will be removed from the imageRef.
+    Notes: Prior to loading, this style argument will be composed of the style prop merged with blur styles. Once the load argument is invoked with a value of true, the filter style attribute will be removed from the imageRef and/or backgroundRef.
   - Prop: imageRef
     Type: Object (Ref)
-    Notes: This argument should be passed to the img or div tag that contains the asset to be lazy loaded.
+    Notes: This argument should be passed to the img tag that contains the asset to be lazy loaded.
+  - Prop: backgroundRef
+    Type: Object (Ref)
+    Notes: Only used when the type of the visible element used to display the lazy-loaded asset is not an `img`. This argument should be passed to the non-img tag that contains the asset to be lazy loaded.
   - Prop: load
     Type: Function
     Notes: This argument should be invoked with a value of true when the imageRef is ready to be loaded. For example, you can use an IntersectionObserver to trigger this function once the imageRef enters the user's viewport.

--- a/src/components/Drawer/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Drawer/__tests__/__snapshots__/index.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Drawer renders default drawer 1`] = `
     className="bwUIrh"
   >
     <span
-      className="gradient--spotlight kjjHxp"
+      className="gradient--spotlight jUSRpb"
       style={
         Object {
           "height": "60px",
@@ -16,8 +16,9 @@ exports[`Drawer renders default drawer 1`] = `
         }
       }
     >
+      
       <div
-        className="gmvlAd"
+        className="nBCnm"
       >
         <svg
           className="czenYD"
@@ -159,10 +160,10 @@ exports[`Drawer renders default drawer 1`] = `
           type="button"
         >
           <span
-            className="hamburger hamburger--closed bGGLlW"
+            className="hamburger hamburger--closed hjDmZH"
           >
             <span
-              className="jmwKIU"
+              className="kpXvGB"
             />
           </span>
         </button>
@@ -180,7 +181,7 @@ exports[`Drawer renders header elements 1`] = `
     className="bwUIrh"
   >
     <span
-      className="gradient--spotlight kjjHxp"
+      className="gradient--spotlight jUSRpb"
       style={
         Object {
           "height": "60px",
@@ -188,8 +189,9 @@ exports[`Drawer renders header elements 1`] = `
         }
       }
     >
+      
       <div
-        className="gmvlAd"
+        className="nBCnm"
       >
         <svg
           className="czenYD"
@@ -335,10 +337,10 @@ exports[`Drawer renders header elements 1`] = `
           type="button"
         >
           <span
-            className="hamburger hamburger--closed bGGLlW"
+            className="hamburger hamburger--closed hjDmZH"
           >
             <span
-              className="jmwKIU"
+              className="kpXvGB"
             />
           </span>
         </button>
@@ -359,7 +361,7 @@ exports[`Drawer renders multiple child elements 1`] = `
     className="bwUIrh"
   >
     <span
-      className="gradient--spotlight kjjHxp"
+      className="gradient--spotlight jUSRpb"
       style={
         Object {
           "height": "60px",
@@ -367,8 +369,9 @@ exports[`Drawer renders multiple child elements 1`] = `
         }
       }
     >
+      
       <div
-        className="gmvlAd"
+        className="nBCnm"
       >
         <svg
           className="czenYD"
@@ -510,10 +513,10 @@ exports[`Drawer renders multiple child elements 1`] = `
           type="button"
         >
           <span
-            className="hamburger hamburger--closed bGGLlW"
+            className="hamburger hamburger--closed hjDmZH"
           >
             <span
-              className="jmwKIU"
+              className="kpXvGB"
             />
           </span>
         </button>
@@ -540,7 +543,7 @@ exports[`Drawer renders string header header 1`] = `
     className="bwUIrh"
   >
     <span
-      className="gradient--spotlight kjjHxp"
+      className="gradient--spotlight jUSRpb"
       style={
         Object {
           "height": "60px",
@@ -548,8 +551,9 @@ exports[`Drawer renders string header header 1`] = `
         }
       }
     >
+      
       <div
-        className="gmvlAd"
+        className="nBCnm"
       >
         <svg
           className="czenYD"
@@ -686,7 +690,7 @@ exports[`Drawer renders string header header 1`] = `
       >
         <div>
           <div
-            className="text text--light text--primary ehXhKz"
+            className="text text--light text--primary eEHYYC"
             disabled={false}
             size={
               Object {
@@ -705,10 +709,10 @@ exports[`Drawer renders string header header 1`] = `
           type="button"
         >
           <span
-            className="hamburger hamburger--closed bGGLlW"
+            className="hamburger hamburger--closed hjDmZH"
           >
             <span
-              className="jmwKIU"
+              className="kpXvGB"
             />
           </span>
         </button>

--- a/src/components/Gradient/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Gradient/__tests__/__snapshots__/index.spec.js.snap
@@ -2,16 +2,19 @@
 
 exports[`Gradient renders default 1`] = `
 <span
-  className="yROTA"
-/>
+  className="evdfwO"
+>
+  
+</span>
 `;
 
 exports[`Gradient renders with spotlight elements 1`] = `
 <span
-  className="gradient--spotlight nuydk"
+  className="gradient--spotlight gmyyDy"
 >
+  
   <div
-    className="bvFcCn"
+    className="chqBEH"
   >
     <svg
       className="jNNrhE"

--- a/src/components/Gradient/index.js
+++ b/src/components/Gradient/index.js
@@ -6,6 +6,7 @@ import colors from "../../theme/colors";
 import { mediumAndUp, largeAndUp } from "../../theme/mediaQueries";
 import SpotLight from "./SpotLight";
 import Angle from "./Angle";
+import StyledImageSeo from "../Image/Seo.styles";
 
 const SPOTLIGHT_STOPS = [
   "rgb(0, 45, 161)",
@@ -101,11 +102,13 @@ const SpotLightWrapper = styled.div`
 class Gradient extends PureComponent {
   render() {
     const {
+      src,
       children,
       className,
       stops,
       deg,
-      gradientRef,
+      imageRef,
+      backgroundRef,
       ...props
     } = this.props;
 
@@ -118,8 +121,9 @@ class Gradient extends PureComponent {
         stops={gradientStops}
         deg={gradientDeg}
         className={className}
-        ref={gradientRef}
+        ref={backgroundRef}
       >
+        {src && imageRef && <StyledImageSeo src={src} ref={imageRef} />}
         {hasSpotLight && (
           <SpotLightWrapper>
             <SpotLight />
@@ -141,9 +145,13 @@ Gradient.propTypes = {
     large: PropTypes.string.isRequired
   }),
   stops: PropTypes.arrayOf(PropTypes.string),
-  backgroundImageRef: PropTypes.shape({
-    current: PropTypes.element
-  })
+  imageRef: PropTypes.shape({
+    current: PropTypes.object
+  }),
+  backgroundRef: PropTypes.shape({
+    current: PropTypes.object
+  }),
+  src: PropTypes.string
 };
 
 Gradient.defaultProps = {
@@ -155,7 +163,9 @@ Gradient.defaultProps = {
     large: "81deg"
   },
   stops: [colors.defaultGradient.from, colors.defaultGradient.to],
-  backgroundImageRef: { current: null }
+  imageRef: { current: null },
+  backgroundRef: { current: null },
+  src: ""
 };
 
 export default Gradient;

--- a/src/components/Header/WithImage.js
+++ b/src/components/Header/WithImage.js
@@ -58,7 +58,8 @@ const ImageHeader = ({
 }) => {
   const {
     style: backgroundImageStyle,
-    ref: backgroundImageRef,
+    imageRef,
+    backgroundRef,
     ...otherBackgroundImageProps
   } = backgroundImageProps;
   return (
@@ -69,7 +70,9 @@ const ImageHeader = ({
             ...(backgroundImageStyle || {}),
             backgroundImage: `url(${backgroundImage})`
           }}
-          gradientRef={backgroundImageRef}
+          src={backgroundImage}
+          imageRef={imageRef}
+          backgroundRef={backgroundRef}
           {...otherBackgroundImageProps}
           className={classNames({
             "gradient--overlay": !withSpotLight && withOverlay,

--- a/src/components/Header/__tests__/__snapshots__/WithImage.spec.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/WithImage.spec.js.snap
@@ -3,29 +3,34 @@
 exports[`WithImage renders header background image 1`] = `
 <header
   aria-level="1"
-  className="gQgvQJ"
+  className="hspOjD"
   role="heading"
 >
   <span
     aria-hidden={true}
-    className="gFBHoc yROTA"
+    className="lblvod evdfwO"
     style={
       Object {
         "backgroundImage": "url(https://placekitten.com/g/2/2)",
       }
     }
-  />
+  >
+    <img
+      className="image image--seo image--hidden fERDWn"
+      src="https://placekitten.com/g/2/2"
+    />
+  </span>
   <div
-    className="hhJOJe"
+    className="fEnjoq"
   >
     <div
-      className="gQIonf"
+      className="DtEVY"
     >
       <div
-        className="kesrzW"
+        className="cIOZtk"
       >
         <div
-          className="fAOYTB"
+          className="zVHGu"
         >
           <img
             alt="place holder"
@@ -41,29 +46,34 @@ exports[`WithImage renders header background image 1`] = `
 exports[`WithImage renders header background image correctly when a withOverlay prop equaling true is passed 1`] = `
 <header
   aria-level="1"
-  className="gQgvQJ"
+  className="hspOjD"
   role="heading"
 >
   <span
     aria-hidden={true}
-    className="gradient--overlay gFBHoc yROTA"
+    className="gradient--overlay lblvod evdfwO"
     style={
       Object {
         "backgroundImage": "url(https://placekitten.com/g/2/2)",
       }
     }
-  />
+  >
+    <img
+      className="image image--seo image--hidden fERDWn"
+      src="https://placekitten.com/g/2/2"
+    />
+  </span>
   <div
-    className="hhJOJe"
+    className="fEnjoq"
   >
     <div
-      className="gQIonf"
+      className="DtEVY"
     >
       <div
-        className="kesrzW"
+        className="cIOZtk"
       >
         <div
-          className="fAOYTB"
+          className="zVHGu"
         >
           <img
             alt="place holder"
@@ -79,29 +89,34 @@ exports[`WithImage renders header background image correctly when a withOverlay 
 exports[`WithImage renders header background image correctly when a withUnderlay prop equaling true is passed 1`] = `
 <header
   aria-level="1"
-  className="gQgvQJ"
+  className="hspOjD"
   role="heading"
 >
   <span
     aria-hidden={true}
-    className="gradient--underlay gFBHoc yROTA"
+    className="gradient--underlay lblvod evdfwO"
     style={
       Object {
         "backgroundImage": "url(https://placekitten.com/g/2/2)",
       }
     }
-  />
+  >
+    <img
+      className="image image--seo image--hidden fERDWn"
+      src="https://placekitten.com/g/2/2"
+    />
+  </span>
   <div
-    className="hhJOJe"
+    className="fEnjoq"
   >
     <div
-      className="gQIonf"
+      className="DtEVY"
     >
       <div
-        className="kesrzW"
+        className="cIOZtk"
       >
         <div
-          className="fAOYTB"
+          className="zVHGu"
         >
           <img
             alt="place holder"
@@ -117,23 +132,25 @@ exports[`WithImage renders header background image correctly when a withUnderlay
 exports[`WithImage renders header with image 1`] = `
 <header
   aria-level="1"
-  className="gQgvQJ"
+  className="hspOjD"
   role="heading"
 >
   <span
-    className="iGVDnG yROTA"
-  />
+    className="gEDJRt evdfwO"
+  >
+    
+  </span>
   <div
-    className="hhJOJe"
+    className="fEnjoq"
   >
     <div
-      className="gQIonf"
+      className="DtEVY"
     >
       <div
-        className="kesrzW"
+        className="cIOZtk"
       >
         <div
-          className="fAOYTB"
+          className="zVHGu"
         >
           <img
             alt="place holder"

--- a/src/components/Header/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/index.spec.js.snap
@@ -3,21 +3,22 @@
 exports[`Header renders with custom level 1`] = `
 <header
   aria-level="1"
-  className="hXMYMY"
+  className="eQlQti"
   role="heading"
 >
   <span
-    className="dSCYBL yROTA"
+    className="icuDWf evdfwO"
     style={Object {}}
   >
+    
     <div
-      className="zaQxq"
+      className="hhJOJe"
     >
       <div
-        className="kFBBeh"
+        className="bHZSLS"
       >
         <h1
-          className="icfhLg"
+          className="femmpc"
           color="blue"
           size={
             Object {
@@ -28,13 +29,13 @@ exports[`Header renders with custom level 1`] = `
           }
         >
           <span
-            className="gzlGrX"
+            className="laAajU"
           >
             Generic
           </span>
            
           <span
-            className="beMIhb"
+            className="jlRdIN"
           >
             Header
           </span>
@@ -48,21 +49,22 @@ exports[`Header renders with custom level 1`] = `
 exports[`Header renders with default 1`] = `
 <header
   aria-level="1"
-  className="hXMYMY"
+  className="eQlQti"
   role="heading"
 >
   <span
-    className="dSCYBL yROTA"
+    className="icuDWf evdfwO"
     style={Object {}}
   >
+    
     <div
-      className="zaQxq"
+      className="hhJOJe"
     >
       <div
-        className="kFBBeh"
+        className="bHZSLS"
       >
         <h2
-          className="jZEkVf"
+          className="djzKum"
           size={
             Object {
               "large": "bronto",
@@ -72,13 +74,13 @@ exports[`Header renders with default 1`] = `
           }
         >
           <span
-            className="gzlGrX"
+            className="laAajU"
           >
             Generic
           </span>
            
           <span
-            className="beMIhb"
+            className="jlRdIN"
           >
             Header
           </span>
@@ -92,21 +94,22 @@ exports[`Header renders with default 1`] = `
 exports[`Header renders withOverlay 1`] = `
 <header
   aria-level="1"
-  className="hXMYMY"
+  className="eQlQti"
   role="heading"
 >
   <span
-    className="gradient--overlay dSCYBL yROTA"
+    className="gradient--overlay icuDWf evdfwO"
     style={Object {}}
   >
+    
     <div
-      className="zaQxq"
+      className="hhJOJe"
     >
       <div
-        className="kFBBeh"
+        className="bHZSLS"
       >
         <h2
-          className="jZEkVf"
+          className="djzKum"
           size={
             Object {
               "large": "bronto",
@@ -116,13 +119,13 @@ exports[`Header renders withOverlay 1`] = `
           }
         >
           <span
-            className="gzlGrX"
+            className="laAajU"
           >
             Generic
           </span>
            
           <span
-            className="beMIhb"
+            className="jlRdIN"
           >
             Header
           </span>

--- a/src/components/Image/Responsive.js
+++ b/src/components/Image/Responsive.js
@@ -14,6 +14,7 @@ class ResponsiveImage extends PureComponent {
       width,
       children,
       imageRef,
+      backgroundRef,
       ...rest
     } = this.props;
 
@@ -23,10 +24,16 @@ class ResponsiveImage extends PureComponent {
           image={src}
           height={height}
           width={width}
-          ref={imageRef}
+          ref={backgroundRef}
           {...rest}
         >
-          <StyledImageSeo src={src} alt={alt} height={height} width={width} />
+          <StyledImageSeo
+            src={src}
+            alt={alt}
+            height={height}
+            width={width}
+            ref={imageRef}
+          />
           {children}
         </StyledResponsiveImage>
       )
@@ -42,7 +49,10 @@ ResponsiveImage.propTypes = {
   width: PropTypes.number,
   children: PropTypes.node,
   imageRef: PropTypes.shape({
-    current: PropTypes.element
+    current: PropTypes.object
+  }),
+  backgroundRef: PropTypes.shape({
+    current: PropTypes.object
   })
 };
 
@@ -53,7 +63,8 @@ ResponsiveImage.defaultProps = {
   height: 1,
   width: 1,
   children: null,
-  imageRef: { current: null }
+  imageRef: { current: null },
+  backgroundRef: { current: null }
 };
 
 export default ResponsiveImage;

--- a/src/components/Image/Static.js
+++ b/src/components/Image/Static.js
@@ -28,7 +28,7 @@ StaticImage.propTypes = {
   height: PropTypes.number,
   width: PropTypes.number,
   imageRef: PropTypes.shape({
-    current: PropTypes.element
+    current: PropTypes.object
   })
 };
 

--- a/src/components/LazyLoader/__mocks__/utils.mocks.js
+++ b/src/components/LazyLoader/__mocks__/utils.mocks.js
@@ -53,11 +53,32 @@ export const renderComponent = (props = {}, renderFn, ref) =>
     ref
   );
 
-export const renderProviderComponent = (props = {}, renderFn, ref) =>
+export const renderProviderComponentWithImg = (props = {}, renderFn, ref) =>
   renderFn(
     <LazyLoaderProvider {...mergeProps(props)}>
       <LazyLoaderConsumer>
         {val => <ImgClass key="test" {...PROPS} {...val} />}
+      </LazyLoaderConsumer>
+    </LazyLoaderProvider>,
+    ref
+  );
+
+export const renderProviderComponentWithImgAndDiv = (
+  props = {},
+  renderFn,
+  ref
+) =>
+  renderFn(
+    <LazyLoaderProvider {...mergeProps(props)}>
+      <LazyLoaderConsumer>
+        {val => {
+          const { imageRef, backgroundRef, ...rest } = val;
+          return (
+            <div {...rest} ref={backgroundRef}>
+              <ImgClass key="test" {...PROPS} {...rest} imageRef={imageRef} />
+            </div>
+          );
+        }}
       </LazyLoaderConsumer>
     </LazyLoaderProvider>,
     ref
@@ -74,6 +95,13 @@ export const createImgWithSrc = () => ({
   style: {}
 });
 
-export const createDiv = () => ({
-  style: {}
-});
+export const createElemByType = elem =>
+  elem.type === "img"
+    ? {
+        srcset: "",
+        src: "",
+        style: {}
+      }
+    : {
+        style: {}
+      };

--- a/src/components/LazyLoader/__tests__/__snapshots__/Provider.spec.js.snap
+++ b/src/components/LazyLoader/__tests__/__snapshots__/Provider.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`LazyLoaderProvider should invoke componentDidUpdate and not setState when src equals prevSrc 1`] = `
 Object {
+  "backgroundRef": null,
   "imageRef": Object {
     "current": Object {
       "src": "",
@@ -33,18 +34,6 @@ exports[`LazyLoaderProvider should invoke componentDidUpdate and set state to a 
 />
 `;
 
-exports[`LazyLoaderProvider should load a high res version of the image passed when the imageRef supports a backgroundImage style 1`] = `
-Object {
-  "current": Object {
-    "onload": [MockFunction],
-    "style": Object {
-      "backgroundImage": "url(https://placekitten.com/g/400/400)",
-      "filter": "none",
-    },
-  },
-}
-`;
-
 exports[`LazyLoaderProvider should load a high res version of the image passed when the imageRef supports src 1`] = `
 Object {
   "current": Object {
@@ -66,6 +55,29 @@ Object {
 }
 `;
 
+exports[`LazyLoaderProvider should load a high res version of the image passed when the tag equals div, imageRef supports src or srcset, and backgroundRef supports a backgroundImage style 1`] = `
+Object {
+  "backgroundRef": Object {
+    "current": Object {
+      "style": Object {
+        "backgroundImage": "url(https://placekitten.com/g/400/400)",
+        "filter": "none",
+      },
+    },
+  },
+  "imageRef": Object {
+    "current": Object {
+      "onload": [Function],
+      "src": "https://placekitten.com/g/400/400",
+      "srcset": "",
+      "style": Object {
+        "filter": "none",
+      },
+    },
+  },
+}
+`;
+
 exports[`LazyLoaderProvider should load a low res, blurred version of the image passed prior to loading 1`] = `
 <img
   alt="Test Kitten"
@@ -79,6 +91,32 @@ exports[`LazyLoaderProvider should load a low res, blurred version of the image 
   }
   width={400}
 />
+`;
+
+exports[`LazyLoaderProvider should low res, blurred version of the image passed prior to loading when the tag equals div, imageRef supports src or srcset, and backgroundRef supports a backgroundImage style 1`] = `
+<div
+  load={[Function]}
+  src="https://placekitten.com/g/40/40"
+  style={
+    Object {
+      "filter": "blur(10px)",
+      "transition": "80ms filter linear",
+    }
+  }
+>
+  <img
+    alt="Test Kitten"
+    height={400}
+    src="https://placekitten.com/g/40/40"
+    style={
+      Object {
+        "filter": "blur(10px)",
+        "transition": "80ms filter linear",
+      }
+    }
+    width={400}
+  />
+</div>
 `;
 
 exports[`LazyLoaderProvider should not load a high res version of the image passed when the load function is invoked with a value of false 1`] = `

--- a/src/components/LazyLoader/__tests__/helpers.spec.js
+++ b/src/components/LazyLoader/__tests__/helpers.spec.js
@@ -208,12 +208,8 @@ describe("getSrcAttr", () => {
     expect(getSrcAttr(refWithSrcSet)).toEqual("srcset");
   });
 
-  it("should return src when supported by the element", () => {
-    expect(getSrcAttr(refWithSrc)).toEqual("src");
-  });
-
-  it("should return backgroundImage by default", () => {
-    expect(getSrcAttr({})).toEqual("backgroundImage");
+  it("should return src by default", () => {
+    expect(getSrcAttr({})).toEqual("src");
   });
 });
 

--- a/src/components/LazyLoader/helpers.js
+++ b/src/components/LazyLoader/helpers.js
@@ -61,8 +61,7 @@ export const getTargetDensity = (targetDensity, devicePixelRatios) => {
 
 export const getSrcAttr = ref => {
   if ("srcset" in ref) return "srcset";
-  if ("src" in ref) return "src";
-  return "backgroundImage";
+  return "src";
 };
 
 export const getSrcVariantByAttr = (

--- a/src/components/LazyLoader/index.js
+++ b/src/components/LazyLoader/index.js
@@ -12,7 +12,8 @@ export const LazyLoader = ({
   width,
   style,
   resizeFn,
-  children
+  children,
+  tag
 }) => (
   <LazyLoaderProvider
     src={src}
@@ -20,6 +21,7 @@ export const LazyLoader = ({
     width={width}
     style={style}
     resizeFn={resizeFn}
+    tag={tag}
   >
     <LazyLoaderConsumer>{value => children(value)}</LazyLoaderConsumer>
   </LazyLoaderProvider>
@@ -33,7 +35,8 @@ LazyLoader.propTypes = {
   resizeFn: PropTypes.func,
   style: PropTypes.objectOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-  )
+  ),
+  tag: PropTypes.string
 };
 
 LazyLoader.defaultProps = {
@@ -41,7 +44,8 @@ LazyLoader.defaultProps = {
   width: null,
   height: null,
   resizeFn: resize,
-  style: {}
+  style: {},
+  tag: "img"
 };
 
 export { LazyLoaderProvider, LazyLoaderConsumer };

--- a/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`NavBar renders fixed 1`] = `
 <nav
-  className="nav--fixed kYUOWu"
+  className="nav--fixed cFQQgK"
   role="navigation"
   style={
     Object {
@@ -11,7 +11,7 @@ exports[`NavBar renders fixed 1`] = `
   }
 >
   <div
-    className="fPuwav"
+    className="WTkEJ"
   >
     <button
       className="egAjOF"
@@ -172,7 +172,7 @@ exports[`NavBar renders fixed 1`] = `
 
 exports[`NavBar renders inverted 1`] = `
 <nav
-  className="nav--relative nav--inverted kYUOWu"
+  className="nav--relative nav--inverted cFQQgK"
   role="navigation"
   style={
     Object {
@@ -181,7 +181,7 @@ exports[`NavBar renders inverted 1`] = `
   }
 >
   <div
-    className="fPuwav"
+    className="WTkEJ"
   >
     <button
       className="egAjOF"
@@ -339,7 +339,7 @@ exports[`NavBar renders inverted 1`] = `
 
 exports[`NavBar renders with defaults 1`] = `
 <nav
-  className="nav--relative kYUOWu"
+  className="nav--relative cFQQgK"
   role="navigation"
   style={
     Object {
@@ -348,7 +348,7 @@ exports[`NavBar renders with defaults 1`] = `
   }
 >
   <div
-    className="fPuwav"
+    className="WTkEJ"
   >
     <button
       className="egAjOF"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am adding backgroundRef; for non img-elements, I am adding support to preload assets using img src and then set backgroundImage style.

<!-- Why are these changes necessary? -->

**Why**: I am making this change to ensure the asset is preloaded and present in the browser cache before being applied to a non-img element's backgroundImage style attribute. 

<!-- How were these changes implemented? -->

**How**: I am adding backgroundRef; for non img-elements, I am adding support to preload assets using img src and then set backgroundImage style.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
