### PR TITLE
fix(SearchComponent): display name should match export from index

### DIFF
--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -165,6 +165,6 @@ SearchInput.defaultProps = {
   isSuggestOpened: false
 };
 
-SearchInput.displayName = "SearcnInput";
+SearchInput.displayName = "SearcnComponent";
 
 export default SearchInput;


### PR DESCRIPTION
**What**:

Change SearchComponent display name

**Why**:

Display name should match component export otherwise it will confuse developers when reading code snippets from design.ticketmaster.com

**How**:

Change display name

**Checklist**:

* [n/a] Documentation
* [n/a] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->