### PR TITLE
DSCO-3266: feat(Modal) Fix modal position to start below the nav bar on native app

### DIFF
--- a/catalog/pages/adaptive_modal/index.md
+++ b/catalog/pages/adaptive_modal/index.md
@@ -9,6 +9,9 @@ rows:
   - Prop: actionBarProps
     Type: object
     Notes: extra props passed to the actionBar wrapper
+  - Prop: overlayProps
+    Type: object
+    Notes: extra props passed to the modal overlay (e.g. to pass custom style props)
   - Prop: containerProps
     Type: object
     Notes: extra props passed to the modal container

--- a/src/components/Modal/__tests__/helper.spec.js
+++ b/src/components/Modal/__tests__/helper.spec.js
@@ -71,7 +71,8 @@ describe("getContentHeight", () => {
         clientHeight: 40
       },
       container: {
-        clientHeight: 376
+        clientHeight: 376,
+        offsetTop: 0
       },
       isFullscreen: true
     });

--- a/src/components/Modal/helper.js
+++ b/src/components/Modal/helper.js
@@ -2,14 +2,11 @@ import { spacing } from "../../theme";
 
 export const SPACING = spacing.colossal.replace("px", "");
 
-const NATIVE_APP_NAV_BAR_HEIGHT = 50;
-
 export const getContentHeight = ({
   actionBar,
   bottomActionBar,
   container,
-  isFullscreen = false,
-  isWebview = false
+  isFullscreen = false
 }) => {
   const actionBarHeight = actionBar ? actionBar.clientHeight : 0;
 
@@ -18,8 +15,7 @@ export const getContentHeight = ({
     : 0;
 
   return `${container.clientHeight -
-    (isFullscreen ? 0 : SPACING * 2) -
-    (isWebview ? NATIVE_APP_NAV_BAR_HEIGHT : 0) -
+    (isFullscreen ? container.offsetTop : SPACING * 2) -
     actionBarHeight -
     bottomActionBarHeight}px`;
 };

--- a/src/components/Modal/helper.js
+++ b/src/components/Modal/helper.js
@@ -2,11 +2,14 @@ import { spacing } from "../../theme";
 
 export const SPACING = spacing.colossal.replace("px", "");
 
+const NATIVE_APP_NAV_BAR_HEIGHT = 50;
+
 export const getContentHeight = ({
   actionBar,
   bottomActionBar,
   container,
-  isFullscreen
+  isFullscreen = false,
+  isWebview = false
 }) => {
   const actionBarHeight = actionBar ? actionBar.clientHeight : 0;
 
@@ -16,6 +19,7 @@ export const getContentHeight = ({
 
   return `${container.clientHeight -
     (isFullscreen ? 0 : SPACING * 2) -
+    (isWebview ? NATIVE_APP_NAV_BAR_HEIGHT : 0) -
     actionBarHeight -
     bottomActionBarHeight}px`;
 };

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -54,10 +54,10 @@ export class Modal extends React.Component {
       MODAL_SIZE_XLARGE
     ]),
     isFullscreen: PropTypes.bool,
-    isWebview: PropTypes.bool,
     onRequestClose: PropTypes.func,
     onScroll: PropTypes.func,
     /* eslint-disable react/forbid-prop-types */
+    overlayProps: PropTypes.object,
     containerProps: PropTypes.object,
     actionBarProps: PropTypes.object,
     contentProps: PropTypes.object,
@@ -73,9 +73,9 @@ export class Modal extends React.Component {
     isOpened: true,
     size: MODAL_SIZE_MEDIUM,
     isFullscreen: false,
-    isWebview: false,
     onRequestClose: null,
     onScroll: null,
+    overlayProps: {},
     containerProps: {},
     actionBarProps: {},
     contentProps: {},
@@ -157,14 +157,13 @@ export class Modal extends React.Component {
     const bottomActionBar = this.bottomActionBarRef.current;
     const content = this.contentRef.current;
     const container = this.containerRef.current;
-    const { isFullscreen, isWebview } = this.props;
+    const { isFullscreen } = this.props;
 
     const contentHeight = getContentHeight({
       isFullscreen,
       actionBar,
       bottomActionBar,
-      container,
-      isWebview
+      container
     });
 
     content.style.maxHeight = contentHeight;
@@ -212,6 +211,7 @@ export class Modal extends React.Component {
       gutters,
       size,
       deviceSize,
+      overlayProps,
       containerProps,
       actionBarProps,
       contentProps,
@@ -231,7 +231,7 @@ export class Modal extends React.Component {
           classNames="open"
         >
           <Backdrop
-            overlayProps={{ ref: this.containerRef }}
+            overlayProps={{ ...overlayProps, ref: this.containerRef }}
             onRequestClose={this.closeModal}
             isVisible={isOpened}
             animated

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -54,6 +54,7 @@ export class Modal extends React.Component {
       MODAL_SIZE_XLARGE
     ]),
     isFullscreen: PropTypes.bool,
+    isWebview: PropTypes.bool,
     onRequestClose: PropTypes.func,
     onScroll: PropTypes.func,
     /* eslint-disable react/forbid-prop-types */
@@ -72,6 +73,7 @@ export class Modal extends React.Component {
     isOpened: true,
     size: MODAL_SIZE_MEDIUM,
     isFullscreen: false,
+    isWebview: false,
     onRequestClose: null,
     onScroll: null,
     containerProps: {},
@@ -155,13 +157,14 @@ export class Modal extends React.Component {
     const bottomActionBar = this.bottomActionBarRef.current;
     const content = this.contentRef.current;
     const container = this.containerRef.current;
-    const { isFullscreen } = this.props;
+    const { isFullscreen, isWebview } = this.props;
 
     const contentHeight = getContentHeight({
       isFullscreen,
       actionBar,
       bottomActionBar,
-      container
+      container,
+      isWebview
     });
 
     content.style.maxHeight = contentHeight;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added spacing for the modal to fix the overlapping with the native nav bar in fullscreen mode
<!-- Why are these changes necessary? -->

**Why**:
To fix overlapping of the nav bar
<!-- How were these changes implemented? -->

**How**:
Added validation for the webview is additional padding-top
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
