### PR TITLE
feat(Breadcrumbs): fix the inline styled to be able to override it if necessary

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -14,6 +14,10 @@ const spanStyles = css`
   }
 `;
 
+const StyledWrapper = styled.li`
+  white-space: nowrap;
+`;
+
 const StyledLink = styled(Link)`
   ${props => (getAsProp(props).as === "span" ? spanStyles : "")};
 `;
@@ -28,7 +32,7 @@ const BreadcrumbItem = ({
   primary,
   ...props
 }) => (
-  <li style={{ whiteSpace: "nowrap" }}>
+  <StyledWrapper>
     <StyledLink
       {...props}
       size={size}
@@ -40,7 +44,7 @@ const BreadcrumbItem = ({
     >
       {children}
     </StyledLink>
-  </li>
+  </StyledWrapper>
 );
 
 BreadcrumbItem.propTypes = {

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
@@ -10,7 +10,7 @@ exports[`<Breadcrumb /> renders correctly 1`] = `
   }
 >
   <ol
-    className="breadcrumb--light VxXFb"
+    className="breadcrumb--light lfxqkB"
   >
     Breadcrumb
     List
@@ -28,7 +28,7 @@ exports[`<Breadcrumb /> should render when empty list passed in 1`] = `
   }
 >
   <ol
-    className="breadcrumb--light dvrazq"
+    className="breadcrumb--light hYQuUt"
   />
 </nav>
 `;

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/BreadcrumbItem.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/BreadcrumbItem.spec.js.snap
@@ -2,14 +2,10 @@
 
 exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] = `
 <li
-  style={
-    Object {
-      "whiteSpace": "nowrap",
-    }
-  }
+  className="hLIAGC"
 >
   <a
-    className="gpukZq boAnYn"
+    className="dwQrcO boAnYn"
     href="/"
     onClick={null}
     rel="_self"
@@ -23,14 +19,10 @@ exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] =
 
 exports[`<Breadcrumb.Item /> renders correctly when no href prop is passed 1`] = `
 <li
-  style={
-    Object {
-      "whiteSpace": "nowrap",
-    }
-  }
+  className="hLIAGC"
 >
   <span
-    className="gKcTgw hCDblW"
+    className="ibDjor hCDblW"
     href={null}
     onClick={null}
     rel="_self"


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Minor changes to the breadcrumbs styling. Fix the inline styles for the breadcrumb item.
<!-- Why are these changes necessary? -->

**Why**:
To have the ability to override these styles if needed.
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
