### PR TITLE
fix(AdaptiveModal): the body should have line-height in order max-height to work

### DIFF
--- a/src/components/Modal/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Modal/__tests__/__snapshots__/index.spec.js.snap
@@ -9,7 +9,7 @@ exports[`<Modal /> closeModal should close the modal when the request was approv
       class="sc-bdVaJa gylckg"
     >
       <div
-        class="sc-htpNat gcBzNf"
+        class="sc-htpNat CqcgG"
         style="max-height: 100px;"
       >
         <button
@@ -30,7 +30,7 @@ exports[`<Modal /> closeModal should close the modal when there is no onRequestC
       class="sc-bdVaJa gylckg"
     >
       <div
-        class="sc-htpNat gcBzNf"
+        class="sc-htpNat CqcgG"
         style="max-height: 100px;"
       >
         <button
@@ -51,7 +51,7 @@ exports[`<Modal /> render should not render the modal if it is closed 1`] = `
       class="sc-bdVaJa gQMJB"
     >
       <div
-        class="sc-htpNat gcBzNf"
+        class="sc-htpNat CqcgG"
       >
         <div>
           Modal contents
@@ -78,7 +78,7 @@ exports[`<Modal /> render should render fullscreen modal with action bars 1`] = 
         </div>
       </div>
       <div
-        class="sc-htpNat gcBzNf"
+        class="sc-htpNat CqcgG"
       >
         <div>
           Modal contents
@@ -112,7 +112,7 @@ exports[`<Modal /> render should render with actionBar and bottomActionBar 1`] =
         </div>
       </div>
       <div
-        class="sc-htpNat gcBzNf"
+        class="sc-htpNat CqcgG"
       >
         <div>
           Modal contents
@@ -140,7 +140,7 @@ exports[`<Modal /> render should render without errors and pass extra props 1`] 
       style="width: 210px;"
     >
       <div
-        class="sc-htpNat gcBzNf"
+        class="sc-htpNat CqcgG"
       >
         <div>
           Modal contents
@@ -160,7 +160,7 @@ exports[`<Modal /> should recalculate shadows and content height on props change
       class="sc-bdVaJa gylckg open-enter open-enter-active"
     >
       <div
-        class="sc-htpNat gcBzNf"
+        class="sc-htpNat CqcgG"
         style="max-height: 100px;"
       >
         <div>
@@ -181,7 +181,7 @@ exports[`<Modal /> should set bottom action bar shadow when the content was scro
       class="sc-bdVaJa gylckg"
     >
       <div
-        class="sc-htpNat gcBzNf"
+        class="sc-htpNat CqcgG"
         style="max-height: 100px;"
       >
         <div

--- a/src/components/Modal/index.styles.js
+++ b/src/components/Modal/index.styles.js
@@ -160,6 +160,7 @@ const contentGutters = css`
 export const ModalContent = styled.div`
   background-color: ${themes.global.white.base};
   overflow-y: auto;
+  line-height: ${typography.lineHeight.body};
 
   .fullscreen & {
     height: 100%;


### PR DESCRIPTION
**What**:

Added line-height css prop to the Adaptive Modal body.

**Why**:

max-height prop wasn't working properly without the line-height

**How**:

Editing index.styles.js in src/Modal/ add line-height: ${typography.lineHeight.body} to the ModalContent.

**Checklist**:

* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
