### PR TITLE
LinkCta: Check if ref exists on blur handler for avoiding exception

### DIFF
--- a/src/components/Text/LinkCta.js
+++ b/src/components/Text/LinkCta.js
@@ -91,7 +91,10 @@ class LinkCta extends Component {
   };
 
   blurHandler = () => {
-    this.link.current.classList.add("noFocus");
+    if (this.link && this.link.current) {
+      this.link.current.classList.add("noFocus");
+    }
+
     global.window.removeEventListener("keyup", this.activateFocusStyles);
   };
 


### PR DESCRIPTION
`LinkCta` is used in `Banner` component, which is unmounted after clicking `href` (Unmounting is done via `Transition` from `react-transition-group`). This behavior causes `onBlur` handler on unmounted node, which causes unhandled exception.