### PR TITLE
fix(LinkCta): remove underline when user clicks and add it only on keyboard focus

### DIFF
--- a/src/components/Banner/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Banner/__tests__/__snapshots__/index.spec.js.snap
@@ -5,14 +5,14 @@ exports[`<Banner /> renders correctly when closed 1`] = `<div />`;
 exports[`<Banner /> renders correctly when open 1`] = `
 <div>
   <div
-    class="collapsed visible-banner sc-fjdhpX dRzThv"
+    class="collapsed visible-banner sc-gZMcBi bsKZGS"
     style="max-height: 56px;"
   >
     <div
-      class="sc-kgoBCf kDgYaG"
+      class="sc-jzJRlG gEWVas"
     />
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <span
         class="text text--dark text--primary sc-ifAKCX jrkHpW"
@@ -21,7 +21,7 @@ exports[`<Banner /> renders correctly when open 1`] = `
       </span>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG hcBAne sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT SFrkV sc-ifAKCX gwaFLV"
         />
       </div>
     </div>
@@ -32,11 +32,11 @@ exports[`<Banner /> renders correctly when open 1`] = `
 exports[`<Banner /> renders correctly when variant is set 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-fjdhpX dRzThv"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
     style="max-height: 56px;"
   >
     <div
-      class="sc-kgoBCf kDgYaG"
+      class="sc-jzJRlG gEWVas"
     >
       <svg
         height="24"
