### PR TITLE
fix(Tooltip): initial animation when tooltip direction is auto

### DIFF
--- a/catalog/pages/tooltip/SeatTooltipDemo.js
+++ b/catalog/pages/tooltip/SeatTooltipDemo.js
@@ -2,15 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import SeatTooltip from "../../../src/components/Tooltip/SeatTooltip";
+import { themes } from "../../../src/theme";
+import { Text } from "../../../src/components/Text";
 
-const Container = styled.div`
-  margin-top: 100px;
-  width: 95%;
-  height: 400px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-direction: row;
+const TooltipText = styled(Text).attrs({
+  weight: "semiBold",
+  tag: "span"
+})`
+  color: ${themes.global.primary.base};
 `;
 
 export const TooltipButton = styled.div`
@@ -24,13 +23,23 @@ export const TooltipButton = styled.div`
 `;
 
 class TooltipDemo extends React.Component {
-  constructor(props) {
-    super(props);
+  static propTypes = {
+    variant: PropTypes.oneOf(["dark", "light"]),
+    text: PropTypes.string.isRequired,
+    direction: PropTypes.string.isRequired,
+    size: PropTypes.oneOf(["small", "large"])
+  };
 
-    this.state = {
-      isOpened: false
-    };
-  }
+  static defaultProps = {
+    variant: "light",
+    size: "large"
+  };
+
+  static tooltipText = "Some text to be rendered in the pop over component.";
+
+  state = {
+    isOpened: false
+  };
 
   mouseLeave = () => {
     this.setState({
@@ -38,72 +47,42 @@ class TooltipDemo extends React.Component {
     });
   };
 
-  elementHovered = (e, direction) => {
+  elementHovered = e => {
     const data = SeatTooltip.getDimensionsFromEvent(e);
     this.setState({
       isOpened: true,
-      direction,
       ...data
     });
   };
 
   render() {
-    const { isOpened, direction, ...position } = this.state;
-    const { size, variant } = this.props;
-    const tooltip =
-      "Some text to be rendered in theeii pop over component. Some text to be rendered in the popover component.";
+    const { isOpened, ...position } = this.state;
+    const { variant, direction, text, size } = this.props;
+
     return (
-      <Container>
-        <TooltipButton
-          onMouseEnter={e => this.elementHovered(e, "top")}
+      <div style={{ display: "flex" }}>
+        <TooltipText
+          onMouseEnter={this.elementHovered}
           onMouseLeave={this.mouseLeave}
         >
-          Top
-        </TooltipButton>
-        <TooltipButton
-          onMouseEnter={e => this.elementHovered(e, "bottom")}
-          onMouseLeave={this.mouseLeave}
-        >
-          Bottom
-        </TooltipButton>
-        <TooltipButton
-          onMouseEnter={e => this.elementHovered(e, "right")}
-          onMouseLeave={this.mouseLeave}
-        >
-          Right
-        </TooltipButton>
-        <TooltipButton
-          onMouseEnter={e => this.elementHovered(e, "left")}
-          onMouseLeave={this.mouseLeave}
-        >
-          Left
-        </TooltipButton>
+          {text}
+        </TooltipText>
 
         <SeatTooltip
-          variant={variant}
           size={size}
-          isVisible={isOpened}
           row={5}
           seat={25}
           section="B"
+          isVisible={isOpened}
           position={{ ...position }}
           direction={direction}
+          variant={variant}
         >
-          {tooltip}
+          {TooltipDemo.tooltipText}
         </SeatTooltip>
-      </Container>
+      </div>
     );
   }
 }
-
-TooltipDemo.propTypes = {
-  size: PropTypes.oneOf(["small", "large"]),
-  variant: PropTypes.oneOf(["light", "dark"])
-};
-
-TooltipDemo.defaultProps = {
-  size: "large",
-  variant: "light"
-};
 
 export default TooltipDemo;

--- a/catalog/pages/tooltip/TooltipDemo.js
+++ b/catalog/pages/tooltip/TooltipDemo.js
@@ -1,44 +1,34 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import Tooltip from "../../../src/components/Tooltip";
-import {
-  VARIANTS,
-  LIGHT,
-  TOP,
-  BOTTOM,
-  LEFT,
-  RIGHT
-} from "../../../src/components/constants";
+import { themes } from "../../../src/theme";
+import { Text } from "../../../src/components/Text";
 
-const Container = styled.div`
-  margin-top: 100px;
-  width: 95%;
-  height: 400px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-direction: row;
+const TooltipText = styled(Text).attrs({
+  weight: "semiBold",
+  tag: "span"
+})`
+  color: ${themes.global.primary.base};
 `;
 
-export const TooltipButton = styled.div`
-  width: 100px;
-  height: 50px;
-  border: 1px solid red;
-  display: inline-block;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
+class TooltipDemo extends Component {
+  static propTypes = {
+    variant: PropTypes.oneOf(["dark", "light"]),
+    text: PropTypes.string.isRequired,
+    direction: PropTypes.string.isRequired
+  };
 
-class TooltipDemo extends React.Component {
-  constructor(props) {
-    super(props);
+  static defaultProps = {
+    variant: "light"
+  };
 
-    this.state = {
-      isOpened: false
-    };
-  }
+  static tooltipText =
+    "This is a basic tooltip. If there is a need for multiple lines, it grows downward.";
+
+  state = {
+    isOpened: false
+  };
 
   mouseLeave = () => {
     this.setState({
@@ -46,46 +36,26 @@ class TooltipDemo extends React.Component {
     });
   };
 
-  elementHovered = (e, direction) => {
+  elementHovered = e => {
     const data = Tooltip.getDimensionsFromEvent(e);
     this.setState({
       isOpened: true,
-      direction,
       ...data
     });
   };
 
   render() {
-    const { isOpened, direction, ...position } = this.state;
-    const { variant } = this.props;
-    const tooltip =
-      "Some text to be rendered in theeii pop over component. Some text to be rendered in the popover component.";
+    const { isOpened, ...position } = this.state;
+    const { variant, direction, text } = this.props;
+
     return (
-      <Container>
-        <TooltipButton
-          onMouseEnter={e => this.elementHovered(e, TOP)}
+      <div style={{ display: "flex" }}>
+        <TooltipText
+          onMouseEnter={this.elementHovered}
           onMouseLeave={this.mouseLeave}
         >
-          Top
-        </TooltipButton>
-        <TooltipButton
-          onMouseEnter={e => this.elementHovered(e, BOTTOM)}
-          onMouseLeave={this.mouseLeave}
-        >
-          Bottom
-        </TooltipButton>
-        <TooltipButton
-          onMouseEnter={e => this.elementHovered(e, RIGHT)}
-          onMouseLeave={this.mouseLeave}
-        >
-          Right
-        </TooltipButton>
-        <TooltipButton
-          onMouseEnter={e => this.elementHovered(e, LEFT)}
-          onMouseLeave={this.mouseLeave}
-        >
-          Left
-        </TooltipButton>
+          {text}
+        </TooltipText>
 
         <Tooltip
           isVisible={isOpened}
@@ -93,18 +63,11 @@ class TooltipDemo extends React.Component {
           direction={direction}
           variant={variant}
         >
-          {tooltip}
+          {TooltipDemo.tooltipText}
         </Tooltip>
-      </Container>
+      </div>
     );
   }
 }
-
-TooltipDemo.propTypes = {
-  variant: PropTypes.oneOf(VARIANTS)
-};
-TooltipDemo.defaultProps = {
-  variant: LIGHT
-};
 
 export default TooltipDemo;

--- a/catalog/pages/tooltip/TooltipRestricted.js
+++ b/catalog/pages/tooltip/TooltipRestricted.js
@@ -1,0 +1,128 @@
+import React from "react";
+import styled from "styled-components";
+import Tooltip from "../../../src/components/Tooltip";
+import { LinkCta } from "../../../src/components/Text";
+
+const Container = styled.div`
+  height: 600px;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+`;
+
+const TooltipButton = styled.div`
+  display: inline-block;
+`;
+
+class TooltipRestrictedDemo extends React.Component {
+  state = {
+    isOpened: false
+  };
+
+  componentWillUnmount() {
+    document.body.removeEventListener("touchstart", this.mouseLeave);
+  }
+
+  containerRef = React.createRef();
+
+  mouseLeave = e => {
+    e.stopPropagation();
+    document.body.removeEventListener("touchstart", this.mouseLeave);
+    this.setState({
+      isOpened: false
+    });
+  };
+
+  buttonSelect = e => {
+    const data = Tooltip.getDimensionsFromEvent(e, this.containerRef.current);
+    this.setState(state => {
+      if (state.isOpened) {
+        return state;
+      }
+
+      document.body.addEventListener("touchstart", this.mouseLeave);
+      return {
+        isOpened: true,
+        ...data
+      };
+    });
+  };
+
+  render() {
+    const { isOpened, ...position } = this.state;
+
+    return (
+      <Container ref={this.containerRef}>
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "space-between"
+          }}
+        >
+          <TooltipButton>
+            <LinkCta
+              onMouseEnter={this.buttonSelect}
+              onMouseLeave={this.mouseLeave}
+              onTouchStart={this.buttonSelect}
+            >
+              Hover for Tooltip
+            </LinkCta>
+          </TooltipButton>
+          <TooltipButton>
+            <LinkCta
+              onMouseEnter={this.buttonSelect}
+              onMouseLeave={this.mouseLeave}
+              onTouchStart={this.buttonSelect}
+            >
+              Hover for Tooltip
+            </LinkCta>
+          </TooltipButton>
+        </div>
+        <div style={{ width: "100%", textAlign: "center" }}>
+          <TooltipButton>
+            <LinkCta
+              onMouseEnter={this.buttonSelect}
+              onMouseLeave={this.mouseLeave}
+              onTouchStart={this.buttonSelect}
+            >
+              Hover for Tooltip
+            </LinkCta>
+          </TooltipButton>
+        </div>
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "space-between"
+          }}
+        >
+          <TooltipButton>
+            <LinkCta
+              onMouseEnter={this.buttonSelect}
+              onMouseLeave={this.mouseLeave}
+              onTouchStart={this.buttonSelect}
+            >
+              Hover for Tooltip
+            </LinkCta>
+          </TooltipButton>
+          <TooltipButton>
+            <LinkCta
+              onMouseEnter={this.buttonSelect}
+              onMouseLeave={this.mouseLeave}
+              onTouchStart={this.buttonSelect}
+            >
+              Hover for Tooltip
+            </LinkCta>
+          </TooltipButton>
+        </div>
+        <Tooltip isVisible={isOpened} position={{ ...position }}>
+          This is a basic tooltip. If there is a need for multiple lines, it
+          grows downward.
+        </Tooltip>
+      </Container>
+    );
+  }
+}
+
+export default TooltipRestrictedDemo;

--- a/catalog/pages/tooltip/index.js
+++ b/catalog/pages/tooltip/index.js
@@ -2,13 +2,15 @@ import { pageLoader } from "catalog";
 
 import TooltipDemo from "./TooltipDemo";
 import SeatTooltipDemo from "./SeatTooltipDemo";
+import TooltipRestrictedDemo from "./TooltipRestricted";
 
 export default {
   path: "/tooltip",
   title: "Tooltip",
   imports: {
     TooltipDemo,
-    SeatTooltipDemo
+    SeatTooltipDemo,
+    TooltipRestrictedDemo
   },
   content: pageLoader(() => import("./index.md"))
 };

--- a/catalog/pages/tooltip/index.md
+++ b/catalog/pages/tooltip/index.md
@@ -19,17 +19,42 @@ rows:
     Type: one of 'dark', 'light'
     Default: 'light'
     Notes: Changes tooltip color scheme
+  - Prop: direction
+    Type: one of 'left', 'right', 'top', 'bottom'
+    Default: 'auto'
+    Notes: Changes tooltip direction from the item that triggers it. Auto shows the tooltip on top/bottom and makes sure it is always visibel in the view port and in the restriction container that is being passed as second param to getDimensionsFromEvent
   - Prop: position
     Type: Object
     Default: all props are 0
-    Notes: This prop is generated from Tooltip.getDimensionsFromEvent(e) static function. The function should receive the event that triggers the Tooltip (usually hover).
+    Notes: This prop is generated from Tooltip.getDimensionsFromEvent(e, parent) static function. The function should receive the event that triggers the Tooltip (usually hover). Secondary parameter that restricts tooltip to be visible in a certain container. Work only if direction is auto
+```
+
+```react
+---
+<div style={{ display: 'flex', justifyContent: 'space-between' }}>
+  <TooltipDemo
+    direction="bottom"
+    text="Hover for Bottom Tooltip"
+  />
+  <TooltipDemo
+    direction="top"
+    text="Hover for Top Tooltip"
+  />
+  <TooltipDemo
+    direction="right"
+    text="Hover for Right Tooltip"
+  />
+  <TooltipDemo
+    direction="left"
+    text="Hover for Left Tooltip"
+  />
+</div>
 ```
 
 ```react
 ---
 <div>
-  <TooltipDemo />
-  <TooltipDemo variant="dark" />
+  <TooltipRestrictedDemo />
 </div>
 ```
 
@@ -57,7 +82,10 @@ rows:
   - Prop: size
     Type: one of 'small', 'large'
     Default: 'large'
-    Notes: Changes tooltip width
+  - Prop: direction
+    Type: one of 'left', 'right', 'top', 'bottom'
+    Default: 'auto'
+    Notes: Changes tooltip direction from the item that triggers it. Auto shows the tooltip on top/bottom and makes sure it is always visibel in the view port and in the restriction container that is being passed as second param to getDimensionsFromEvent
   - Prop: section
     Type: string or number
     Default: n/a
@@ -73,13 +101,55 @@ rows:
   - Prop: position
     Type: Object
     Default: all props are 0
-    Notes: This prop is generated from Tooltip.getDimensionsFromEvent(e) static function. The function should recieve the event that triggers the Tooltip (usually hover).
+    Notes: This prop is generated from SeatTooltip.getDimensionsFromEvent(e, parent) static function. The function should recieve the event that triggers the Tooltip (usually hover). Secondary parameter that restricts seat tooltip to be visible in a certain container. Work only if direction is auto
 ```
 
 ```react
 ---
 <div>
-  <SeatTooltipDemo />
-  <SeatTooltipDemo size="small" variant="dark" />
+  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+    <SeatTooltipDemo
+      direction="bottom"
+      text="Hover for Bottom Tooltip"
+    />
+    <SeatTooltipDemo
+      direction="top"
+      text="Hover for Top Tooltip"
+    />
+    <SeatTooltipDemo
+      direction="right"
+      text="Hover for Right Tooltip"
+    />
+    <SeatTooltipDemo
+      direction="left"
+      text="Hover for Left Tooltip"
+    />
+  </div>
+  <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '20px' }}>
+    <SeatTooltipDemo
+      size="small"
+      variant="dark"
+      direction="bottom"
+      text="Hover for Bottom Tooltip"
+    />
+    <SeatTooltipDemo
+      size="small"
+      variant="dark"
+      direction="top"
+      text="Hover for Top Tooltip"
+    />
+    <SeatTooltipDemo
+      size="small"
+      variant="dark"
+      direction="right"
+      text="Hover for Right Tooltip"
+    />
+    <SeatTooltipDemo
+      size="small"
+      variant="dark"
+      direction="left"
+      text="Hover for Left Tooltip"
+    />
+  </div>
 </div>
 ```

--- a/src/components/Tooltip/Tooltip.styles.js
+++ b/src/components/Tooltip/Tooltip.styles.js
@@ -78,22 +78,7 @@ export const StyledTooltip = styled.div`
 
   &.open-enter,
   &.open-appear {
-    transition: opacity 0.3s ${constants.easing.easeOutQuad},
-      transform 0.3s ${constants.easing.easeOutQuad};
-    transform: translate(0, 10px);
-    ${({ direction }) => {
-      switch (direction) {
-        case TOP:
-          return "transform: translate(0, 10px);";
-        case BOTTOM:
-          return "transform: translate(0, -10px);";
-        case LEFT:
-          return "transform: translate(10px, 0);";
-        case RIGHT:
-        default:
-          return "transform: translate(-10px, 0);";
-      }
-    }};
+    transition: opacity 0.3s ${constants.easing.easeOutQuad};
   }
 
   &.open-enter-active,
@@ -109,7 +94,6 @@ export const StyledTooltip = styled.div`
   &.open-appear-active {
     transition: opacity 0.3s ${constants.easing.easeOutQuad},
       transform 0.3s ${constants.easing.easeOutQuad};
-    transform: translate(0);
   }
 
   &.open-enter-done,

--- a/src/components/Tooltip/__tests__/__snapshots__/SeatTooltip.spec.js.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/SeatTooltip.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SeatTooltip should match snapshot when has children 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -11,7 +11,7 @@ exports[`SeatTooltip should match snapshot when has children 1`] = `
 }
 
 <div
-  className="c0 jhiaLu"
+  className="c0 cENRLf"
   direction="auto"
   style={
     Object {
@@ -85,9 +85,9 @@ exports[`SeatTooltip should match snapshot when has children 1`] = `
 `;
 
 exports[`SeatTooltip should match snapshot when no children and dark 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -95,7 +95,7 @@ exports[`SeatTooltip should match snapshot when no children and dark 1`] = `
 }
 
 <div
-  className="c0 jhiaLu"
+  className="c0 cENRLf"
   direction="auto"
   style={
     Object {
@@ -161,9 +161,9 @@ exports[`SeatTooltip should match snapshot when no children and dark 1`] = `
 `;
 
 exports[`SeatTooltip should match snapshot when small and dark 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -171,7 +171,7 @@ exports[`SeatTooltip should match snapshot when small and dark 1`] = `
 }
 
 <div
-  className="c0 jhiaLu"
+  className="c0 cENRLf"
   direction="auto"
   style={
     Object {

--- a/src/components/Tooltip/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/index.spec.js.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip dark should match snapshot 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.kISaWX.open-enter .c0.open-enter:before,
-.kISaWX.open-appear,
-.kISaWX.open-appear:before {
+.bcUhGD.open-enter .c0.open-enter:before,
+.bcUhGD.open-appear,
+.bcUhGD.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -20,15 +20,15 @@ exports[`Tooltip dark should match snapshot 1`] = `
 }
 
 <div
-  className="c0 kISaWX"
+  className="c0 bcUhGD"
   direction="auto"
 />
 `;
 
 exports[`Tooltip should match snapshot 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -36,33 +36,33 @@ exports[`Tooltip should match snapshot 1`] = `
 }
 
 <div
-  className="c0 jhiaLu"
+  className="c0 cENRLf"
   direction="auto"
 />
 `;
 
 exports[`Tooltip should match snapshot when visisble and direction is bottom 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.kISaWX.open-enter .c0.open-enter:before,
-.kISaWX.open-appear,
-.kISaWX.open-appear:before {
+.bcUhGD.open-enter .c0.open-enter:before,
+.bcUhGD.open-appear,
+.bcUhGD.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.gcYeuC.open-enter .c0.open-enter:before,
-.gcYeuC.open-appear,
-.gcYeuC.open-appear:before {
+.kyRINg.open-enter .c0.open-enter:before,
+.kyRINg.open-appear,
+.kyRINg.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -70,60 +70,60 @@ exports[`Tooltip should match snapshot when visisble and direction is bottom 1`]
 }
 
 <div
-  className="c0 gcYeuC"
+  className="c0 kyRINg"
   direction="bottom"
 />
 `;
 
 exports[`Tooltip should match snapshot when visisble and direction is invalid 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.kISaWX.open-enter .c0.open-enter:before,
-.kISaWX.open-appear,
-.kISaWX.open-appear:before {
+.bcUhGD.open-enter .c0.open-enter:before,
+.bcUhGD.open-appear,
+.bcUhGD.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.gcYeuC.open-enter .c0.open-enter:before,
-.gcYeuC.open-appear,
-.gcYeuC.open-appear:before {
+.kyRINg.open-enter .c0.open-enter:before,
+.kyRINg.open-appear,
+.kyRINg.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.htWMCk.open-enter .c0.open-enter:before,
-.htWMCk.open-appear,
-.htWMCk.open-appear:before {
+.diTJYY.open-enter .c0.open-enter:before,
+.diTJYY.open-appear,
+.diTJYY.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.gyvfKo.open-enter .c0.open-enter:before,
-.gyvfKo.open-appear,
-.gyvfKo.open-appear:before {
+.gCIEPE.open-enter .c0.open-enter:before,
+.gCIEPE.open-appear,
+.gCIEPE.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.jQqalR.open-enter .c0.open-enter:before,
-.jQqalR.open-appear,
-.jQqalR.open-appear:before {
+.cnGjUl.open-enter .c0.open-enter:before,
+.cnGjUl.open-appear,
+.cnGjUl.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -131,51 +131,51 @@ exports[`Tooltip should match snapshot when visisble and direction is invalid 1`
 }
 
 <div
-  className="c0 kISaWX"
+  className="c0 bcUhGD"
   direction="invalid"
 />
 `;
 
 exports[`Tooltip should match snapshot when visisble and direction is left 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.kISaWX.open-enter .c0.open-enter:before,
-.kISaWX.open-appear,
-.kISaWX.open-appear:before {
+.bcUhGD.open-enter .c0.open-enter:before,
+.bcUhGD.open-appear,
+.bcUhGD.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.gcYeuC.open-enter .c0.open-enter:before,
-.gcYeuC.open-appear,
-.gcYeuC.open-appear:before {
+.kyRINg.open-enter .c0.open-enter:before,
+.kyRINg.open-appear,
+.kyRINg.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.htWMCk.open-enter .c0.open-enter:before,
-.htWMCk.open-appear,
-.htWMCk.open-appear:before {
+.diTJYY.open-enter .c0.open-enter:before,
+.diTJYY.open-appear,
+.diTJYY.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.gyvfKo.open-enter .c0.open-enter:before,
-.gyvfKo.open-appear,
-.gyvfKo.open-appear:before {
+.gCIEPE.open-enter .c0.open-enter:before,
+.gCIEPE.open-appear,
+.gCIEPE.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -183,60 +183,60 @@ exports[`Tooltip should match snapshot when visisble and direction is left 1`] =
 }
 
 <div
-  className="c0 gyvfKo"
+  className="c0 gCIEPE"
   direction="left"
 />
 `;
 
 exports[`Tooltip should match snapshot when visisble and direction is right 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.kISaWX.open-enter .c0.open-enter:before,
-.kISaWX.open-appear,
-.kISaWX.open-appear:before {
+.bcUhGD.open-enter .c0.open-enter:before,
+.bcUhGD.open-appear,
+.bcUhGD.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.gcYeuC.open-enter .c0.open-enter:before,
-.gcYeuC.open-appear,
-.gcYeuC.open-appear:before {
+.kyRINg.open-enter .c0.open-enter:before,
+.kyRINg.open-appear,
+.kyRINg.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.htWMCk.open-enter .c0.open-enter:before,
-.htWMCk.open-appear,
-.htWMCk.open-appear:before {
+.diTJYY.open-enter .c0.open-enter:before,
+.diTJYY.open-appear,
+.diTJYY.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.gyvfKo.open-enter .c0.open-enter:before,
-.gyvfKo.open-appear,
-.gyvfKo.open-appear:before {
+.gCIEPE.open-enter .c0.open-enter:before,
+.gCIEPE.open-appear,
+.gCIEPE.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.jQqalR.open-enter .c0.open-enter:before,
-.jQqalR.open-appear,
-.jQqalR.open-appear:before {
+.cnGjUl.open-enter .c0.open-enter:before,
+.cnGjUl.open-appear,
+.cnGjUl.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -244,42 +244,42 @@ exports[`Tooltip should match snapshot when visisble and direction is right 1`] 
 }
 
 <div
-  className="c0 jQqalR"
+  className="c0 cnGjUl"
   direction="right"
 />
 `;
 
 exports[`Tooltip should match snapshot when visisble and direction is top 1`] = `
-.jhiaLu.open-enter .c0.open-enter:before,
-.jhiaLu.open-appear,
-.jhiaLu.open-appear:before {
+.cENRLf.open-enter .c0.open-enter:before,
+.cENRLf.open-appear,
+.cENRLf.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.kISaWX.open-enter .c0.open-enter:before,
-.kISaWX.open-appear,
-.kISaWX.open-appear:before {
+.bcUhGD.open-enter .c0.open-enter:before,
+.bcUhGD.open-appear,
+.bcUhGD.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.gcYeuC.open-enter .c0.open-enter:before,
-.gcYeuC.open-appear,
-.gcYeuC.open-appear:before {
+.kyRINg.open-enter .c0.open-enter:before,
+.kyRINg.open-appear,
+.kyRINg.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
   opacity: 0;
 }
 
-.htWMCk.open-enter .c0.open-enter:before,
-.htWMCk.open-appear,
-.htWMCk.open-appear:before {
+.diTJYY.open-enter .c0.open-enter:before,
+.diTJYY.open-appear,
+.diTJYY.open-appear:before {
   -webkit-transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   transition: opacity 0.25s cubic-bezier(0.25,0.46,0.45,0.94);
   display: block;
@@ -287,7 +287,7 @@ exports[`Tooltip should match snapshot when visisble and direction is top 1`] = 
 }
 
 <div
-  className="c0 htWMCk"
+  className="c0 diTJYY"
   direction="top"
 />
 `;


### PR DESCRIPTION
**What**:

When tooltip direction is auto initial animation was wrong.

**Why**:

Depending on tooltips direction the animation should be correct.

**How**:

Add inline transition using onEnter, onEntering, onExit functions provided by CSSTransition component.

**Checklist**:
* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
