### PR TITLE
fix(InlineFeedback): event object passed to onButtonClick prop, allow additional props

### DIFF
--- a/src/components/FeedbackInline/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/FeedbackInline/__tests__/__snapshots__/index.spec.js.snap
@@ -231,6 +231,7 @@ exports[`<FeedbackInline /> renders correctly with link 1`] = `
 <div>
   <div
     class="collapsed banner-variant--alert sc-VigVT joHkLC"
+    href="https://www.ticketmaster.com/"
     style="max-height: 21px;"
   >
     <div

--- a/src/components/FeedbackInline/index.js
+++ b/src/components/FeedbackInline/index.js
@@ -96,7 +96,7 @@ class FeedbackInline extends Component {
   content = React.createRef();
   heading = React.createRef();
 
-  toggleContent = () => {
+  toggleContent = e => {
     const { onButtonClick } = this.props;
     const contentHeight = this.content.current.offsetHeight;
     const headingHeight = this.heading.current.offsetHeight;
@@ -111,7 +111,7 @@ class FeedbackInline extends Component {
     }));
 
     if (onButtonClick) {
-      onButtonClick();
+      onButtonClick(e);
     }
   };
 
@@ -156,7 +156,7 @@ class FeedbackInline extends Component {
   };
 
   render() {
-    const { heading, content, variant, style } = this.props;
+    const { heading, content, variant, style, ...props } = this.props;
     const { isExpanded, maxHeight } = this.state;
 
     return (
@@ -166,6 +166,7 @@ class FeedbackInline extends Component {
           [`banner-variant--${variant}`]: variant
         })}
         style={{ ...style, maxHeight }}
+        {...props}
       >
         <IconSection>{this.renderIcon()}</IconSection>
         <ContentSection>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
* event object passed to `onButtonClick` prop
* additional props can be passed `InlineFeedback`
<!-- Why are these changes necessary? -->

**Why**:
An improvement that would allow increasing usability
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