@@ -69,7 +69,7 @@ exports[`<Banner /> renders correctly when variant is set 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <span
         class="text text--dark text--primary sc-ifAKCX jrkHpW"
@@ -78,7 +78,7 @@ exports[`<Banner /> renders correctly when variant is set 1`] = `
       </span>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG hcBAne sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT SFrkV sc-ifAKCX gwaFLV"
         >
           test content
         </div>
@@ -91,11 +91,11 @@ exports[`<Banner /> renders correctly when variant is set 1`] = `
 exports[`<Banner /> renders correctly with close button 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-fjdhpX dRzThv"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
     style="max-height: 56px;"
   >
     <div
-      class="sc-kgoBCf kDgYaG"
+      class="sc-jzJRlG gEWVas"
     >
       <svg
         height="24"
@@ -128,7 +128,7 @@ exports[`<Banner /> renders correctly with close button 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <span
         class="text text--dark text--primary sc-ifAKCX jrkHpW"
@@ -137,7 +137,7 @@ exports[`<Banner /> renders correctly with close button 1`] = `
       </span>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG hcBAne sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT SFrkV sc-ifAKCX gwaFLV"
         >
           test content
         </div>
@@ -150,14 +150,14 @@ exports[`<Banner /> renders correctly with close button 1`] = `
 exports[`<Banner /> renders correctly with content 1`] = `
 <div>
   <div
-    class="collapsed visible-banner sc-fjdhpX dRzThv"
+    class="collapsed visible-banner sc-gZMcBi bsKZGS"
     style="max-height: 56px;"
   >
     <div
-      class="sc-kgoBCf kDgYaG"
+      class="sc-jzJRlG gEWVas"
     />
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <span
         class="text text--dark text--primary sc-ifAKCX jrkHpW"
@@ -166,7 +166,7 @@ exports[`<Banner /> renders correctly with content 1`] = `
       </span>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG hcBAne sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT SFrkV sc-ifAKCX gwaFLV"
         >
           test content
         </div>
@@ -179,11 +179,11 @@ exports[`<Banner /> renders correctly with content 1`] = `
 exports[`<Banner /> renders correctly with custom icon 1`] = `
 <div>
   <div
-    class="collapsed visible-banner sc-fjdhpX dRzThv"
+    class="collapsed visible-banner sc-gZMcBi bsKZGS"
     style="max-height: 56px;"
   >
     <div
-      class="sc-kgoBCf kDgYaG"
+      class="sc-jzJRlG gEWVas"
     >
       <svg
         height="24"
@@ -208,7 +208,7 @@ exports[`<Banner /> renders correctly with custom icon 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <span
         class="text text--dark text--primary sc-ifAKCX jrkHpW"
@@ -217,7 +217,7 @@ exports[`<Banner /> renders correctly with custom icon 1`] = `
       </span>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG hcBAne sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT SFrkV sc-ifAKCX gwaFLV"
         >
           test content
         </div>
@@ -230,11 +230,11 @@ exports[`<Banner /> renders correctly with custom icon 1`] = `
 exports[`<Banner /> renders correctly with custom title for the close button 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-fjdhpX dRzThv"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
     style="max-height: 56px;"
   >
     <div
-      class="sc-kgoBCf kDgYaG"
+      class="sc-jzJRlG gEWVas"
     >
       <svg
         height="24"
@@ -267,24 +267,16 @@ exports[`<Banner /> renders correctly with custom title for the close button 1`]
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <span
         class="text text--dark text--primary sc-ifAKCX jrkHpW"
       >
         This is your primary message text.
       </span>
-      <a
-        class="sc-jTzLTM cjtCRQ sc-dnqmqq dlopAQ"
-        href="ticketmaster.com"
-        rel=""
-        target="_self"
-      >
-        test link text
-      </a>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG hcBAne sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT SFrkV sc-ifAKCX gwaFLV"
         />
       </div>
     </div>
@@ -295,11 +287,11 @@ exports[`<Banner /> renders correctly with custom title for the close button 1`]
 exports[`<Banner /> renders correctly with expand/collapse button 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-fjdhpX dRzThv"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
     style="max-height: 56px;"
   >
     <div
-      class="sc-kgoBCf kDgYaG"
+      class="sc-jzJRlG gEWVas"
     >
       <svg
         height="24"
@@ -332,23 +324,16 @@ exports[`<Banner /> renders correctly with expand/collapse button 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <span
         class="text text--dark text--primary sc-ifAKCX jrkHpW"
       >
         This is your primary message text.
       </span>
-      <button
-        class="sc-jTzLTM cjtCRQ sc-gZMcBi euikXH"
-        rel=""
-        target="_self"
-      >
-        collapsedText
-      </button>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG hcBAne sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT SFrkV sc-ifAKCX gwaFLV"
         >
           test content
         </div>
@@ -361,11 +346,11 @@ exports[`<Banner /> renders correctly with expand/collapse button 1`] = `
 exports[`<Banner /> renders correctly with link 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-fjdhpX dRzThv"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
     style="max-height: 56px;"
   >
     <div
-      class="sc-kgoBCf kDgYaG"
+      class="sc-jzJRlG gEWVas"
     >
       <svg
         height="24"
@@ -398,24 +383,16 @@ exports[`<Banner /> renders correctly with link 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <span
         class="text text--dark text--primary sc-ifAKCX jrkHpW"
       >
         This is your primary message text.
       </span>
-      <a
-        class="sc-jTzLTM cjtCRQ sc-dnqmqq dlopAQ"
-        href="ticketmaster.com"
-        rel=""
-        target="_self"
-      >
-        test link text
-      </a>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG hcBAne sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT SFrkV sc-ifAKCX gwaFLV"
         />
       </div>
     </div>

--- a/src/components/Banner/__tests__/index.spec.js
+++ b/src/components/Banner/__tests__/index.spec.js
@@ -6,6 +6,7 @@ import { ClearIcon } from "../../Icons";
 import Banner from "..";
 
 jest.mock("../../Button");
+jest.mock("../../Text/LinkCta");
 
 describe("<Banner />", () => {
   it("renders correctly when closed", () => {

--- a/src/components/FeedbackInline/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/FeedbackInline/__tests__/__snapshots__/index.spec.js.snap
@@ -3,25 +3,25 @@
 exports[`<FeedbackInline /> renders correctly 1`] = `
 <div>
   <div
-    class="collapsed sc-fjdhpX cktlnv"
+    class="collapsed sc-gZMcBi gdDZRZ"
     style="max-height: 21px;"
   >
     <div
-      class="sc-kAzzGY hmZSsV"
+      class="sc-jTzLTM fSclqV"
     />
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <div>
         <span
-          class="text text--dark text--primary sc-chPdSV fsNAas sc-ifAKCX jrkHpW"
+          class="text text--dark text--primary sc-fjdhpX kBqDjO sc-ifAKCX jrkHpW"
         >
           This is your primary message text.
         </span>
       </div>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG PrNzx sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT hQKXeL sc-ifAKCX gwaFLV"
         />
       </div>
     </div>
@@ -32,11 +32,11 @@ exports[`<FeedbackInline /> renders correctly 1`] = `
 exports[`<FeedbackInline /> renders correctly when variant is set 1`] = `
 <div>
   <div
-    class="collapsed banner-variant--alert sc-fjdhpX cktlnv"
+    class="collapsed banner-variant--alert sc-gZMcBi gdDZRZ"
     style="max-height: 21px;"
   >
     <div
-      class="sc-kAzzGY hmZSsV"
+      class="sc-jTzLTM fSclqV"
     >
       <svg
         class=""
@@ -70,25 +70,18 @@ exports[`<FeedbackInline /> renders correctly when variant is set 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <div>
         <span
-          class="text text--dark text--primary sc-chPdSV fsNAas sc-ifAKCX jrkHpW"
+          class="text text--dark text--primary sc-fjdhpX kBqDjO sc-ifAKCX jrkHpW"
         >
           This is your primary message text.
         </span>
-        <button
-          class="sc-jTzLTM gRMNJN sc-gZMcBi euikXH"
-          rel=""
-          target="_self"
-        >
-          collapsed
-        </button>
       </div>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG PrNzx sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT hQKXeL sc-ifAKCX gwaFLV"
         >
           test content
         </div>
@@ -101,11 +94,11 @@ exports[`<FeedbackInline /> renders correctly when variant is set 1`] = `
 exports[`<FeedbackInline /> renders correctly with content 1`] = `
 <div>
   <div
-    class="collapsed banner-variant--alert sc-fjdhpX cktlnv"
+    class="collapsed banner-variant--alert sc-gZMcBi gdDZRZ"
     style="max-height: 21px;"
   >
     <div
-      class="sc-kAzzGY hmZSsV"
+      class="sc-jTzLTM fSclqV"
     >
       <svg
         class=""
@@ -139,25 +132,18 @@ exports[`<FeedbackInline /> renders correctly with content 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <div>
         <span
-          class="text text--dark text--primary sc-chPdSV fsNAas sc-ifAKCX jrkHpW"
+          class="text text--dark text--primary sc-fjdhpX kBqDjO sc-ifAKCX jrkHpW"
         >
           This is your primary message text.
         </span>
-        <button
-          class="sc-jTzLTM gRMNJN sc-gZMcBi euikXH"
-          rel=""
-          target="_self"
-        >
-          collapsed
-        </button>
       </div>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG PrNzx sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT hQKXeL sc-ifAKCX gwaFLV"
         >
           test content
         </div>
@@ -170,11 +156,11 @@ exports[`<FeedbackInline /> renders correctly with content 1`] = `
 exports[`<FeedbackInline /> renders correctly with custom icon 1`] = `
 <div>
   <div
-    class="collapsed sc-fjdhpX cktlnv"
+    class="collapsed sc-gZMcBi gdDZRZ"
     style="max-height: 21px;"
   >
     <div
-      class="sc-kAzzGY hmZSsV"
+      class="sc-jTzLTM fSclqV"
     >
       <svg
         height="24"
@@ -199,25 +185,18 @@ exports[`<FeedbackInline /> renders correctly with custom icon 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <div>
         <span
-          class="text text--dark text--primary sc-chPdSV fsNAas sc-ifAKCX jrkHpW"
+          class="text text--dark text--primary sc-fjdhpX kBqDjO sc-ifAKCX jrkHpW"
         >
           This is your primary message text.
         </span>
-        <button
-          class="sc-jTzLTM gRMNJN sc-gZMcBi euikXH"
-          rel=""
-          target="_self"
-        >
-          collapsed
-        </button>
       </div>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG PrNzx sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT hQKXeL sc-ifAKCX gwaFLV"
         >
           test content
         </div>
@@ -230,12 +209,12 @@ exports[`<FeedbackInline /> renders correctly with custom icon 1`] = `
 exports[`<FeedbackInline /> renders correctly with link 1`] = `
 <div>
   <div
-    class="collapsed banner-variant--alert sc-fjdhpX cktlnv"
+    class="collapsed banner-variant--alert sc-gZMcBi gdDZRZ"
     href="https://www.ticketmaster.com/"
     style="max-height: 21px;"
   >
     <div
-      class="sc-kAzzGY hmZSsV"
+      class="sc-jTzLTM fSclqV"
     >
       <svg
         class=""
@@ -269,26 +248,18 @@ exports[`<FeedbackInline /> renders correctly with link 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jzJRlG fvgFIg"
+      class="sc-gqjmRU bnZzdM"
     >
       <div>
         <span
-          class="text text--dark text--primary sc-chPdSV fsNAas sc-ifAKCX jrkHpW"
+          class="text text--dark text--primary sc-fjdhpX kBqDjO sc-ifAKCX jrkHpW"
         >
           This is your primary message text.
         </span>
-        <a
-          class="sc-jTzLTM gRMNJN sc-dnqmqq dlopAQ"
-          href="https://www.ticketmaster.com/"
-          rel="noopener"
-          target="_blank"
-        >
-          Link
-        </a>
       </div>
       <div>
         <div
-          class="text text--dark text--primary sc-cSHVUG PrNzx sc-ifAKCX gwaFLV"
+          class="text text--dark text--primary sc-VigVT hQKXeL sc-ifAKCX gwaFLV"
         >
           test content
         </div>

--- a/src/components/FeedbackInline/__tests__/index.spec.js
+++ b/src/components/FeedbackInline/__tests__/index.spec.js
@@ -6,6 +6,8 @@ import { ClearIcon } from "../../Icons";
 import FeedbackInline, { contentValidator } from "..";
 import { BASE_FEEDBACK_HEIGHT } from "../FeedbackInline.styles";
 
+jest.mock("../../Text/LinkCta");
+
 describe("<FeedbackInline />", () => {
   it("renders correctly", () => {
     const { container } = render(renderInlineFeedback());

--- a/src/components/Text/LinkCta.js
+++ b/src/components/Text/LinkCta.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
@@ -31,6 +31,10 @@ const LinkCtaBase = styled.a`
 
   &:hover {
     color: ${getThemeValue("primary", "medium")};
+  }
+
+  &.noFocus:focus {
+    text-decoration: none;
   }
 `;
 
@@ -69,33 +73,66 @@ const getElement = ({ href, onClick, reverseColors }) => {
   return LinkCtaSpanBase;
 };
 
-const LinkCta = ({
-  href,
-  onClick,
-  children,
-  size,
-  responsiveSize,
-  reverseColors,
-  ...props
-}) => {
-  const { target, rel } = props;
-  const Elm = getElement({ href, onClick, reverseColors });
-  const asProp = getAsProp({ href, onClick });
-  const validatedRel = getRelByTarget(target, rel);
+class LinkCta extends Component {
+  componentDidMount() {
+    if (this.link && this.link.current) {
+      this.link.current.addEventListener("focus", this.focusHandler);
+      this.link.current.addEventListener("blur", this.blurHandler);
+    }
+  }
 
-  return (
-    <Elm
-      {...props}
-      {...asProp}
-      size={getResponsiveSize({ size, responsiveSize })}
-      href={href}
-      onClick={onClick}
-      rel={validatedRel}
-    >
-      {children}
-    </Elm>
-  );
-};
+  componentWillUnmount() {
+    // in case user leaves a page before onBlur is triggered
+    global.window.removeEventListener("keyup", this.activateFocusStyles);
+  }
+
+  focusHandler = () => {
+    global.window.addEventListener("keyup", this.activateFocusStyles);
+  };
+
+  blurHandler = () => {
+    this.link.current.classList.add("noFocus");
+    global.window.removeEventListener("keyup", this.activateFocusStyles);
+  };
+
+  activateFocusStyles = () => {
+    this.link.current.classList.remove("noFocus");
+  };
+
+  link = React.createRef();
+
+  render() {
+    const {
+      href,
+      onClick,
+      children,
+      size,
+      responsiveSize,
+      reverseColors,
+      ...rest
+    } = this.props;
+
+    const { target, rel } = rest;
+    const Elm = getElement({ href, onClick, reverseColors });
+    const asProp = getAsProp({ href, onClick });
+    const validatedRel = getRelByTarget(target, rel);
+
+    return (
+      <Elm
+        {...rest}
+        {...asProp}
+        size={getResponsiveSize({ size, responsiveSize })}
+        href={href}
+        onClick={onClick}
+        rel={validatedRel}
+        ref={this.link}
+        className={`${rest.className || ""} noFocus`}
+      >
+        {children}
+      </Elm>
+    );
+  }
+}
 
 LinkCta.propTypes = {
   size: PropTypes.string,

--- a/src/components/Text/__tests__/LinkCta.spec.js
+++ b/src/components/Text/__tests__/LinkCta.spec.js
@@ -26,6 +26,89 @@ describe("LinkCta", () => {
     ).toMatchSnapshot();
   });
 
+  it("activateFocusStyles should remove noFocus class from link", () => {
+    const instance = renderer
+      .create(<LinkCta>I am a link</LinkCta>)
+      .getInstance();
+    const mock = jest.fn();
+
+    instance.link.current = {
+      classList: {
+        remove: mock
+      }
+    };
+    instance.activateFocusStyles();
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith("noFocus");
+  });
+
+  it("focusHandler should add keyup listener", () => {
+    const instance = renderer
+      .create(<LinkCta>I am a link</LinkCta>)
+      .getInstance();
+    const mock = jest.fn();
+    global.window.addEventListener = mock;
+
+    instance.focusHandler();
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith("keyup", instance.activateFocusStyles);
+  });
+
+  it("componentWillUnmount should remove keyup listener", () => {
+    const instance = renderer
+      .create(<LinkCta>I am a link</LinkCta>)
+      .getInstance();
+    const mock = jest.fn();
+    global.window.removeEventListener = mock;
+
+    instance.componentWillUnmount();
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith("keyup", instance.activateFocusStyles);
+  });
+
+  it("componentDidMount should add focus and blur listeners to link", () => {
+    const instance = renderer
+      .create(<LinkCta>I am a link</LinkCta>)
+      .getInstance();
+    const mock = jest.fn();
+
+    instance.link.current = {
+      addEventListener: mock
+    };
+    instance.componentDidMount();
+
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(mock).toHaveBeenCalledWith("focus", instance.focusHandler);
+    expect(mock).toHaveBeenCalledWith("blur", instance.blurHandler);
+  });
+
+  it("blurHandler should add noFocus class to link and remove keyup listener", () => {
+    const instance = renderer
+      .create(<LinkCta>I am a link</LinkCta>)
+      .getInstance();
+    const mock = jest.fn();
+    const mockKeyUp = jest.fn();
+
+    instance.link.current = {
+      classList: {
+        add: mock
+      }
+    };
+    global.window.removeEventListener = mockKeyUp;
+    instance.blurHandler();
+
+    expect(mockKeyUp).toHaveBeenCalledTimes(1);
+    expect(mockKeyUp).toHaveBeenCalledWith(
+      "keyup",
+      instance.activateFocusStyles
+    );
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith("noFocus");
+  });
+
   it("static size from typography", () => {
     expect(
       renderer.create(<LinkCta size="normal">I am a link</LinkCta>).toJSON() // eslint-disable-line

--- a/src/components/Text/__tests__/__snapshots__/LinkCta.spec.js.snap
+++ b/src/components/Text/__tests__/__snapshots__/LinkCta.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`LinkCta renders a button when only onclick is provided 1`] = `
 <button
-  className="yFSnI"
+  className=" noFocus jGTFdF"
   href={null}
   onClick={[Function]}
   rel=""
@@ -15,7 +15,7 @@ exports[`LinkCta renders a button when only onclick is provided 1`] = `
 
 exports[`LinkCta renders a default LinkCta 1`] = `
 <a
-  className="cCHMdr"
+  className=" noFocus jBwpNk"
   href="http://localhost/"
   onClick={null}
   rel=""
@@ -28,7 +28,7 @@ exports[`LinkCta renders a default LinkCta 1`] = `
 
 exports[`LinkCta renders a span when no href or onClick provided 1`] = `
 <span
-  className="fWfuCJ"
+  className=" noFocus KUoDS"
   href={null}
   onClick={null}
   rel=""
@@ -41,7 +41,7 @@ exports[`LinkCta renders a span when no href or onClick provided 1`] = `
 
 exports[`LinkCta renders correctly with reverse colors 1`] = `
 <a
-  className="inHduZ"
+  className=" noFocus kGjWNx"
   href="#"
   onClick={null}
   rel=""
@@ -54,7 +54,7 @@ exports[`LinkCta renders correctly with reverse colors 1`] = `
 
 exports[`LinkCta static size as pixels 1`] = `
 <span
-  className="imKxef"
+  className=" noFocus fUMEpv"
   href={null}
   onClick={null}
   rel=""
@@ -67,7 +67,7 @@ exports[`LinkCta static size as pixels 1`] = `
 
 exports[`LinkCta static size from typography 1`] = `
 <span
-  className="imKxef"
+  className=" noFocus fUMEpv"
   href={null}
   onClick={null}
   rel=""


### PR DESCRIPTION
**What**:

LinkCta doesn't get underlined when user clicks on it. It get underlined on keyboard focus.

**Why**:

Behavior change was requested

**How**:

Add noFocus class by default. Add keyup listener to the window object and focus and blur listeners to the link. Use the callbacks to add/remove noFocus class which disables the underline.

**Checklist**:
* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
