### PR TITLE
Using right name for AdaptiveModal in catalog

### DIFF
--- a/catalog/index.js
+++ b/catalog/index.js
@@ -16,7 +16,7 @@ import navBar from "./pages/nav_bar";
 import bottomSheet from "./pages/bottom_sheet";
 import images from "./pages/images";
 import breadcrumbs from "./pages/breadcrumbs";
-import modal from "./pages/modal";
+import adaptiveModal from "./pages/adaptive_modal";
 import calendarView from "./pages/calendar_view";
 import popover from "./pages/popover";
 import tooltip from "./pages/tooltip";
@@ -44,7 +44,7 @@ const pages = [
   navBar,
   breadcrumbs,
   bottomSheet,
-  modal,
+  adaptiveModal,
   calendarView,
   popover,
   tooltip,

--- a/catalog/pages/adaptive_modal/index.js
+++ b/catalog/pages/adaptive_modal/index.js
@@ -1,13 +1,13 @@
 import { pageLoader } from "catalog";
-import Modal from "../../../src/components/Modal";
+import AdaptiveModal from "../../../src/components/Modal";
 import DeviceSizeProvider from "../../../src/components/DeviceSize/Provider";
 import { Button } from "../../../src/components/Button";
 
 export default {
   path: "modal",
-  title: "Modal",
+  title: "Adaptive Modal",
   imports: {
-    Modal,
+    AdaptiveModal,
     Button,
     DeviceSizeProvider
   },

--- a/catalog/pages/adaptive_modal/index.md
+++ b/catalog/pages/adaptive_modal/index.md
@@ -1,4 +1,4 @@
-### Modal
+### AdaptiveModal
 
 ```table
 span: 6
@@ -44,30 +44,30 @@ rows:
     Notes: Optional. Callback is fired when the user scrolls modal's content
 ```
 
-### Default Modal with default action bars
+### Default AdaptiveModal with default action bars
 
 ```react
 responsive: true
 ---
 <DeviceSizeProvider>
-    <Modal
+    <AdaptiveModal
         onRequestClose={() => console.log('You shall not pass!')}
     >
         {Array(1000).fill('').map((_, i) => <div key={i}>Text Row {i}</div>)}
-    </Modal>
+    </AdaptiveModal>
 </DeviceSizeProvider>
 ```
 
-### Modal with custom action bars and long content
+### AdaptiveModal with custom action bars and long content
 
 ```react
 responsive: true
 ---
 <DeviceSizeProvider>
-    <Modal
+    <AdaptiveModal
         actionBar={
             <div style={{ backgroundColor: 'white' }}>
-                <h1 style={{ padding: 0, margin: 0, fontSize: 16 }}>Demo Modal</h1>
+                <h1 style={{ padding: 0, margin: 0, fontSize: 16 }}>Demo AdaptiveModal</h1>
             </div>
         }
         bottomActionBar={
@@ -77,20 +77,20 @@ responsive: true
         }
     >
         {Array(1000).fill('').map((_, i) => <div key={i}>Text Row {i}</div>)}
-    </Modal>
+    </AdaptiveModal>
 </DeviceSizeProvider>
 ```
 
-### Modal with custom action bars and short content
+### AdaptiveModal with custom action bars and short content
 
 ```react
 responsive: true
 ---
 <DeviceSizeProvider>
-    <Modal
+    <AdaptiveModal
         actionBar={
             <div style={{ backgroundColor: 'white' }}>
-                <h1 style={{ padding: 0, margin: 0, fontSize: 16 }}>Demo Modal</h1>
+                <h1 style={{ padding: 0, margin: 0, fontSize: 16 }}>Demo AdaptiveModal</h1>
             </div>
         }
         bottomActionBar={
@@ -100,6 +100,6 @@ responsive: true
         }
     >
         {Array(8).fill('').map((_, i) => <div key={i}>Text Row {i}</div>)}
-    </Modal>
+    </AdaptiveModal>
 </DeviceSizeProvider>
 ```


### PR DESCRIPTION
Rename `Modal` (which export is used in `List` component) to `AdaptiveModal` (real modal window) in `catalog`

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

