### PR TITLE
feat(CalendarView): add highlighting for DayTileItem

### DIFF
--- a/catalog/pages/calendar_view/index.md
+++ b/catalog/pages/calendar_view/index.md
@@ -11,10 +11,6 @@ rows:
     Type: boolean
     Default: '`false`'
     Notes: Determines whether the DayTile container needs a border-radius
-  - Prop: highlighted
-    Type: boolean
-    Default: '`false`'
-    Notes: Determines whether the DayTile container needs to be highlighted
   - Prop: ...props
     Type: any
     Default:
@@ -25,17 +21,17 @@ rows:
 ---
 <Container>
   <Row>
-    <Column medium={3}>
+    <Column medium={4}>
       <Spacing top={{xSmall: "cozy" }} bottom={{xSmall: "cozy" }} style={{ maxWidth: "160px", margin: "auto" }}>
         <DayTile />
       </Spacing>
     </Column>
-    <Column medium={3}>
+    <Column medium={4}>
       <Spacing top={{xSmall: "cozy" }} bottom={{xSmall: "cozy" }} style={{ maxWidth: "160px", margin: "auto" }}>
         <DayTile noBorderRadius />
       </Spacing>
     </Column>
-    <Column medium={3}>
+    <Column medium={4}>
       <Spacing top={{xSmall: "cozy" }} bottom={{xSmall: "cozy" }} style={{ maxWidth: "160px", margin: "auto" }}>
         <DayTile>
           <DayTile.Header>
@@ -52,46 +48,6 @@ rows:
                     Henderson, NV — Sunset Station Outdoor Amphitheater
                   </DayTileItem.Title>
                   <DayTileItem.Label variant="positive">
-                    ON SALE: TUE • JAN 29 • 5 PM
-                  </DayTileItem.Label>
-                </DayTileItem.ContentColumn>
-              </DayTileItem.Content>
-              <DayTileItem.Footer>
-                <DayTileButton.Group>
-                  <DayTileButton href="#">2:00 pm</DayTileButton>
-                  <DayTileButton variant="outline" href="#">6:00 pm</DayTileButton>
-                </DayTileButton.Group>
-                <DayTileMoreButton
-                  role="button"
-                  onClick={() => {
-                    alert('More Button Clicked');
-                  }}
-                >
-                  +4 More
-                </DayTileMoreButton>
-              </DayTileItem.Footer>
-            </DayTileItem>
-          </DayTileItem.Group>
-        </DayTile>
-      </Spacing>
-    </Column>
-    <Column medium={3}>
-      <Spacing top={{xSmall: "cozy" }} bottom={{xSmall: "cozy" }} style={{ maxWidth: "160px", margin: "auto" }}>
-        <DayTile highlighted>
-          <DayTile.Header>
-            <DayTileDate accent>10</DayTileDate>
-          </DayTile.Header>
-          <DayTileItem.Group>
-            <DayTileItem>
-              <DayTileItem.Header>
-                <DayTileOverflowButton aria-label="More Info" onClick={() => alert('Overflow Button Clicked')} />
-              </DayTileItem.Header>
-              <DayTileItem.Content>
-                <DayTileItem.ContentColumn>
-                  <DayTileItem.Title>
-                    Henderson, NV — Sunset Station Outdoor Amphitheater
-                  </DayTileItem.Title>
-                  <DayTileItem.Label variant="positiveDark">
                     ON SALE: TUE • JAN 29 • 5 PM
                   </DayTileItem.Label>
                 </DayTileItem.ContentColumn>
