### PR TITLE
Make palette for lne consistent with default tm

### DIFF
--- a/src/theme/colorThemes.js
+++ b/src/theme/colorThemes.js
@@ -101,6 +101,7 @@ const themes = {
       medium: "#239893",
       dark: "#1f8783",
       light: "#e9f7f6",
+      lightest: "#e9f7f6",
       muted: "#d5f0ef"
     }
   }


### PR DESCRIPTION
There is `getThemeValue` function at `https://github.com/ticketmaster/aurora/blob/master/src/utils/getThemeValue.js` which is used to calculate value from theme object.

Currently there is `lightest` color in `primary` theme, which is used in `Banner` and `QtySelector.styles`. This color is absent in `lne` theme, and this causes full break of application because of thrown error.

I have added `lightest` color just the same as `lightest` for now. Guess it could be updated later.