### PR TITLE
chore(Gradient): Export internal components to enable composition outside of lib

### DIFF
--- a/src/components/Gradient/index.js
+++ b/src/components/Gradient/index.js
@@ -20,7 +20,7 @@ const SPOTLIGHT_DEG = {
   large: "262deg"
 };
 
-const GradientStyles = styled.span`
+export const GradientStyles = styled.span`
   z-index: 1;
   width: 100%;
 
@@ -90,7 +90,7 @@ const GradientStyles = styled.span`
   }
 `;
 
-const SpotLightWrapper = styled.div`
+export const SpotLightWrapper = styled.div`
   position: absolute;
   top: 0;
   bottom: 0;
@@ -168,4 +168,5 @@ Gradient.defaultProps = {
   src: ""
 };
 
+export { SpotLight, Angle };
 export default Gradient;

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,3 +1,4 @@
 export { default as ResponsiveImage } from "./Responsive";
 export { default as StaticImage } from "./Static";
 export { default as ThumbnailCircle } from "./ThumbnailCircle";
+export { default as StyledImageSeo } from "./Seo.styles";

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,13 @@ export { default as Column } from "./components/Grid/Column";
 export { default as Container } from "./components/Grid/Container";
 export { default as LoaderRing } from "./components/LoaderRing";
 export { default as DrawerProvider } from "./components/Drawer/Provider";
-export { default as Gradient } from "./components/Gradient";
+export {
+  default as Gradient,
+  GradientStyles,
+  SpotLightWrapper,
+  SpotLight,
+  Angle
+} from "./components/Gradient";
 export { default as Header } from "./components/Header";
 export { default as HeaderWithImage } from "./components/Header/WithImage";
 export { default as Heading } from "./components/Header/Heading";
@@ -41,7 +47,8 @@ export { default as ContainerBlock } from "./components/Container/Block.styles";
 export {
   ResponsiveImage,
   StaticImage,
-  ThumbnailCircle
+  ThumbnailCircle,
+  StyledImageSeo
 } from "./components/Image";
 export { Text } from "./components/Text";
 export {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am exporting the components utilized internally by the `Gradient` component, so they can be composed outside of the library.

<!-- Why are these changes necessary? -->

**Why**: These changes are necessary to ensure `Gradient` composition is possible.

<!-- How were these changes implemented? -->

**How**: I am exporting the components utilized internally by the `Gradient` component, so they can be composed outside of the library.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
