### PR TITLE
fix(LinkCta): Remove null defaultProps for href and onClick to ensure markup is semantic

### DIFF
--- a/src/components/Text/LinkCta.js
+++ b/src/components/Text/LinkCta.js
@@ -147,9 +147,9 @@ LinkCta.propTypes = {
 
 LinkCta.defaultProps = {
   size: null,
-  onClick: null,
+  onClick: undefined,
   responsiveSize: PT.defaultResponsiveSize,
-  href: null,
+  href: undefined,
   target: "_self",
   rel: "",
   reverseColors: false

--- a/src/components/Text/__tests__/__snapshots__/LinkCta.spec.js.snap
+++ b/src/components/Text/__tests__/__snapshots__/LinkCta.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`LinkCta renders a button when only onclick is provided 1`] = `
 <button
   className=" noFocus jGTFdF"
-  href={null}
+  href={undefined}
   onClick={[Function]}
   rel=""
   size={null}
@@ -17,7 +17,7 @@ exports[`LinkCta renders a default LinkCta 1`] = `
 <a
   className=" noFocus jBwpNk"
   href="http://localhost/"
-  onClick={null}
+  onClick={undefined}
   rel=""
   size={null}
   target="_self"
@@ -29,8 +29,8 @@ exports[`LinkCta renders a default LinkCta 1`] = `
 exports[`LinkCta renders a span when no href or onClick provided 1`] = `
 <span
   className=" noFocus KUoDS"
-  href={null}
-  onClick={null}
+  href={undefined}
+  onClick={undefined}
   rel=""
   size={null}
   target="_self"
@@ -43,7 +43,7 @@ exports[`LinkCta renders correctly with reverse colors 1`] = `
 <a
   className=" noFocus kGjWNx"
   href="#"
-  onClick={null}
+  onClick={undefined}
   rel=""
   size={null}
   target="_self"
@@ -55,8 +55,8 @@ exports[`LinkCta renders correctly with reverse colors 1`] = `
 exports[`LinkCta static size as pixels 1`] = `
 <span
   className=" noFocus fUMEpv"
-  href={null}
-  onClick={null}
+  href={undefined}
+  onClick={undefined}
   rel=""
   size="20px"
   target="_self"
@@ -68,8 +68,8 @@ exports[`LinkCta static size as pixels 1`] = `
 exports[`LinkCta static size from typography 1`] = `
 <span
   className=" noFocus fUMEpv"
-  href={null}
-  onClick={null}
+  href={undefined}
+  onClick={undefined}
   rel=""
   size="normal"
   target="_self"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am removing null defaultProps for href and onClick

<!-- Why are these changes necessary? -->

**Why**: To ensure markup is semantic

<!-- How were these changes implemented? -->

**How**: I am removing null defaultProps for href and onClick

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
