### PR TITLE
add margin-top to badges inside BadgeTooltip

### DIFF
--- a/src/components/StatusBadge/StatusBadgeGroup.js
+++ b/src/components/StatusBadge/StatusBadgeGroup.js
@@ -35,6 +35,9 @@ const HiddenBadgesCount = styled(StyledBadge)`
 
 const BadgeTooltip = styled(Tooltip)`
   padding: 8px;
+  .badge + .badge {
+    margin-top: 8px;
+  }
 `;
 
 class StatusBadgeGroup extends Component {
@@ -107,16 +110,15 @@ class StatusBadgeGroup extends Component {
     return (
       <StatusBadgeContainer>
         {this.renderBadges(visibleBadges, variant)}
-        {hiddenBadges &&
-          hiddenBadges.length > 0 && (
-            <HiddenBadgesCount
-              onMouseEnter={this.elementHovered}
-              onMouseLeave={this.mouseLeave}
-              onTouchStart={this.elementHovered}
-            >
-              {`+${hiddenBadges.length} more`}
-            </HiddenBadgesCount>
-          )}
+        {hiddenBadges && hiddenBadges.length > 0 && (
+          <HiddenBadgesCount
+            onMouseEnter={this.elementHovered}
+            onMouseLeave={this.mouseLeave}
+            onTouchStart={this.elementHovered}
+          >
+            {`+${hiddenBadges.length} more`}
+          </HiddenBadgesCount>
+        )}
         <BadgeTooltip
           direction={tooltipDirection}
           position={{ ...position }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Added margin-top ti badges inside BageTooltip

<!-- Why are these changes necessary? -->

**Why**:Makes it consistent with bage spacing without the tooltip

<!-- How were these changes implemented? -->

**How**: using adjacent .badge selector to add the margin

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->



<!-- feel free to add additional comments -->

Before: 
<img width="223" alt="Screenshot 2019-03-25 at 3 41 21 PM" src="https://user-images.githubusercontent.com/5713737/54911470-963c8680-4f14-11e9-8840-5790877241c2.png">

After:
<img width="177" alt="Screenshot 2019-03-25 at 3 42 57 PM" src="https://user-images.githubusercontent.com/5713737/54911544-bf5d1700-4f14-11e9-8836-930fe7159242.png">


