### PR TITLE
feat(Typography): Update displayNames to be prefixed with Typography obj name; add THEME_TM as the default theme in all relevant utils/mixins

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -4,11 +4,19 @@ import { ThemeProvider } from "styled-components";
 
 import "jest-styled-components";
 
-global.snapshotWithTheme = (Component, { children = null, ...props } = {}) =>
+global.componentSnapshotWithTheme = (
+  Component,
+  { children = null, ...props } = {}
+) =>
   expect(
     renderer.create(
       <ThemeProvider theme={{ themeName: "tm" }}>
         <Component {...props}>{children}</Component>
       </ThemeProvider>
     )
+  ).toMatchSnapshot();
+
+global.componentSnapshot = (Component, { children = null, ...props } = {}) =>
+  expect(
+    renderer.create(<Component {...props}>{children}</Component>)
   ).toMatchSnapshot();

--- a/src/components/Text/Base.js
+++ b/src/components/Text/Base.js
@@ -4,8 +4,9 @@ import classnames from "classnames";
 
 import StyledTextBase from "./Base.styles";
 import * as PT from "./PropTypes";
-import { themeShape, themeTm } from "../../utils/getThemeValue";
+import { themeShape } from "../../utils/getThemeValue";
 import { getResponsiveSize } from "../../utils/responsiveSize";
+import { THEME_TM } from "../../theme/constants";
 
 const AVAILABLE_TAGS = ["div", "span", "p", "h3", "h4", "h5", "h6"];
 
@@ -89,7 +90,7 @@ TextBase.defaultProps = {
   disabled: false,
   allCaps: false,
   monospace: false,
-  theme: themeTm,
+  theme: THEME_TM,
   themed: false
 };
 

