### PR TITLE
add react-transition-group as peer dependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 Aurora relies on the [react](https://www.npmjs.com/package/react),
 [prop-types](https://www.npmjs.com/package/prop-types),
+[react-transition-group](https://www.npmjs.com/package/react-transition-group),
 and [styled-components](https://www.npmjs.com/package/styled-components)
 peer-dependency packages are already to be installed and set up in your project.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 Aurora relies on the [react](https://www.npmjs.com/package/react),
 [prop-types](https://www.npmjs.com/package/prop-types),
 [react-transition-group](https://www.npmjs.com/package/react-transition-group),
+[classnames](https://www.npmjs.com/package/classnames),
 and [styled-components](https://www.npmjs.com/package/styled-components)
 peer-dependency packages are already to be installed and set up in your project.
 


### PR DESCRIPTION
Here's the result when `react-transition-group` is not installed: https://codesandbox.io/s/pwjx2m1qn0