### PR TITLE
fix(PopOver): ios safari scroll position

### DIFF
--- a/src/components/PopOver/index.js
+++ b/src/components/PopOver/index.js
@@ -254,10 +254,15 @@ class PopOver extends Component {
     const dimensions = {};
     if (global.window && isVisible) {
       const {
-        scrollTop,
         clientWidth,
         clientHeight
       } = global.window.document.documentElement;
+
+      const scrollTop = Math.max(
+        global.window.pageYOffset,
+        global.document.documentElement.scrollTop,
+        global.document.body.scrollTop
+      );
 
       if (scrollTop !== windowScroll) {
         dimensions.windowScroll = scrollTop;


### PR DESCRIPTION
**What**:

Get correct window scroll position.

**Why**:

Show popover on the correct position.

**How**:

Get max value from pageYOffset, documentElement.scrollTop and body.scrollTop

**Checklist**:
* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
