### PR TITLE
fix(Button): avoid focus on click

### DIFF
--- a/src/components/Button/Base.js
+++ b/src/components/Button/Base.js
@@ -1,36 +1,74 @@
-import React from "react";
+/* global window: true */
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 import { StyledButton, StyledButtonLink } from "./Base.styles";
 import { SIZES, REGULAR, BUTTON_VARIANTS, STANDARD } from "../constants";
 import { getRelByTarget } from "../../utils/link";
 
-const Button = ({ variant, size, children, ...rest }) => {
-  const { href } = rest;
-
-  if (href) {
-    const { rel, target } = rest;
-    const validatedRel = getRelByTarget(target, rel);
-
-    return (
-      <StyledButtonLink
-        variant={variant}
-        size={size}
-        rel={validatedRel}
-        as="a"
-        {...rest}
-      >
-        {children}
-      </StyledButtonLink>
-    );
+class Button extends Component {
+  componentDidMount() {
+    if (!this.props.href) {
+      // this functionality is required to avoid focus outline on click but keep it on tab focus
+      this.button.current.addEventListener("focus", this.focusHandler);
+      this.button.current.addEventListener("blur", this.blurHandler);
+    }
   }
 
-  return (
-    <StyledButton variant={variant} size={size} {...rest}>
-      {children}
-    </StyledButton>
-  );
-};
+  componentWillUnmount() {
+    // in case user leaves a page before onBlur is triggered
+    window.removeEventListener("keyup", this.activateFocusStyles);
+  }
+
+  focusHandler = () => {
+    window.addEventListener("keyup", this.activateFocusStyles);
+  };
+
+  blurHandler = () => {
+    this.button.current.classList.add("noFocus");
+    window.removeEventListener("keyup", this.activateFocusStyles);
+  };
+
+  activateFocusStyles = () => {
+    this.button.current.classList.remove("noFocus");
+  };
+
+  button = React.createRef();
+
+  render() {
+    const { variant, size, children, ...rest } = this.props;
+    const { href } = rest;
+
+    if (href) {
+      const { rel, target } = rest;
+      const validatedRel = getRelByTarget(target, rel);
+
+      return (
+        <StyledButtonLink
+          variant={variant}
+          size={size}
+          rel={validatedRel}
+          as="a"
+          {...rest}
+        >
+          {children}
+        </StyledButtonLink>
+      );
+    }
+
+    return (
+      <StyledButton
+        variant={variant}
+        size={size}
+        {...rest}
+        className={`${rest.className || ""} noFocus`}
+        ref={this.button}
+      >
+        {children}
+      </StyledButton>
+    );
+  }
+}
 
 Button.propTypes = {
   variant: PropTypes.oneOf(BUTTON_VARIANTS),

--- a/src/components/Button/Base.styles.js
+++ b/src/components/Button/Base.styles.js
@@ -157,6 +157,11 @@ export const StyledButton = styled.button`
     ${({ variant }) =>
       variant === SPECIAL ? "opacity: 0.4;" : "opacity: 0.2;"};
   }
+
+
+  &.noFocus:focus {
+    box-shadow: none;
+  }
 `;
 
 StyledButton.defaultProps = {

--- a/src/components/Button/__tests__/Base.spec.js
+++ b/src/components/Button/__tests__/Base.spec.js
@@ -6,149 +6,103 @@ import { Button } from "../";
 
 describe("<Button />", () => {
   it("renders standard small size button correctly", () => {
-    const component = renderer.create(
-      <Button size="small">Dummy Label</Button>
-    );
+    const component = renderButton({ size: "small" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders standard regular size button correctly", () => {
-    const component = renderer.create(<Button>Dummy Label</Button>);
+    const component = renderButton();
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders standard large size button correctly", () => {
-    const component = renderer.create(
-      <Button size="large">Dummy Label</Button>
-    );
+    const component = renderButton({ size: "large" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders standard regular size disabled button correctly", () => {
-    const component = renderer.create(<Button disabled>Dummy Label</Button>);
+    const component = renderButton({ disabled: true });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders special small size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="special" size="small">
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "special", size: "small" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders special regular size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="special">Dummy Label</Button>
-    );
+    const component = renderButton({ variant: "special" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders special large size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="special" size="large">
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "special", size: "large" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders special regular size disabled button correctly", () => {
-    const component = renderer.create(
-      <Button variant="special" disabled>
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "special", disabled: true });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders outline small size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="outline" size="small">
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "outline", size: "small" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders outline regular size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="outline">Dummy Label</Button>
-    );
+    const component = renderButton({ variant: "outline" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders outline large size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="outline" size="large">
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "outline", size: "large" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders outline regular size disabled button correctly", () => {
-    const component = renderer.create(
-      <Button variant="outline" disabled>
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "outline", disabled: true });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders transparent small size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="transparent" size="small">
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "transparent", size: "small" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders transparent regular size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="transparent">Dummy Label</Button>
-    );
+    const component = renderButton({ variant: "transparent" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders transparent large size button correctly", () => {
-    const component = renderer.create(
-      <Button variant="transparent" size="large">
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "transparent", size: "large" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders transparent regular size disabled button correctly", () => {
-    const component = renderer.create(
-      <Button variant="transparent" disabled>
-        Dummy Label
-      </Button>
-    );
+    const component = renderButton({ variant: "transparent", disabled: true });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("renders link button correctly", () => {
-    const component = renderer.create(<Button href="/">Dummy Label</Button>);
+    const component = renderButton({ href: "/" });
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -165,3 +119,11 @@ describe("<Button />", () => {
     expect(onClick).toHaveBeenCalled();
   });
 });
+
+function renderButton(props = {}) {
+  return renderer.create(<Button {...props}>Dummy Label</Button>, {
+    createNodeMock: () => ({
+      addEventListener: () => {}
+    })
+  });
+}

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Button /> renders link button correctly 1`] = `
 <a
-  className="bxsgwy"
+  className="kHnYRc"
   href="/"
   rel={undefined}
   size="regular"
@@ -13,7 +13,7 @@ exports[`<Button /> renders link button correctly 1`] = `
 
 exports[`<Button /> renders outline large size button correctly 1`] = `
 <button
-  className="dSRBVy"
+  className=" noFocus eBkRKA"
   size="large"
 >
   Dummy Label
@@ -22,7 +22,7 @@ exports[`<Button /> renders outline large size button correctly 1`] = `
 
 exports[`<Button /> renders outline regular size button correctly 1`] = `
 <button
-  className="fZANJS"
+  className=" noFocus fAhIdS"
   size="regular"
 >
   Dummy Label
@@ -31,7 +31,7 @@ exports[`<Button /> renders outline regular size button correctly 1`] = `
 
 exports[`<Button /> renders outline regular size disabled button correctly 1`] = `
 <button
-  className="fZANJS"
+  className=" noFocus fAhIdS"
   disabled={true}
   size="regular"
 >
@@ -41,7 +41,7 @@ exports[`<Button /> renders outline regular size disabled button correctly 1`] =
 
 exports[`<Button /> renders outline small size button correctly 1`] = `
 <button
-  className="hytSzx"
+  className=" noFocus dVAURc"
   size="small"
 >
   Dummy Label
@@ -50,7 +50,7 @@ exports[`<Button /> renders outline small size button correctly 1`] = `
 
 exports[`<Button /> renders special large size button correctly 1`] = `
 <button
-  className="kYlOcU"
+  className=" noFocus fxuzOL"
   size="large"
 >
   Dummy Label
@@ -59,7 +59,7 @@ exports[`<Button /> renders special large size button correctly 1`] = `
 
 exports[`<Button /> renders special regular size button correctly 1`] = `
 <button
-  className="hClayG"
+  className=" noFocus iShFr"
   size="regular"
 >
   Dummy Label
@@ -68,7 +68,7 @@ exports[`<Button /> renders special regular size button correctly 1`] = `
 
 exports[`<Button /> renders special regular size disabled button correctly 1`] = `
 <button
-  className="hClayG"
+  className=" noFocus iShFr"
   disabled={true}
   size="regular"
 >
@@ -78,7 +78,7 @@ exports[`<Button /> renders special regular size disabled button correctly 1`] =
 
 exports[`<Button /> renders special small size button correctly 1`] = `
 <button
-  className="bgGsnj"
+  className=" noFocus ibrbUd"
   size="small"
 >
   Dummy Label
@@ -87,7 +87,7 @@ exports[`<Button /> renders special small size button correctly 1`] = `
 
 exports[`<Button /> renders standard large size button correctly 1`] = `
 <button
-  className="iafmgw"
+  className=" noFocus kdJqXr"
   size="large"
 >
   Dummy Label
@@ -96,7 +96,7 @@ exports[`<Button /> renders standard large size button correctly 1`] = `
 
 exports[`<Button /> renders standard regular size button correctly 1`] = `
 <button
-  className="jDSxdZ"
+  className=" noFocus encbkH"
   size="regular"
 >
   Dummy Label
@@ -105,7 +105,7 @@ exports[`<Button /> renders standard regular size button correctly 1`] = `
 
 exports[`<Button /> renders standard regular size disabled button correctly 1`] = `
 <button
-  className="jDSxdZ"
+  className=" noFocus encbkH"
   disabled={true}
   size="regular"
 >
@@ -115,7 +115,7 @@ exports[`<Button /> renders standard regular size disabled button correctly 1`] 
 
 exports[`<Button /> renders standard small size button correctly 1`] = `
 <button
-  className="geITcv"
+  className=" noFocus bFeSYA"
   size="small"
 >
   Dummy Label
@@ -124,7 +124,7 @@ exports[`<Button /> renders standard small size button correctly 1`] = `
 
 exports[`<Button /> renders transparent large size button correctly 1`] = `
 <button
-  className="irikcu"
+  className=" noFocus hegczD"
   size="large"
 >
   Dummy Label
@@ -133,7 +133,7 @@ exports[`<Button /> renders transparent large size button correctly 1`] = `
 
 exports[`<Button /> renders transparent regular size button correctly 1`] = `
 <button
-  className="dTVfim"
+  className=" noFocus bSoaLb"
   size="regular"
 >
   Dummy Label
@@ -142,7 +142,7 @@ exports[`<Button /> renders transparent regular size button correctly 1`] = `
 
 exports[`<Button /> renders transparent regular size disabled button correctly 1`] = `
 <button
-  className="dTVfim"
+  className=" noFocus bSoaLb"
   disabled={true}
   size="regular"
 >
@@ -152,7 +152,7 @@ exports[`<Button /> renders transparent regular size disabled button correctly 1
 
 exports[`<Button /> renders transparent small size button correctly 1`] = `
 <button
-  className="cBUZry"
+  className=" noFocus kEKykV"
   size="small"
 >
   Dummy Label

--- a/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
@@ -97,7 +97,7 @@ exports[`CalendarView should render without errors 1`] = `
           className="c2 ktYHxE"
         >
           <a
-            className="dbOaOg"
+            className="SWBLm"
             href="#"
             rel={undefined}
             size="small"
@@ -109,7 +109,7 @@ exports[`CalendarView should render without errors 1`] = `
           className="c2 ktYHxE"
         >
           <a
-            className="dbOaOg"
+            className="SWBLm"
             href="#"
             rel={undefined}
             size="small"
@@ -193,7 +193,7 @@ exports[`CalendarView should render without errors 1`] = `
           className="c2 ktYHxE"
         >
           <a
-            className="dbOaOg"
+            className="SWBLm"
             href="#"
             rel={undefined}
             size="small"
@@ -205,7 +205,7 @@ exports[`CalendarView should render without errors 1`] = `
           className="c2 ktYHxE"
         >
           <a
-            className="dbOaOg"
+            className="SWBLm"
             href="#"
             rel={undefined}
             size="small"

--- a/src/components/Input/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -34,7 +34,7 @@ Object {
             class="sc-jKJlTe hKEYQO"
           >
             <button
-              class="button__selected sc-eNQAEJ cDhCpH sc-jzJRlG gPDwPN"
+              class="button__selected sc-eNQAEJ cDhCpH noFocus sc-jzJRlG cgVIfE"
               data-testid="test-button0"
             >
               All
@@ -44,7 +44,7 @@ Object {
             class="sc-jKJlTe hKEYQO"
           >
             <button
-              class="sc-eNQAEJ cDhCpH sc-jzJRlG gPDwPN"
+              class="sc-eNQAEJ cDhCpH noFocus sc-jzJRlG cgVIfE"
               data-testid="test-button1"
             >
               Concerts
@@ -54,7 +54,7 @@ Object {
             class="sc-jKJlTe hKEYQO"
           >
             <button
-              class="sc-eNQAEJ cDhCpH sc-jzJRlG gPDwPN"
+              class="sc-eNQAEJ cDhCpH noFocus sc-jzJRlG cgVIfE"
               data-testid="test-button2"
             >
               Button Label
@@ -132,7 +132,7 @@ Object {
             class="sc-jKJlTe hKEYQO"
           >
             <button
-              class="sc-eNQAEJ cDhCpH sc-jzJRlG gPDwPN"
+              class="sc-eNQAEJ cDhCpH noFocus sc-jzJRlG cgVIfE"
               data-testid="test-button0"
             >
               All
@@ -142,7 +142,7 @@ Object {
             class="sc-jKJlTe hKEYQO"
           >
             <button
-              class="sc-eNQAEJ cDhCpH sc-jzJRlG gPDwPN"
+              class="sc-eNQAEJ cDhCpH noFocus sc-jzJRlG cgVIfE"
               data-testid="test-button1"
             >
               Concerts
@@ -152,7 +152,7 @@ Object {
             class="sc-jKJlTe hKEYQO"
           >
             <button
-              class="sc-eNQAEJ cDhCpH sc-jzJRlG gPDwPN"
+              class="sc-eNQAEJ cDhCpH noFocus sc-jzJRlG cgVIfE"
               data-testid="test-button2"
             >
               Button Label

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -100,7 +100,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -512,7 +512,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -924,7 +924,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -1336,7 +1336,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -1756,7 +1756,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -2168,7 +2168,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -2580,7 +2580,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="Acheter des Billets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -2992,7 +2992,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -3412,7 +3412,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -3824,7 +3824,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -4236,7 +4236,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -4648,7 +4648,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -5068,7 +5068,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -5480,7 +5480,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -5892,7 +5892,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="Acheter des Billets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -6304,7 +6304,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -6725,7 +6725,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -6977,7 +6977,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -7389,7 +7389,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -7801,7 +7801,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -8213,7 +8213,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -8632,7 +8632,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -9044,7 +9044,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -9456,7 +9456,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -9868,7 +9868,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -10287,7 +10287,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -10731,7 +10731,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -11175,7 +11175,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -11619,7 +11619,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -12070,7 +12070,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -12482,7 +12482,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -12894,7 +12894,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -13306,7 +13306,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -13726,7 +13726,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -14138,7 +14138,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -14550,7 +14550,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="Acheter des Billets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -14962,7 +14962,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-ksYbfQ kvVKLl"
+              class="sc-ksYbfQ hiqXqr"
               role="button"
               width="102px"
             >
@@ -15382,7 +15382,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -15513,7 +15513,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -15644,7 +15644,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >
@@ -15775,7 +15775,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-ksYbfQ kvVKLl"
+            class="sc-ksYbfQ hiqXqr"
             role="button"
             width="102px"
           >

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -236,7 +236,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="eMaJMc"
+            className="EFFDU"
             role="button"
             size="regular"
             width="102px"
@@ -481,7 +481,7 @@ exports[`<ListRow /> renders List Row with label correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="eMaJMc"
+            className="EFFDU"
             role="button"
             size="regular"
             width="102px"
@@ -682,7 +682,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="eMaJMc"
+            className="EFFDU"
             role="button"
             size="regular"
             width="102px"
@@ -924,7 +924,7 @@ exports[`<ListRow /> renders List Row with styled button 1`] = `
         >
           <span
             aria-label="More Info"
-            className="dNRPHv"
+            className="cOVTfz"
             role="button"
             size="regular"
             width="102px"
@@ -1125,7 +1125,7 @@ exports[`<ListRow /> renders List Row with title correctly when expanded 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="eMaJMc"
+            className="EFFDU"
             role="button"
             size="regular"
             width="102px"
@@ -1326,7 +1326,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="eMaJMc"
+            className="EFFDU"
             role="button"
             size="regular"
             width="102px"
@@ -1568,7 +1568,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="eMaJMc"
+            className="EFFDU"
             role="button"
             size="regular"
             width="102px"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
When a button is clicked it gets focused. It is a default behaviour of all the browsers except Safari. Designers would like to avoid this behaviour but we need to comply with accessibility standards.
This PR tackles both: doesn't break accessibility and avoid blue outline on click.
<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:
Detect if a button was focused by click or by keypress.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