@@ -179,6 +135,10 @@ Use `<DayTileItem.Header />` with `<DayTileOverflowButton />` in order to achiev
 ```table
 span: 6
 rows:
+  - Prop: highlighted
+    Type: boolean
+    Default: '`false`'
+    Notes: Determines whether the DayTileItem needs to be highlighted
   - Prop: ...props
     Type: any
     Default:
@@ -265,7 +225,7 @@ rows:
             <DayTileDate accent>10</DayTileDate>
           </DayTile.Header>
           <DayTileItem.Group>
-            <DayTileItem>
+            <DayTileItem highlighted>
               <DayTileItem.Header>
                 <DayTileOverflowButton aria-label="More Info" onClick={() => alert('Overflow Button Clicked')} />
               </DayTileItem.Header>

--- a/src/components/CalendarView/DayTile.js
+++ b/src/components/CalendarView/DayTile.js
@@ -1,9 +1,18 @@
 import styled from "styled-components";
+import classnames from "classnames";
 
 import { constants } from "../../theme";
 import { getThemeValue } from "../../utils";
 
-const DayTile = styled.div`
+const DAY_TILE_CLASS = "day-tile";
+const DAY_TILE_NO_BORDER_RADIUS_CLASS = `${DAY_TILE_CLASS}--no-border-radius`;
+
+const DayTile = styled.div.attrs({
+  className: ({ noBorderRadius }) =>
+    classnames(DAY_TILE_CLASS, {
+      [DAY_TILE_NO_BORDER_RADIUS_CLASS]: noBorderRadius
+    })
+})`
   position: relative;
   display: flex;
   flex-flow: column nowrap;
@@ -11,12 +20,12 @@ const DayTile = styled.div`
   min-height: 192px;
   border: solid 1px ${getThemeValue("gray04")};
   overflow: hidden;
-  background-color: ${({ highlighted }) =>
-    highlighted
-      ? getThemeValue("primary", "lightBase")
-      : getThemeValue("white", "base")};
-  border-radius: ${({ noBorderRadius }) =>
-    !noBorderRadius ? constants.borderRadius.small : "0"};
+  background-color: ${getThemeValue("white", "base")};
+  border-radius: ${constants.borderRadius.small};
+
+  &.${DAY_TILE_NO_BORDER_RADIUS_CLASS} {
+    border-radius: 0;
+  }
 `;
 
 DayTile.Header = styled.header`

--- a/src/components/CalendarView/DayTileItem.js
+++ b/src/components/CalendarView/DayTileItem.js
@@ -1,5 +1,7 @@
 import React, { Children } from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
+import classnames from "classnames";
 
 import { Text } from "../Text";
 
@@ -7,12 +9,31 @@ import { spacing } from "../../theme";
 
 import { getThemeValue, getLabelTextColor } from "../../utils";
 
-const DayTileItem = styled.article`
+const DAY_TILE_ITEM_CLASS_HIGHLIGHTED = "day-tile-item--highlighted";
+
+const DayTileItem = styled.article.attrs({
+  className: ({ highlighted }) =>
+    classnames({
+      [DAY_TILE_ITEM_CLASS_HIGHLIGHTED]: highlighted
+    })
+})`
   flex: 0 0 auto;
   display: flex;
   flex-flow: column nowrap;
   min-height: 190px;
+
+  &.${DAY_TILE_ITEM_CLASS_HIGHLIGHTED} {
+    background-color: ${getThemeValue("primary", "lightBase")};
+  }
 `;
+
+DayTileItem.propTypes = {
+  highlighted: PropTypes.bool
+};
+
+DayTileItem.defaultProps = {
+  highlighted: false
+};
 
 DayTileItem.Header = styled.header`
   display: flex;
@@ -36,7 +57,7 @@ DayTileItem.Footer = styled.footer`
 `;
 
 DayTileItem.Divider = styled.div`
-  margin: 0 ${spacing.cozy} ${spacing.cozy};
+  margin: ${spacing.slim} ${spacing.cozy};
   border-bottom: solid 1px ${getThemeValue("gray04")};
 `;
 

--- a/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
@@ -11,7 +11,7 @@ exports[`CalendarView should render without errors 1`] = `
 }
 
 <div
-  className="ggGwWQ"
+  className="day-tile GnYRo"
 >
   <header
     className="gVZTwB"
@@ -35,7 +35,7 @@ exports[`CalendarView should render without errors 1`] = `
     </div>
   </header>
   <article
-    className="cSkcyn"
+    className="eJBEmz"
   >
     <header
       className="isAWQW"
@@ -166,10 +166,10 @@ exports[`CalendarView should render without errors 1`] = `
     </footer>
   </article>
   <div
-    className="bmGypZ"
+    className="bJScud"
   />
   <article
-    className="cSkcyn"
+    className="eJBEmz"
   >
     <header
       className="isAWQW"


### PR DESCRIPTION
**What**: Add possibility to highlight DayTileItem. Removed highlighting for DayTile.

**Why**: We need that for cases when we have a group of Items and some of those should be highlighted. There's no need to highlight DayTile when we can do same with DayTileItem.

**How**: By adding `highlighted` prop to DayTileItem

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

**Note**: also I updated margin of DayTileItem.Divider 'cause it becomes hard to see it when DayTileItem is highlighted.
