### PR TITLE
fix(Tabs): add check for a valid ref before checking for overflows

### DIFF
--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -86,8 +86,12 @@ const Tab = styled.div`
   }
 `;
 
-const checkIfOverflows = ({ offsetWidth = 0, scrollWidth = 0 } = {}) =>
-  offsetWidth < scrollWidth;
+const checkIfOverflows = (content = {}) => {
+  if (!content) return false;
+
+  const { offsetWidth = 0, scrollWidth = 0 } = content
+  return offsetWidth < scrollWidth;
+};
 
 const TabItemButton = styled.button.attrs(props => {
   const { isActive, dataIndex, ...rest } = props;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Tabs

<!-- Why are these changes necessary? -->

**Why**:
Need to add safety checks before accessing props on refs

<!-- How were these changes implemented? -->

**How**:
Updated the `checkIfOverflows` function with safety checks for null values

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
