### PR TITLE
fix(PopOver): position correctly regardless parent element position property

### DIFF
--- a/src/components/PopOver/PopOverPortal.js
+++ b/src/components/PopOver/PopOverPortal.js
@@ -1,0 +1,35 @@
+import { Component } from "react";
+import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
+
+class Portal extends Component {
+  componentDidMount() {
+    if (global.window.document.body) {
+      this.rootEl = global.window.document.createElement("div");
+      this.rootEl.id = `popover-root-${new Date().getTime()}`;
+      global.window.document.body.appendChild(this.rootEl);
+    }
+  }
+
+  componentWillUnmount() {
+    global.window.document.body.removeChild(this.rootEl);
+  }
+
+  rootEl = null;
+
+  render() {
+    const { children } = this.props;
+
+    return this.rootEl ? ReactDOM.createPortal(children, this.rootEl) : null;
+  }
+}
+
+Portal.propTypes = {
+  children: PropTypes.node
+};
+
+Portal.defaultProps = {
+  children: null
+};
+
+export default Portal;

--- a/src/components/PopOver/__tests__/PopOverPortal.spec.js
+++ b/src/components/PopOver/__tests__/PopOverPortal.spec.js
@@ -1,0 +1,49 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import "jest-styled-components";
+
+import Portal from "../PopOverPortal";
+
+describe("PopOverPortal", () => {
+  let getTimeMock;
+  beforeEach(() => {
+    getTimeMock = jest.fn(() => 1234);
+    global.Date = jest.fn(() => ({ getTime: getTimeMock }));
+  });
+
+  it("should match snapshot", () => {
+    const component = renderer.create(<Portal>test</Portal>).getInstance();
+
+    const result = component.render();
+
+    expect(result).toMatchSnapshot();
+    expect(getTimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("componentWillUnmount should call remove child", () => {
+    const spy = jest.spyOn(global.window.document.body, "removeChild");
+    const tree = renderer.create(<Portal>test</Portal>).getInstance();
+
+    tree.componentWillUnmount();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+  });
+
+  it("componentWillMount should not call create element when body is undefined", () => {
+    const spy = jest.spyOn(global.window.document, "createElement");
+    const tree = renderer.create(<Portal>test</Portal>).getInstance();
+
+    Object.defineProperty(global.window.document, "body", {
+      value: null,
+      writable: true
+    });
+
+    tree.componentDidMount();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+  });
+});

--- a/src/components/PopOver/__tests__/__snapshots__/PopOverPortal.spec.js.snap
+++ b/src/components/PopOver/__tests__/__snapshots__/PopOverPortal.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PopOverPortal should match snapshot 1`] = `
+Object {
+  "$$typeof": Symbol(react.portal),
+  "children": "test",
+  "containerInfo": <div
+    id="popover-root-1234"
+  />,
+  "implementation": null,
+  "key": null,
+}
+`;

--- a/src/components/PopOver/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/PopOver/__tests__/__snapshots__/index.spec.js.snap
@@ -2,18 +2,18 @@
 
 exports[`PopOver should match snapshot 1`] = `
 <div
-  className="dbzfGp"
+  className="cbyErf"
 />
 `;
 
 exports[`PopOver should match snapshot when visible 1`] = `
 <div
-  className="bqoXdg"
+  className="cwoXzC"
 />
 `;
 
 exports[`PopOver should match snapshot when visible and without borders 1`] = `
 <div
-  className="fBMBDA"
+  className="hIOIEX"
 />
 `;

--- a/src/components/PopOver/__tests__/index.spec.js
+++ b/src/components/PopOver/__tests__/index.spec.js
@@ -4,6 +4,12 @@ import "jest-styled-components";
 
 import PopOver from "..";
 
+jest.mock("../PopOverPortal", () => ({ children }) => children);
+
+jest.mock("react-transition-group", () => ({
+  CSSTransition: ({ children }) => children
+}));
+
 describe("PopOver", () => {
   it("should match snapshot", () => {
     const tree = renderer.create(<PopOver />).toJSON();
@@ -32,11 +38,12 @@ describe("PopOver", () => {
       const position = {
         elBottom: 10,
         elTop: 0,
-        mouseX: 5,
         offsetTop: 0,
         clientHeight: 1000,
         offsetLeft: 0,
-        clientWidth: 500
+        clientWidth: 500,
+        elWidth: 10,
+        elLeft: 0
       };
       const dimensions = {
         width: 100,
@@ -58,12 +65,14 @@ describe("PopOver", () => {
       const position = {
         elBottom: 510,
         elTop: 500,
-        mouseX: 5,
+        elLeft: 0,
+        elWidth: 10,
         offsetTop: 0,
         clientHeight: 1000,
         offsetLeft: 0,
         clientWidth: 10000
       };
+
       const dimensions = {
         width: 100,
         windowScroll: 100,
@@ -76,7 +85,7 @@ describe("PopOver", () => {
         PopOver.calculatePosition({ position, dimensions, reduce })
       ).toEqual({
         x: 24,
-        y: 390
+        y: 490
       });
     });
 
@@ -86,7 +95,6 @@ describe("PopOver", () => {
         elTop: 500,
         elLeft: 30,
         elWidth: 150,
-        mouseX: 5,
         offsetTop: 0,
         clientHeight: 1000,
         offsetLeft: 0,
@@ -109,7 +117,7 @@ describe("PopOver", () => {
         })
       ).toEqual({
         x: 188,
-        y: 500
+        y: 600
       });
     });
 
@@ -119,7 +127,6 @@ describe("PopOver", () => {
         elTop: 500,
         elLeft: 900,
         elWidth: 150,
-        mouseX: 5,
         offsetTop: 0,
         clientHeight: 1000,
         offsetLeft: 0,
@@ -142,7 +149,7 @@ describe("PopOver", () => {
         })
       ).toEqual({
         x: 792,
-        y: 500
+        y: 600
       });
     });
   });
@@ -201,7 +208,6 @@ describe("PopOver", () => {
     const setDimensionsMock = jest.fn();
     const calculatePositionMock = jest.fn(() => ({ x: 5, y: 10 }));
     const position = {
-      mouseX: 30,
       elTop: 20,
       elBottom: 40
     };
@@ -229,7 +235,6 @@ describe("PopOver", () => {
     const setDimensionsMock = jest.fn();
     const calculatePositionMock = jest.fn(() => ({ x: 5, y: 10 }));
     const position = {
-      mouseX: 30,
       elTop: 20,
       elBottom: 40
     };
@@ -281,23 +286,25 @@ describe("PopOver", () => {
 
   describe("getDimensionsFromEvent", () => {
     const event = {
-      clientX: 100,
-      currentTarget: {
-        offsetTop: 20,
-        clientHeight: 1000,
-        offsetLeft: 30,
-        offsetWidth: 150
+      target: {
+        getBoundingClientRect: () => ({
+          y: 20,
+          height: 1000,
+          x: 30,
+          width: 150
+        })
       }
     };
     const wrapper = {
-      offsetTop: 50,
-      clientHeight: 200,
-      offsetLeft: 100,
-      clientWidth: 300
+      getBoundingClientRect: () => ({
+        y: 50,
+        height: 200,
+        x: 100,
+        width: 300
+      })
     };
     it("without wrapper", () => {
       expect(PopOver.getDimensionsFromEvent(event)).toEqual({
-        mouseX: 100,
         elTop: 20,
         elLeft: 30,
         elWidth: 150,
@@ -311,7 +318,6 @@ describe("PopOver", () => {
 
     it("plus wrapper", () => {
       expect(PopOver.getDimensionsFromEvent(event, wrapper)).toEqual({
-        mouseX: 100,
         elTop: 20,
         elLeft: 30,
         elWidth: 150,


### PR DESCRIPTION
**What**:

Fix popover positioning

**Why**:

Popover was displaying properly only if it is not wrapped in element that has position property set to "relative"

**How**:

Render the popover into a portal. Use getBoundingClientRect for calculating popover position.

**Checklist**:
* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->