### PR TITLE
Set @babel/preset-env dependency to 7.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/plugin-proposal-throw-expressions": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-syntax-import-meta": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-env": "7.4.5",
     "@babel/preset-react": "^7.0.0",
     "babel-cli": "^7.0.0-beta.3",
     "babel-core": "^7.0.0-bridge.0",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

A recent change to the babel preset env dependency is causing Invariant Violation errors when Catalog's PageLoader component tries to load .md files using the import() function.  Please see screenshot.

![Screen Shot 2019-07-09 at 12 58 37](https://user-images.githubusercontent.com/52719588/60920516-352f8900-a24d-11e9-9956-4ba3565a66b3.png)

Setting the preset env dependency version to 7.4.5 fixes the issue.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation NA
* [ ] Tests NA
* [X ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
