### PR TITLE
fix(SectionItem): resetOpenIndex when an item with a url is clicked

### DIFF
--- a/src/components/List/SectionItem.js
+++ b/src/components/List/SectionItem.js
@@ -37,13 +37,17 @@ const MultiLineLink = styled.div.attrs({
 `;
 /* stylelint-enable */
 
-const handleItemClick = (children, value, event, onItemClick) => {
+const handleItemClick = (children, value, event, onItemClick, url) => {
   if (children && value) {
     value.renderIntoPortal({ children, contentType: "desktop" });
   }
 
   if (onItemClick) {
     onItemClick(event);
+  }
+
+  if (url && value) {
+    value.resetOpenIndex();
   }
 };
 
@@ -64,7 +68,7 @@ const SectionItem = ({
           role="link"
           aria-label="Section Item"
           onClick={event =>
-            handleItemClick(children, value, event, onItemClick)
+            handleItemClick(children, value, event, onItemClick, url)
           }
           onItemClick={onItemClick}
           href={url}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am invoking resetOpenIndex when an item with a url is clicked.

<!-- Why are these changes necessary? -->

**Why**: These changes are required to ensure that the open item is closed when the user client-side navigates between pages that utilize the `ListRow` UI.

<!-- How were these changes implemented? -->

**How**: I am invoking resetOpenIndex when an item with a url is clicked.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
