### PR TITLE
feat(Popover): extend Popover component by adding zIndex prop

### DIFF
--- a/src/components/PopOver/index.js
+++ b/src/components/PopOver/index.js
@@ -18,7 +18,7 @@ const StyledPopOver = styled.div`
   position: absolute;
   max-width: 300px;
   padding: ${spacing.moderate};
-  z-index: ${zIndex.layout.overlay};
+  z-index: ${({ zInd }) => zInd};
   display: ${({ isVisible }) => (isVisible ? "block" : "none")};
   transition: opacity 0.1s ${constants.easing.easeInQuad},
     transform 0.1s ${constants.easing.easeInQuad};
@@ -314,7 +314,7 @@ class PopOver extends Component {
   };
 
   render() {
-    const { children, isVisible, noBorders } = this.props;
+    const { children, isVisible, noBorders, zInd } = this.props;
 
     return (
       <CSSTransition
@@ -328,6 +328,7 @@ class PopOver extends Component {
           ref={this.myRef}
           isVisible={isVisible}
           noBorders={noBorders}
+          zInd={zInd}
         >
           {children}
         </StyledPopOver>
@@ -351,7 +352,8 @@ PopOver.propTypes = {
     clientHeight: PropTypes.number,
     offsetLeft: PropTypes.number,
     clientWidth: PropTypes.number
-  })
+  }),
+  zInd: PropTypes.number
 };
 
 PopOver.defaultProps = {
@@ -368,7 +370,8 @@ PopOver.defaultProps = {
     clientHeight: 0,
     offsetLeft: 0,
     clientWidth: 0
-  }
+  },
+  zInd: zIndex.layout.overlay
 };
 
 PopOver.displayName = "PopOver";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: extend Popover component by adding zIndex prop.

<!-- Why are these changes necessary? -->

**Why**: to be more flexible in the place where the Popover is used, to be able to manipulate its overlaying other components.

<!-- How were these changes implemented? -->

**How**: introduced new prop: 'zInd', use it if it's passed, otherwise use default.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
