### PR TITLE
fix(StatusBadgeGroup): dont't show counter when no hidden items

### DIFF
--- a/src/components/StatusBadge/StatusBadgeGroup.js
+++ b/src/components/StatusBadge/StatusBadgeGroup.js
@@ -85,7 +85,7 @@ class StatusBadgeGroup extends Component {
       <StatusBadgeContainer>
         {this.renderBadges(visibleBadges, variant)}
         {hiddenBadges &&
-          hiddenBadges.length && (
+          hiddenBadges.length > 0 && (
             <HiddenBadgesCount
               onMouseEnter={this.elementHovered}
               onMouseLeave={this.mouseLeave}


### PR DESCRIPTION
**What**:

Status badge group doesn't show counter when no hidden items are passed

**Why**:

Rquired

**How**:

Check if hidden items array length is greater than 0

**Checklist**:

* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