--- a/src/components/Typography/H1.js
+++ b/src/components/Typography/H1.js
@@ -15,6 +15,6 @@ const H1 = styled.h1.attrs(
   ${fontSize`zetta`} ${largeAndUp`${fontSize`bronto`}`};
 `;
 
-H1.displayName = "H1";
+H1.displayName = "Typography.H1";
 
 export default H1;

--- a/src/components/Typography/H2.js
+++ b/src/components/Typography/H2.js
@@ -15,6 +15,6 @@ const H2 = styled.h2.attrs(
   ${fontSize`tera`} ${largeAndUp`${fontSize`zetta`}`};
 `;
 
-H2.displayName = "H2";
+H2.displayName = "Typography.H2";
 
 export default H2;

--- a/src/components/Typography/H3.js
+++ b/src/components/Typography/H3.js
@@ -15,6 +15,6 @@ const H3 = styled.h3.attrs(
   ${fontSize`giga`} ${largeAndUp`${fontSize`tera`}`};
 `;
 
-H3.displayName = "H3";
+H3.displayName = "Typography.H3";
 
 export default H3;

--- a/src/components/Typography/H4.js
+++ b/src/components/Typography/H4.js
@@ -14,6 +14,6 @@ const H4 = styled.h4.attrs(
   ${fontSize`giga`};
 `;
 
-H4.displayName = "H4";
+H4.displayName = "Typography.H4";
 
 export default H4;

--- a/src/components/Typography/P1.js
+++ b/src/components/Typography/P1.js
@@ -13,6 +13,6 @@ const P1 = styled.p.attrs(
   ${fontSize`kilo`};
 `;
 
-P1.displayName = "P1";
+P1.displayName = "Typography.P1";
 
 export default P1;

--- a/src/components/Typography/P2.js
+++ b/src/components/Typography/P2.js
@@ -13,6 +13,6 @@ const P2 = styled.p.attrs(
   ${fontSize`hecto`};
 `;
 
-P2.displayName = "P2";
+P2.displayName = "Typography.P2";
 
 export default P2;

--- a/src/components/Typography/P3.js
+++ b/src/components/Typography/P3.js
@@ -13,6 +13,6 @@ const P3 = styled.p.attrs(
   ${fontSize`uno`};
 `;
 
-P3.displayName = "P3";
+P3.displayName = "Typography.P3";
 
 export default P3;

--- a/src/components/Typography/P4.js
+++ b/src/components/Typography/P4.js
@@ -13,6 +13,6 @@ const P4 = styled.p.attrs(
   ${fontSize`mini`};
 `;
 
-P4.displayName = "P4";
+P4.displayName = "Typography.P4";
 
 export default P4;

--- a/src/components/Typography/__tests__/H1.spec.js
+++ b/src/components/Typography/__tests__/H1.spec.js
@@ -3,25 +3,25 @@ import MOCK_STRING from "../__mocks__/string.mocks";
 
 describe("Typography.H1", () => {
   it("should render default markup when no props are passed", () => {
-    global.snapshotWithTheme(Typography.H1, { children: MOCK_STRING });
+    global.componentSnapshotWithTheme(Typography.H1, { children: MOCK_STRING });
   });
 
   it("should render with a textTransform prop", () => {
-    global.snapshotWithTheme(Typography.H1, {
+    global.componentSnapshotWithTheme(Typography.H1, {
       children: MOCK_STRING,
       textTransform: "uppercase"
     });
   });
 
   it("should render with a custom weight prop", () => {
-    global.snapshotWithTheme(Typography.H1, {
+    global.componentSnapshotWithTheme(Typography.H1, {
       children: MOCK_STRING,
       weight: "semiBold"
     });
   });
 
   it("should render with custom color and variant props", () => {
-    global.snapshotWithTheme(Typography.H1, {
+    global.componentSnapshotWithTheme(Typography.H1, {
       children: MOCK_STRING,
       color: "accent01",
       variant: "dark"
@@ -29,13 +29,17 @@ describe("Typography.H1", () => {
   });
 
   it("should render with a custom color prop that lacks variants", () => {
-    global.snapshotWithTheme(Typography.H1, {
+    global.componentSnapshotWithTheme(Typography.H1, {
       children: MOCK_STRING,
       color: "brand"
     });
   });
 
   it("should render without children", () => {
-    global.snapshotWithTheme(Typography.H1);
+    global.componentSnapshotWithTheme(Typography.H1);
+  });
+
+  it("should render without a theme", () => {
+    global.componentSnapshot(Typography.H1);
   });
 });

--- a/src/components/Typography/__tests__/H2.spec.js
+++ b/src/components/Typography/__tests__/H2.spec.js
@@ -3,25 +3,25 @@ import MOCK_STRING from "../__mocks__/string.mocks";
 
 describe("Typography.H2", () => {
   it("should render default markup when no props are passed", () => {
-    global.snapshotWithTheme(Typography.H2, { children: MOCK_STRING });
+    global.componentSnapshotWithTheme(Typography.H2, { children: MOCK_STRING });
   });
 
   it("should render with a textTransform prop", () => {
-    global.snapshotWithTheme(Typography.H2, {
+    global.componentSnapshotWithTheme(Typography.H2, {
       children: MOCK_STRING,
       textTransform: "uppercase"
     });
   });
 
   it("should render with a custom weight prop", () => {
-    global.snapshotWithTheme(Typography.H2, {
+    global.componentSnapshotWithTheme(Typography.H2, {
       children: MOCK_STRING,
       weight: "semiBold"
     });
   });
 
   it("should render with custom color and variant props", () => {
-    global.snapshotWithTheme(Typography.H2, {
+    global.componentSnapshotWithTheme(Typography.H2, {
       children: MOCK_STRING,
       color: "accent01",
       variant: "dark"
@@ -29,13 +29,17 @@ describe("Typography.H2", () => {
   });
 
   it("should render with a custom color prop that lacks variants", () => {
-    global.snapshotWithTheme(Typography.H2, {
+    global.componentSnapshotWithTheme(Typography.H2, {
       children: MOCK_STRING,
       color: "brand"
     });
   });
 
   it("should render without children", () => {
-    global.snapshotWithTheme(Typography.H2);
+    global.componentSnapshotWithTheme(Typography.H2);
+  });
+
+  it("should render without a theme", () => {
+    global.componentSnapshot(Typography.H2);
   });
 });

--- a/src/components/Typography/__tests__/H3.spec.js
+++ b/src/components/Typography/__tests__/H3.spec.js
@@ -3,25 +3,25 @@ import MOCK_STRING from "../__mocks__/string.mocks";
 
 describe("Typography.H3", () => {
   it("should render default markup when no props are passed", () => {
-    global.snapshotWithTheme(Typography.H3, { children: MOCK_STRING });
+    global.componentSnapshotWithTheme(Typography.H3, { children: MOCK_STRING });
   });
 
   it("should render with a textTransform prop", () => {
-    global.snapshotWithTheme(Typography.H3, {
+    global.componentSnapshotWithTheme(Typography.H3, {
       children: MOCK_STRING,
       textTransform: "uppercase"
     });
   });
 
   it("should render with a custom weight prop", () => {
-    global.snapshotWithTheme(Typography.H3, {
+    global.componentSnapshotWithTheme(Typography.H3, {
       children: MOCK_STRING,
       weight: "semiBold"
     });
   });
 
   it("should render with custom color and variant props", () => {
-    global.snapshotWithTheme(Typography.H3, {
+    global.componentSnapshotWithTheme(Typography.H3, {
       children: MOCK_STRING,
       color: "accent01",
       variant: "dark"
@@ -29,13 +29,17 @@ describe("Typography.H3", () => {
   });
 
   it("should render with a custom color prop that lacks variants", () => {
-    global.snapshotWithTheme(Typography.H3, {
+    global.componentSnapshotWithTheme(Typography.H3, {
       children: MOCK_STRING,
       color: "brand"
     });
   });
 
   it("should render without children", () => {
-    global.snapshotWithTheme(Typography.H3);
+    global.componentSnapshotWithTheme(Typography.H3);
+  });
+
+  it("should render without a theme", () => {
+    global.componentSnapshot(Typography.H3);
   });
 });

--- a/src/components/Typography/__tests__/H4.spec.js
+++ b/src/components/Typography/__tests__/H4.spec.js
@@ -3,25 +3,25 @@ import MOCK_STRING from "../__mocks__/string.mocks";
 
 describe("Typography.H4", () => {
   it("should render default markup when no props are passed", () => {
-    global.snapshotWithTheme(Typography.H4, { children: MOCK_STRING });
+    global.componentSnapshotWithTheme(Typography.H4, { children: MOCK_STRING });
   });
 
   it("should render with a textTransform prop", () => {
-    global.snapshotWithTheme(Typography.H4, {
+    global.componentSnapshotWithTheme(Typography.H4, {
       children: MOCK_STRING,
       textTransform: "uppercase"
     });
   });
 
   it("should render with a custom weight prop", () => {
-    global.snapshotWithTheme(Typography.H4, {
+    global.componentSnapshotWithTheme(Typography.H4, {
       children: MOCK_STRING,
       weight: "semiBold"
     });
   });
 
   it("should render with custom color and variant props", () => {
-    global.snapshotWithTheme(Typography.H4, {
+    global.componentSnapshotWithTheme(Typography.H4, {
       children: MOCK_STRING,
       color: "accent01",
       variant: "dark"
@@ -29,13 +29,17 @@ describe("Typography.H4", () => {
   });
 
   it("should render with a custom color prop that lacks variants", () => {
-    global.snapshotWithTheme(Typography.H4, {
+    global.componentSnapshotWithTheme(Typography.H4, {
       children: MOCK_STRING,
       color: "brand"
     });
   });
 
   it("should render without children", () => {
-    global.snapshotWithTheme(Typography.H4);
+    global.componentSnapshotWithTheme(Typography.H4);
+  });
+
+  it("should render without a theme", () => {
+    global.componentSnapshot(Typography.H4);
   });
 });

--- a/src/components/Typography/__tests__/P1.spec.js
+++ b/src/components/Typography/__tests__/P1.spec.js
@@ -3,25 +3,25 @@ import MOCK_STRING from "../__mocks__/string.mocks";
 
 describe("Typography.P1", () => {
   it("should render default markup when no props are passed", () => {
-    global.snapshotWithTheme(Typography.P1, { children: MOCK_STRING });
+    global.componentSnapshotWithTheme(Typography.P1, { children: MOCK_STRING });
   });
 
   it("should render with a textTransform prop", () => {
-    global.snapshotWithTheme(Typography.P1, {
+    global.componentSnapshotWithTheme(Typography.P1, {
       children: MOCK_STRING,
       textTransform: "uppercase"
     });
   });
 
   it("should render with a custom weight prop", () => {
-    global.snapshotWithTheme(Typography.P1, {
+    global.componentSnapshotWithTheme(Typography.P1, {
       children: MOCK_STRING,
       weight: "semiBold"
     });
   });
 
   it("should render with custom color and variant props", () => {
-    global.snapshotWithTheme(Typography.P1, {
+    global.componentSnapshotWithTheme(Typography.P1, {
       children: MOCK_STRING,
       color: "accent01",
       variant: "dark"
@@ -29,13 +29,17 @@ describe("Typography.P1", () => {
   });
 
   it("should render with a custom color prop that lacks variants", () => {
-    global.snapshotWithTheme(Typography.P1, {
+    global.componentSnapshotWithTheme(Typography.P1, {
       children: MOCK_STRING,
       color: "brand"
     });
   });
 
   it("should render without children", () => {
-    global.snapshotWithTheme(Typography.P1);
+    global.componentSnapshotWithTheme(Typography.P1);
+  });
+
+  it("should render without a theme", () => {
+    global.componentSnapshot(Typography.P1);
   });
 });

--- a/src/components/Typography/__tests__/P2.spec.js
+++ b/src/components/Typography/__tests__/P2.spec.js
@@ -3,25 +3,25 @@ import MOCK_STRING from "../__mocks__/string.mocks";
 
 describe("Typography.P2", () => {
   it("should render default markup when no props are passed", () => {
-    global.snapshotWithTheme(Typography.P2, { children: MOCK_STRING });
+    global.componentSnapshotWithTheme(Typography.P2, { children: MOCK_STRING });
   });
 
   it("should render with a textTransform prop", () => {
-    global.snapshotWithTheme(Typography.P2, {
+    global.componentSnapshotWithTheme(Typography.P2, {
       children: MOCK_STRING,
       textTransform: "uppercase"
     });
   });
 
   it("should render with a custom weight prop", () => {
-    global.snapshotWithTheme(Typography.P2, {
+    global.componentSnapshotWithTheme(Typography.P2, {
       children: MOCK_STRING,
       weight: "semiBold"
     });
   });
 
   it("should render with custom color and variant props", () => {
-    global.snapshotWithTheme(Typography.P2, {
+    global.componentSnapshotWithTheme(Typography.P2, {
       children: MOCK_STRING,
       color: "accent01",
       variant: "dark"
@@ -29,13 +29,17 @@ describe("Typography.P2", () => {
   });
 
   it("should render with a custom color prop that lacks variants", () => {
-    global.snapshotWithTheme(Typography.P2, {
+    global.componentSnapshotWithTheme(Typography.P2, {
       children: MOCK_STRING,
       color: "brand"
     });
   });
 
   it("should render without children", () => {
-    global.snapshotWithTheme(Typography.P2);
+    global.componentSnapshotWithTheme(Typography.P2);
+  });
+
+  it("should render without a theme", () => {
+    global.componentSnapshot(Typography.P2);
   });
 });

--- a/src/components/Typography/__tests__/P3.spec.js
+++ b/src/components/Typography/__tests__/P3.spec.js
@@ -3,25 +3,25 @@ import MOCK_STRING from "../__mocks__/string.mocks";
 
 describe("Typography.P3", () => {
   it("should render default markup when no props are passed", () => {
-    global.snapshotWithTheme(Typography.P3, { children: MOCK_STRING });
+    global.componentSnapshotWithTheme(Typography.P3, { children: MOCK_STRING });
   });
 
   it("should render with a textTransform prop", () => {
-    global.snapshotWithTheme(Typography.P3, {
+    global.componentSnapshotWithTheme(Typography.P3, {
       children: MOCK_STRING,
       textTransform: "uppercase"
     });
   });
 
   it("should render with a custom weight prop", () => {
-    global.snapshotWithTheme(Typography.P3, {
+    global.componentSnapshotWithTheme(Typography.P3, {
       children: MOCK_STRING,
       weight: "semiBold"
     });
   });
 
   it("should render with custom color and variant props", () => {
-    global.snapshotWithTheme(Typography.P3, {
+    global.componentSnapshotWithTheme(Typography.P3, {
       children: MOCK_STRING,
       color: "accent01",
       variant: "dark"
@@ -29,13 +29,17 @@ describe("Typography.P3", () => {
   });
 
   it("should render with a custom color prop that lacks variants", () => {
-    global.snapshotWithTheme(Typography.P3, {
+    global.componentSnapshotWithTheme(Typography.P3, {
       children: MOCK_STRING,
       color: "brand"
     });
   });
 
   it("should render without children", () => {
-    global.snapshotWithTheme(Typography.P3);
+    global.componentSnapshotWithTheme(Typography.P3);
+  });
+
+  it("should render without a theme", () => {
+    global.componentSnapshot(Typography.P3);
   });
 });

--- a/src/components/Typography/__tests__/P4.spec.js
+++ b/src/components/Typography/__tests__/P4.spec.js
@@ -3,25 +3,25 @@ import MOCK_STRING from "../__mocks__/string.mocks";
 
 describe("Typography.P4", () => {
   it("should render default markup when no props are passed", () => {
-    global.snapshotWithTheme(Typography.P4, { children: MOCK_STRING });
+    global.componentSnapshotWithTheme(Typography.P4, { children: MOCK_STRING });
   });
 
   it("should render with a textTransform prop", () => {
-    global.snapshotWithTheme(Typography.P4, {
+    global.componentSnapshotWithTheme(Typography.P4, {
       children: MOCK_STRING,
       textTransform: "uppercase"
     });
   });
 
   it("should render with a custom weight prop", () => {
-    global.snapshotWithTheme(Typography.P4, {
+    global.componentSnapshotWithTheme(Typography.P4, {
       children: MOCK_STRING,
       weight: "semiBold"
     });
   });
 
   it("should render with custom color and variant props", () => {
-    global.snapshotWithTheme(Typography.P4, {
+    global.componentSnapshotWithTheme(Typography.P4, {
       children: MOCK_STRING,
       color: "accent01",
       variant: "dark"
@@ -29,13 +29,17 @@ describe("Typography.P4", () => {
   });
 
   it("should render with a custom color prop that lacks variants", () => {
-    global.snapshotWithTheme(Typography.P4, {
+    global.componentSnapshotWithTheme(Typography.P4, {
       children: MOCK_STRING,
       color: "brand"
     });
   });
 
   it("should render without children", () => {
-    global.snapshotWithTheme(Typography.P4);
+    global.componentSnapshotWithTheme(Typography.P4);
+  });
+
+  it("should render without a theme", () => {
+    global.componentSnapshot(Typography.P4);
   });
 });

--- a/src/components/Typography/__tests__/__snapshots__/H1.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/H1.spec.js.snap
@@ -42,6 +42,12 @@ exports[`Typography.H1 should render with custom color and variant props 1`] = `
 </h1>
 `;
 
+exports[`Typography.H1 should render without a theme 1`] = `
+<h1
+  className="h1 h1--extraBold h1--onyx-base ciPfPp"
+/>
+`;
+
 exports[`Typography.H1 should render without children 1`] = `
 <h1
   className="h1 h1--extraBold h1--onyx-base ciPfPp"

--- a/src/components/Typography/__tests__/__snapshots__/H2.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/H2.spec.js.snap
@@ -42,6 +42,12 @@ exports[`Typography.H2 should render with custom color and variant props 1`] = `
 </h2>
 `;
 
+exports[`Typography.H2 should render without a theme 1`] = `
+<h2
+  className="h2 h2--regular h2--onyx-base fsqIAZ"
+/>
+`;
+
 exports[`Typography.H2 should render without children 1`] = `
 <h2
   className="h2 h2--regular h2--onyx-base fsqIAZ"

--- a/src/components/Typography/__tests__/__snapshots__/H3.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/H3.spec.js.snap
@@ -42,6 +42,12 @@ exports[`Typography.H3 should render with custom color and variant props 1`] = `
 </h3>
 `;
 
+exports[`Typography.H3 should render without a theme 1`] = `
+<h3
+  className="h3 h3--regular h3--onyx-base emrIB"
+/>
+`;
+
 exports[`Typography.H3 should render without children 1`] = `
 <h3
   className="h3 h3--regular h3--onyx-base emrIB"

--- a/src/components/Typography/__tests__/__snapshots__/H4.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/H4.spec.js.snap
@@ -42,6 +42,12 @@ exports[`Typography.H4 should render with custom color and variant props 1`] = `
 </h4>
 `;
 
+exports[`Typography.H4 should render without a theme 1`] = `
+<h4
+  className="h4 h4--regular h4--onyx-base jaCmRM"
+/>
+`;
+
 exports[`Typography.H4 should render without children 1`] = `
 <h4
   className="h4 h4--regular h4--onyx-base jaCmRM"

--- a/src/components/Typography/__tests__/__snapshots__/P1.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/P1.spec.js.snap
@@ -42,6 +42,12 @@ exports[`Typography.P1 should render with custom color and variant props 1`] = `
 </p>
 `;
 
+exports[`Typography.P1 should render without a theme 1`] = `
+<p
+  className="p1 p1--regular p1--onyx-base grArvb"
+/>
+`;
+
 exports[`Typography.P1 should render without children 1`] = `
 <p
   className="p1 p1--regular p1--onyx-base grArvb"

--- a/src/components/Typography/__tests__/__snapshots__/P2.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/P2.spec.js.snap
@@ -42,6 +42,12 @@ exports[`Typography.P2 should render with custom color and variant props 1`] = `
 </p>
 `;
 
+exports[`Typography.P2 should render without a theme 1`] = `
+<p
+  className="p2 p2--regular p2--onyx-base XygHP"
+/>
+`;
+
 exports[`Typography.P2 should render without children 1`] = `
 <p
   className="p2 p2--regular p2--onyx-base XygHP"

--- a/src/components/Typography/__tests__/__snapshots__/P3.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/P3.spec.js.snap
@@ -42,6 +42,12 @@ exports[`Typography.P3 should render with custom color and variant props 1`] = `
 </p>
 `;
 
+exports[`Typography.P3 should render without a theme 1`] = `
+<p
+  className="p3 p3--regular p3--onyx-base filIGg"
+/>
+`;
+
 exports[`Typography.P3 should render without children 1`] = `
 <p
   className="p3 p3--regular p3--onyx-base filIGg"

--- a/src/components/Typography/__tests__/__snapshots__/P4.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/P4.spec.js.snap
@@ -42,6 +42,12 @@ exports[`Typography.P4 should render with custom color and variant props 1`] = `
 </p>
 `;
 
+exports[`Typography.P4 should render without a theme 1`] = `
+<p
+  className="p4 p4--regular p4--onyx-base yTlJf"
+/>
+`;
+
 exports[`Typography.P4 should render without children 1`] = `
 <p
   className="p4 p4--regular p4--onyx-base yTlJf"

--- a/src/mixins/themeColor.js
+++ b/src/mixins/themeColor.js
@@ -1,9 +1,10 @@
 import { css } from "styled-components";
 
+import { THEME_TM } from "../theme/constants";
 import { getThemeValue, isValidThemeColorVariant } from "../utils";
 
 const themeColor = (color, variant) => css`
-  color: ${({ theme }) =>
+  color: ${({ theme = THEME_TM }) =>
     isValidThemeColorVariant(theme, color, variant)
       ? getThemeValue(color, variant)(theme)
       : getThemeValue(color)(theme)};

--- a/src/mixins/themeColors.js
+++ b/src/mixins/themeColors.js
@@ -1,10 +1,11 @@
 import { css } from "styled-components";
 
 import { getThemeValue, isValidThemeColorVariant } from "../utils";
+import { THEME_TM } from "../theme/constants";
 import { ONYX, BASE } from "../components/constants";
 
 const themeColors = css`
-  color: ${({ color = ONYX, variant = BASE, theme }) =>
+  color: ${({ color = ONYX, variant = BASE, theme = THEME_TM }) =>
     isValidThemeColorVariant(theme, color, variant)
       ? getThemeValue(color, variant)(theme)
       : getThemeValue(color)(theme) || getThemeValue(ONYX, BASE)(theme)};

--- a/src/theme/constants.js
+++ b/src/theme/constants.js
@@ -29,5 +29,6 @@ export const cardBoxShadow =
 export const popContainersBoxShadow = "0 4px 4px 0 rgba(0, 0, 0, 0.12)";
 export const popContainersSharpBoxShadow =
   "0 2px 8px 0 rgba(159, 159, 159, 0.5)";
+export const THEME_TM = { themeName: "tm" };
 
 export default constants;

--- a/src/utils/__tests__/isValidThemeColorVariant.spec.js
+++ b/src/utils/__tests__/isValidThemeColorVariant.spec.js
@@ -1,27 +1,29 @@
 import { isValidThemeColorVariant } from "../";
-import { themeTm } from "../getThemeValue";
+import { THEME_TM } from "../../theme/constants";
 
 describe("isValidThemeColorVariant", () => {
   it("should return true when the color and variant passed are valid for the theme provided", () => {
-    expect(isValidThemeColorVariant(themeTm, "accent01", "dark")).toEqual(true);
+    expect(isValidThemeColorVariant(THEME_TM, "accent01", "dark")).toEqual(
+      true
+    );
   });
 
   it("should return false when the color passed does not have variants for the theme provided", () => {
-    expect(isValidThemeColorVariant(themeTm, "brand", "dark")).toEqual(false);
+    expect(isValidThemeColorVariant(THEME_TM, "brand", "dark")).toEqual(false);
   });
 
   it("should return false when an invalid variant is passed", () => {
-    expect(isValidThemeColorVariant(themeTm, "accent01", "awesome")).toEqual(
+    expect(isValidThemeColorVariant(THEME_TM, "accent01", "awesome")).toEqual(
       false
     );
   });
 
   it("should return false when no variant is passed", () => {
-    expect(isValidThemeColorVariant(themeTm, "brand")).toEqual(false);
+    expect(isValidThemeColorVariant(THEME_TM, "brand")).toEqual(false);
   });
 
   it("should return false when an invalid color is passed", () => {
-    expect(isValidThemeColorVariant(themeTm, "fakecolor")).toEqual(false);
+    expect(isValidThemeColorVariant(THEME_TM, "fakecolor")).toEqual(false);
   });
 
   it("should use the tm theme by default", () => {

--- a/src/utils/__tests__/typography.spec.js
+++ b/src/utils/__tests__/typography.spec.js
@@ -1,6 +1,6 @@
 import { getFontColor, getFontHue, getThemedFontColor } from "../typography";
 import { colors, themes } from "../../theme";
-import { themeTm } from "../../utils/getThemeValue";
+import { THEME_TM } from "../../theme/constants";
 
 const themeLne = { themeName: "lne" };
 
@@ -261,44 +261,44 @@ describe("getFontHue", () => {
 describe("getThemedFontColor", () => {
   it("should return the primary dark color when variant equals dark and primary equals true", () => {
     expect(
-      getThemedFontColor({ theme: themeTm, variant: "dark", primary: true })
+      getThemedFontColor({ theme: THEME_TM, variant: "dark", primary: true })
     ).toEqual(themes.tm.onyx.base);
   });
 
   it("should return the secondary dark color when variant equals dark and secondary equals true", () => {
     expect(
-      getThemedFontColor({ theme: themeTm, variant: "dark", secondary: true })
+      getThemedFontColor({ theme: THEME_TM, variant: "dark", secondary: true })
     ).toEqual(themes.tm.onyx.light);
   });
 
   it("should return the disabled dark color when variant equals dark and disabled equals true", () => {
     expect(
-      getThemedFontColor({ theme: themeTm, variant: "dark", disabled: true })
+      getThemedFontColor({ theme: THEME_TM, variant: "dark", disabled: true })
     ).toEqual(themes.tm.onyx.muted);
   });
 
   it("should return the primary light color when variant equals light and primary equals true", () => {
     expect(
-      getThemedFontColor({ theme: themeTm, variant: "light", primary: true })
+      getThemedFontColor({ theme: THEME_TM, variant: "light", primary: true })
     ).toEqual(themes.tm.white.base);
   });
 
   it("should return the secondary light color when variant equals light and secondary equals true", () => {
     expect(
-      getThemedFontColor({ theme: themeTm, variant: "light", secondary: true })
+      getThemedFontColor({ theme: THEME_TM, variant: "light", secondary: true })
     ).toEqual(themes.tm.white.light);
   });
 
   it("should return the disabled light color when variant equals light and disabled equals true", () => {
     expect(
-      getThemedFontColor({ theme: themeTm, variant: "light", disabled: true })
+      getThemedFontColor({ theme: THEME_TM, variant: "light", disabled: true })
     ).toEqual(themes.tm.white.muted);
   });
 
   it("should return the primary accent color when variant equals accent and primary equals true", () => {
     expect(
       getThemedFontColor({
-        theme: themeTm,
+        theme: THEME_TM,
         variant: "accent",
         accent: "primary",
         primary: true
@@ -309,7 +309,7 @@ describe("getThemedFontColor", () => {
   it("should return the secondary accent color when variant equals accent and secondary equals true", () => {
     expect(
       getThemedFontColor({
-        theme: themeTm,
+        theme: THEME_TM,
         variant: "accent",
         accent: "primary",
         secondary: true
@@ -320,7 +320,7 @@ describe("getThemedFontColor", () => {
   it("should return the disabled accent color when variant equals accent and disabled equals true", () => {
     expect(
       getThemedFontColor({
-        theme: themeTm,
+        theme: THEME_TM,
         variant: "accent",
         accent: "primary",
         disabled: true

--- a/src/utils/getThemeValue.js
+++ b/src/utils/getThemeValue.js
@@ -1,12 +1,11 @@
 import PropTypes from "prop-types";
 
 import { themes } from "../theme";
+import { THEME_TM } from "../theme/constants";
 
 export const themeShape = {
   themeName: PropTypes.string.isRequired
 };
-
-export const themeTm = { themeName: "tm" };
 
 /**
  * This function allows to retrieve a value from the themes object.
@@ -14,7 +13,9 @@ export const themeTm = { themeName: "tm" };
  * The second function accepts a theme object. It's provided in styled components
  * automatically.
  */
-export default (...args) => ({ theme: { themeName = "tm" } = {} } = {}) =>
+export default (...args) => ({
+  theme: { themeName = THEME_TM.themeName } = THEME_TM
+} = {}) =>
   args.reduce((acc, el) => {
     if (acc[el] === undefined) {
       throw new ReferenceError("value is not defined");

--- a/src/utils/isValidThemeColorVariant.js
+++ b/src/utils/isValidThemeColorVariant.js
@@ -1,8 +1,11 @@
 import { themes } from "../theme";
+import { THEME_TM } from "../theme/constants";
 
-import { themeTm } from "./getThemeValue";
-
-const isValidThemeColorVariant = ({ themeName } = themeTm, color, variant) =>
+const isValidThemeColorVariant = (
+  { themeName = THEME_TM.themeName } = THEME_TM,
+  color,
+  variant
+) =>
   Boolean(
     themes[themeName][color] &&
       themes[themeName][color].constructor === Object &&

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -67,7 +67,7 @@ export const getThemedFontColor = ({
   secondary,
   disabled
 }) => {
-  if (!theme.themeName) {
+  if (!theme || !theme.themeName) {
     return getFontColor({
       variant,
       accent,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am updating displayNames to be prefixed with Typography obj name; adding THEME_TM as the default theme in all relevant utils/mixins.

<!-- Why are these changes necessary? -->

**Why**: The displayName change is necessary to ensure Typography displayNames accurately reflect exported component names. The default theme change is required to ensure that these utils/mixins as well as the components that rely on them do not fail if a properly configured `ThemeProvider` is not present in `ReactDOM`.

<!-- How were these changes implemented? -->

**How**:  I am updating displayNames to be prefixed with Typography obj name; adding THEME_TM as the default theme in all relevant utils/mixins.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
