### PR TITLE
feat(LazyLoader): Add auto=webp query param when image ext is not svg in resize function

### DIFF
--- a/catalog/pages/images/index.md
+++ b/catalog/pages/images/index.md
@@ -159,7 +159,7 @@ rows:
   - Prop: resizeFn
     Type: Function({ src, height, width }) => String
     Default: resize function
-    Notes: The default resize function appends computed width, height, and fit query parameters depending on the user's device resolution.
+    Notes: The default resize function appends computed width, height, fit, and auto query parameters depending on the image dimensions, the src's extension, and the user's device resolution.
   - Prop: children
     Type: Function({ src, style, imageRef, backgroundRef, load }) => Node
     Default: ''

--- a/src/components/LazyLoader/__tests__/__snapshots__/helpers.spec.js.snap
+++ b/src/components/LazyLoader/__tests__/__snapshots__/helpers.spec.js.snap
@@ -1,11 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`resize should return a URL with a valid width and an invalid height param appended 1`] = `"https://ticketmaster.com/assets/test.jpg?width=100"`;
+exports[`resize should return a URL with a valid width and an invalid height param appended 1`] = `"https://ticketmaster.com/assets/test.jpg?width=100&auto=webp"`;
 
-exports[`resize should return a URL with an invalid width and a valid height param appended 1`] = `"https://ticketmaster.com/assets/test.jpg?height=100"`;
+exports[`resize should return a URL with an invalid width and a valid height param appended 1`] = `"https://ticketmaster.com/assets/test.jpg?height=100&auto=webp"`;
 
-exports[`resize should return a URL with valid width and height params appended 1`] = `"https://ticketmaster.com/assets/test.jpg?width=100&height=100&fit=crop"`;
+exports[`resize should return a URL with valid width and height params appended 1`] = `"https://ticketmaster.com/assets/test.jpg?width=100&height=100&fit=crop&auto=webp"`;
 
 exports[`resize should return src if an error occurs 1`] = `null`;
 
 exports[`resize should return src when src does not contain a host 1`] = `"/assets/test.jpg"`;
+
+exports[`resize should return src without the auto param when src has an svg extension 1`] = `"https://ticketmaster.com/assets/icon.svg"`;

--- a/src/components/LazyLoader/__tests__/helpers.spec.js
+++ b/src/components/LazyLoader/__tests__/helpers.spec.js
@@ -72,6 +72,12 @@ describe("resize", () => {
 
     expect(resize({ src })).toMatchSnapshot();
   });
+
+  it("should return src without the auto param when src has an svg extension", () => {
+    const src = "https://ticketmaster.com/assets/icon.svg";
+
+    expect(resize({ src })).toMatchSnapshot();
+  });
 });
 
 describe("createGetSrcByDensity", () => {

--- a/src/components/LazyLoader/helpers.js
+++ b/src/components/LazyLoader/helpers.js
@@ -15,7 +15,8 @@ export const resize = ({ src = "", ...params }) => {
 
     const url = `https://${host}${pathname}`;
     const fit = params.width && params.height ? { fit: "crop" } : {};
-    const resizeSrc = `${url}${createParams({ ...params, ...fit })}`;
+    const webp = pathname.endsWith(".svg") ? {} : { auto: "webp" };
+    const resizeSrc = `${url}${createParams({ ...params, ...fit, ...webp })}`;
     return resizeSrc;
   } catch (e) {
     return src;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am updating the `resize` function used in the `LazyLoaderProvider` component to append the `auto-webp` query param when the image's extension is not `svg`.

<!-- Why are these changes necessary? -->

**Why**: These changes are necessary to leverage Fastly's `webp` image converter when the user's browser supports the image extension.

<!-- How were these changes implemented? -->

**How**: I am updating the `resize` function used in the `LazyLoaderProvider` component to append the `auto-webp` query param when the image's extension is not `svg`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
