### PR TITLE
feat(PopOver): add inline with toggle positioning

### DIFF
--- a/catalog/pages/popover/PopOverDemo.js
+++ b/catalog/pages/popover/PopOverDemo.js
@@ -47,6 +47,8 @@ class PopOverDemo extends React.Component {
 
   render() {
     const { showPopOver, ...position } = this.state;
+    const { inlineWithTarget, noBorders } = this.props;
+
     return (
       <Container ref={this.containerRef}>
         <div
@@ -76,6 +78,8 @@ class PopOverDemo extends React.Component {
           isVisible={showPopOver}
           position={{ ...position }}
           reduceTop={76}
+          inlineWithTarget={inlineWithTarget}
+          noBorders={noBorders}
         >
           Some text to be rendered in the pop over component. Some text to be
           rendered in the pop over component.
@@ -86,11 +90,15 @@ class PopOverDemo extends React.Component {
 }
 
 PopOverDemo.propTypes = {
-  withinContainer: PropTypes.bool
+  withinContainer: PropTypes.bool,
+  inlineWithTarget: PropTypes.bool,
+  noBorders: PropTypes.bool
 };
 
 PopOverDemo.defaultProps = {
-  withinContainer: false
+  withinContainer: false,
+  inlineWithTarget: false,
+  noBorders: false
 };
 
 export default PopOverDemo;

--- a/catalog/pages/popover/index.md
+++ b/catalog/pages/popover/index.md
@@ -15,6 +15,14 @@ rows:
     Type: boolean
     Default: false
     Notes: Show/hide popover
+  - Prop: inlineWithTarget
+    Type: boolean
+    Default: false
+    Notes: Indicates if PopOver should be placed right near toggle
+  - Prop: noBorders
+    Type: boolean
+    Default: false
+    Notes: Hides borders when set in true
   - Prop: reduceTop
     Type: number
     Default: 0
@@ -32,4 +40,11 @@ rows:
 ```react
 ---
 <PopOverDemo withinContainer />
+```
+
+### Inline with target and without borders
+
+```react
+---
+<PopOverDemo withinContainer inlineWithTarget noBorders/>
 ```

--- a/src/components/PopOver/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/PopOver/__tests__/__snapshots__/index.spec.js.snap
@@ -2,12 +2,18 @@
 
 exports[`PopOver should match snapshot 1`] = `
 <div
-  className="fSRmwf"
+  className="dbzfGp"
 />
 `;
 
-exports[`PopOver should match snapshot 2`] = `
+exports[`PopOver should match snapshot when visible 1`] = `
 <div
-  className="hokLBr"
+  className="bqoXdg"
+/>
+`;
+
+exports[`PopOver should match snapshot when visible and without borders 1`] = `
+<div
+  className="fBMBDA"
 />
 `;

--- a/src/components/PopOver/__tests__/index.spec.js
+++ b/src/components/PopOver/__tests__/index.spec.js
@@ -11,8 +11,14 @@ describe("PopOver", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("should match snapshot", () => {
+  it("should match snapshot when visible", () => {
     const tree = renderer.create(<PopOver isVisible />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("should match snapshot when visible and without borders", () => {
+    const tree = renderer.create(<PopOver isVisible noBorders />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -40,7 +46,9 @@ describe("PopOver", () => {
         windowHeight: 400
       };
 
-      expect(PopOver.calculatePosition(position, dimensions, reduce)).toEqual({
+      expect(
+        PopOver.calculatePosition({ position, dimensions, reduce })
+      ).toEqual({
         x: 16,
         y: 20
       });
@@ -64,9 +72,77 @@ describe("PopOver", () => {
         windowHeight: 400
       };
 
-      expect(PopOver.calculatePosition(position, dimensions, reduce)).toEqual({
+      expect(
+        PopOver.calculatePosition({ position, dimensions, reduce })
+      ).toEqual({
         x: 24,
         y: 390
+      });
+    });
+
+    it("should position PopOver near toggle to the right", () => {
+      const position = {
+        elBottom: 510,
+        elTop: 500,
+        elLeft: 30,
+        elWidth: 150,
+        mouseX: 5,
+        offsetTop: 0,
+        clientHeight: 1000,
+        offsetLeft: 0,
+        clientWidth: 1000
+      };
+      const dimensions = {
+        width: 100,
+        windowScroll: 100,
+        height: 100,
+        windowWidth: 1000,
+        windowHeight: 400
+      };
+
+      expect(
+        PopOver.calculatePosition({
+          position,
+          dimensions,
+          reduce,
+          inlineWithTarget: true
+        })
+      ).toEqual({
+        x: 188,
+        y: 500
+      });
+    });
+
+    it("should position PopOver near toggle to the left", () => {
+      const position = {
+        elBottom: 510,
+        elTop: 500,
+        elLeft: 900,
+        elWidth: 150,
+        mouseX: 5,
+        offsetTop: 0,
+        clientHeight: 1000,
+        offsetLeft: 0,
+        clientWidth: 1000
+      };
+      const dimensions = {
+        width: 100,
+        windowScroll: 100,
+        height: 100,
+        windowWidth: 1000,
+        windowHeight: 400
+      };
+
+      expect(
+        PopOver.calculatePosition({
+          position,
+          dimensions,
+          reduce,
+          inlineWithTarget: true
+        })
+      ).toEqual({
+        x: 792,
+        y: 500
       });
     });
   });
@@ -208,7 +284,9 @@ describe("PopOver", () => {
       clientX: 100,
       currentTarget: {
         offsetTop: 20,
-        clientHeight: 1000
+        clientHeight: 1000,
+        offsetLeft: 30,
+        offsetWidth: 150
       }
     };
     const wrapper = {
@@ -221,6 +299,8 @@ describe("PopOver", () => {
       expect(PopOver.getDimensionsFromEvent(event)).toEqual({
         mouseX: 100,
         elTop: 20,
+        elLeft: 30,
+        elWidth: 150,
         elBottom: 1020,
         offsetTop: 0,
         clientHeight: 100000,
@@ -233,6 +313,8 @@ describe("PopOver", () => {
       expect(PopOver.getDimensionsFromEvent(event, wrapper)).toEqual({
         mouseX: 100,
         elTop: 20,
+        elLeft: 30,
+        elWidth: 150,
         elBottom: 1020,
         offsetTop: 50,
         clientHeight: 200,

--- a/src/theme/constants.js
+++ b/src/theme/constants.js
@@ -26,5 +26,7 @@ const constants = {
 export const cardBoxShadow =
   "0 4px 4px 0 rgba(0, 0, 0, 0.06), 0 0 4px 0 rgba(0, 0, 0, 0.12)";
 export const popContainersBoxShadow = "0 4px 4px 0 rgba(0, 0, 0, 0.12)";
+export const popContainersSharpBoxShadow =
+  "0 2px 8px 0 rgba(159, 159, 159, 0.5)";
 
 export default constants;

--- a/src/theme/spacing.js
+++ b/src/theme/spacing.js
@@ -9,6 +9,7 @@ const spacing = {
   giant: "64px",
   colossal: "88px",
   gutters: {
+    tiny: 8,
     small: 16,
     mediumAndUp: 24,
     largeAndUp: 32


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: add possibility to position PopOver near toggle that opens it

<!-- Why are these changes necessary? -->

**Why**: currently PopOver opens too far from toggle 

<!-- How were these changes implemented? -->

**How**: by adding `inlineWithTarget` property. If it's true than position would be calculated in different way

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
**Notes** 
* Added an optional property `noBorders` as in some cases we need to display PopOver without any border.
* Added an additional `popContainersSharpBoxShadow` value and used it in PopOver