### PR TITLE
fix(ListRow): Remove z-index updates from ContentColumn

### DIFF
--- a/src/components/List/RowContent.js
+++ b/src/components/List/RowContent.js
@@ -112,7 +112,6 @@ const ContentColumn = styled(Column)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  z-index: 2;
   
   &.column__content--expanded {
     transition: opacity 0.1s ${constants.easing.easeInQuad};
@@ -131,10 +130,6 @@ const ContentColumn = styled(Column)`
     width: 100%;
     height: 100%;
     text-align: center;
-
-    &.column__content--expanded {
-      z-index: 1;
-    }
 
     ${mediumAndUp`
       padding: 0 calc(${spacing.moderate} + ${spacing.gutters.mediumAndUp /

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -68,7 +68,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -77,7 +77,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -86,7 +86,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -481,7 +481,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -490,7 +490,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -499,7 +499,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -894,7 +894,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -903,7 +903,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -912,7 +912,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -1307,7 +1307,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -1316,7 +1316,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -1325,7 +1325,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -1728,7 +1728,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -1737,7 +1737,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -1746,7 +1746,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2141,7 +2141,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2150,7 +2150,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2159,7 +2159,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2554,7 +2554,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2563,7 +2563,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2572,7 +2572,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2967,7 +2967,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2976,7 +2976,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -2985,7 +2985,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -3388,7 +3388,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -3397,7 +3397,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -3406,7 +3406,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -3801,7 +3801,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -3810,7 +3810,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -3819,7 +3819,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -4214,7 +4214,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -4223,7 +4223,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -4232,7 +4232,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -4627,7 +4627,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -4636,7 +4636,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -4645,7 +4645,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5048,7 +5048,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5057,7 +5057,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5066,7 +5066,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5461,7 +5461,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5470,7 +5470,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5479,7 +5479,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5874,7 +5874,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5883,7 +5883,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -5892,7 +5892,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6287,7 +6287,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6296,7 +6296,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6305,7 +6305,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6709,7 +6709,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6718,7 +6718,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6727,7 +6727,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6961,7 +6961,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6970,7 +6970,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -6979,7 +6979,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -7374,7 +7374,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -7383,7 +7383,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -7392,7 +7392,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -7787,7 +7787,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -7796,7 +7796,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -7805,7 +7805,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -8200,7 +8200,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -8209,7 +8209,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -8218,7 +8218,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -8620,7 +8620,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -8629,7 +8629,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -8638,7 +8638,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9033,7 +9033,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9042,7 +9042,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9051,7 +9051,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9446,7 +9446,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9455,7 +9455,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9464,7 +9464,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9859,7 +9859,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9868,7 +9868,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -9877,7 +9877,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -10279,7 +10279,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -10288,7 +10288,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -10297,7 +10297,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -10724,7 +10724,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -10733,7 +10733,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -10742,7 +10742,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -11169,7 +11169,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -11178,7 +11178,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -11187,7 +11187,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -11614,7 +11614,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -11623,7 +11623,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -11632,7 +11632,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12066,7 +12066,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12075,7 +12075,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12084,7 +12084,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12479,7 +12479,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12488,7 +12488,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12497,7 +12497,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12892,7 +12892,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12901,7 +12901,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -12910,7 +12910,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -13305,7 +13305,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -13314,7 +13314,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -13323,7 +13323,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -13726,7 +13726,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -13735,7 +13735,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--expanded sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--expanded sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -13744,7 +13744,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--collapsed sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14139,7 +14139,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14148,7 +14148,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14157,7 +14157,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14552,7 +14552,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14561,7 +14561,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14570,7 +14570,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14965,7 +14965,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14974,7 +14974,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+              class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
             >
               <div
                 class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -14983,7 +14983,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+              class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
             >
               <div
                 class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15386,7 +15386,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15395,7 +15395,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15404,7 +15404,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15517,7 +15517,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15526,7 +15526,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15535,7 +15535,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15648,7 +15648,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15657,7 +15657,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15666,7 +15666,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15779,7 +15779,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15788,7 +15788,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--collapsed sc-cHGsZl gxWpya"
+            class="column__content list-row__title column__content--collapsed sc-cHGsZl dEYPfe"
           >
             <div
               class="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed sc-frDJqD dXIiZk sc-htoDjs fuRDJc"
@@ -15797,7 +15797,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
           <div
-            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl huemHw"
+            class="column__content list-row__title column__content--fixed column__content--expanded sc-cHGsZl dnzeFa"
           >
             <div
               class="text text--dark text--primary subtitle sc-frDJqD dXIiZk sc-htoDjs fuRDJc"

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -103,7 +103,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary hHGuXJ iFABcd"
@@ -122,7 +122,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed hHGuXJ iFABcd"
@@ -141,7 +141,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--fixed column__content--expanded jXoLcI"
+            className="column__content list-row__title column__content--fixed column__content--expanded czEgYB"
           >
             <div
               className="text text--dark text--primary subtitle hHGuXJ iFABcd"
@@ -348,7 +348,7 @@ exports[`<ListRow /> renders List Row with label correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary hHGuXJ iFABcd"
@@ -367,7 +367,7 @@ exports[`<ListRow /> renders List Row with label correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed hHGuXJ iFABcd"
@@ -386,7 +386,7 @@ exports[`<ListRow /> renders List Row with label correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--fixed column__content--expanded jXoLcI"
+            className="column__content list-row__title column__content--fixed column__content--expanded czEgYB"
           >
             <div
               className="text text--dark text--primary subtitle hHGuXJ iFABcd"
@@ -549,7 +549,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary hHGuXJ iFABcd"
@@ -568,7 +568,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed hHGuXJ iFABcd"
@@ -587,7 +587,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--fixed column__content--expanded jXoLcI"
+            className="column__content list-row__title column__content--fixed column__content--expanded czEgYB"
           >
             <div
               className="text text--dark text--primary subtitle hHGuXJ iFABcd"
@@ -791,7 +791,7 @@ exports[`<ListRow /> renders List Row with styled button 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary hHGuXJ iFABcd"
@@ -810,7 +810,7 @@ exports[`<ListRow /> renders List Row with styled button 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed hHGuXJ iFABcd"
@@ -829,7 +829,7 @@ exports[`<ListRow /> renders List Row with styled button 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--fixed column__content--expanded jXoLcI"
+            className="column__content list-row__title column__content--fixed column__content--expanded czEgYB"
           >
             <div
               className="text text--dark text--primary subtitle hHGuXJ iFABcd"
@@ -992,7 +992,7 @@ exports[`<ListRow /> renders List Row with title correctly when expanded 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--expanded jBTLqa"
+            className="column__content list-row__title column__content--expanded jXtwVK"
           >
             <div
               className="text text--dark text--primary hHGuXJ iFABcd"
@@ -1011,7 +1011,7 @@ exports[`<ListRow /> renders List Row with title correctly when expanded 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--expanded jBTLqa"
+            className="column__content list-row__title column__content--expanded jXtwVK"
           >
             <div
               className="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed hHGuXJ iFABcd"
@@ -1030,7 +1030,7 @@ exports[`<ListRow /> renders List Row with title correctly when expanded 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--fixed column__content--collapsed jXoLcI"
+            className="column__content list-row__title column__content--fixed column__content--collapsed czEgYB"
           >
             <div
               className="text text--dark text--primary subtitle hHGuXJ iFABcd"
@@ -1193,7 +1193,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary hHGuXJ iFABcd"
@@ -1212,7 +1212,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed hHGuXJ iFABcd"
@@ -1231,7 +1231,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--fixed column__content--expanded jXoLcI"
+            className="column__content list-row__title column__content--fixed column__content--expanded czEgYB"
           >
             <div
               className="text text--dark text--primary subtitle hHGuXJ iFABcd"
@@ -1435,7 +1435,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary hHGuXJ iFABcd"
@@ -1454,7 +1454,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--collapsed jBTLqa"
+            className="column__content list-row__title column__content--collapsed jXtwVK"
           >
             <div
               className="text text--dark text--primary subtitle list-row--subtitle subtitle--collapsed hHGuXJ iFABcd"
@@ -1473,7 +1473,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
             </div>
           </div>
           <div
-            className="column__content list-row__title column__content--fixed column__content--expanded jXoLcI"
+            className="column__content list-row__title column__content--fixed column__content--expanded czEgYB"
           >
             <div
               className="text text--dark text--primary subtitle hHGuXJ iFABcd"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am removing the `z-index` style attributes from the `ContentColumn`.

<!-- Why are these changes necessary? -->

**Why**: We added `z-index` style attributes to the `ContentColumn` that conflicted with the `DropDownGroup` and caused the `ContentColumn` to obscure the `DropDownGroup` children's content.

<!-- How were these changes implemented? -->

**How**: I am removing the `z-index` style attributes from the `ContentColumn`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
