### PR TITLE
fix(AdaptiveModal): export xLarge size for Adaptive Modal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,8 @@ export {
 export {
   MODAL_SIZE_SMALL,
   MODAL_SIZE_MEDIUM,
-  MODAL_SIZE_LARGE
+  MODAL_SIZE_LARGE,
+  MODAL_SIZE_XLARGE
 } from "./components/Modal/size";
 export { ModalConsumer, withModal } from "./components/Modal/context";
 export { default as AdaptiveBackdrop } from "./components/Backdrop";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: added MODAL_SIZE_XLARGE to exported constants.

<!-- Why are these changes necessary? -->

**Why**: to have the ability to pass it to Adaptive Modal component.

<!-- How were these changes implemented? -->

**How**: added it to libs exports.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
