### PR TITLE
fix(Banner): Padding breaks for width less than 415px

### DIFF
--- a/src/components/Banner/Banner.styles.js
+++ b/src/components/Banner/Banner.styles.js
@@ -27,7 +27,7 @@ export const Container = styled.div`
   transition: max-height 0.3s ${constants.easing.easeInOutQuad},
     opacity 0.3s ${constants.easing.easeInQuad};
   background-color: ${getThemeValue("white", "muted")};
-  box-sizing: border-box;
+  box-sizing: content-box;
   opacity: 0;
 
   &.visible-banner {

--- a/src/components/Banner/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Banner/__tests__/__snapshots__/index.spec.js.snap
@@ -5,7 +5,7 @@ exports[`<Banner /> renders correctly when closed 1`] = `<div />`;
 exports[`<Banner /> renders correctly when open 1`] = `
 <div>
   <div
-    class="collapsed visible-banner sc-gZMcBi bsKZGS"
+    class="collapsed visible-banner sc-gZMcBi dmfFSg"
     style="max-height: 56px;"
   >
     <div
@@ -32,7 +32,7 @@ exports[`<Banner /> renders correctly when open 1`] = `
 exports[`<Banner /> renders correctly when variant is set 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi dmfFSg"
     style="max-height: 56px;"
   >
     <div
@@ -91,7 +91,7 @@ exports[`<Banner /> renders correctly when variant is set 1`] = `
 exports[`<Banner /> renders correctly with close button 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi dmfFSg"
     style="max-height: 56px;"
   >
     <div
@@ -150,7 +150,7 @@ exports[`<Banner /> renders correctly with close button 1`] = `
 exports[`<Banner /> renders correctly with content 1`] = `
 <div>
   <div
-    class="collapsed visible-banner sc-gZMcBi bsKZGS"
+    class="collapsed visible-banner sc-gZMcBi dmfFSg"
     style="max-height: 56px;"
   >
     <div
@@ -179,7 +179,7 @@ exports[`<Banner /> renders correctly with content 1`] = `
 exports[`<Banner /> renders correctly with custom icon 1`] = `
 <div>
   <div
-    class="collapsed visible-banner sc-gZMcBi bsKZGS"
+    class="collapsed visible-banner sc-gZMcBi dmfFSg"
     style="max-height: 56px;"
   >
     <div
@@ -230,7 +230,7 @@ exports[`<Banner /> renders correctly with custom icon 1`] = `
 exports[`<Banner /> renders correctly with custom title for the close button 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi dmfFSg"
     style="max-height: 56px;"
   >
     <div
@@ -287,7 +287,7 @@ exports[`<Banner /> renders correctly with custom title for the close button 1`]
 exports[`<Banner /> renders correctly with expand/collapse button 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi dmfFSg"
     style="max-height: 56px;"
   >
     <div
@@ -346,7 +346,7 @@ exports[`<Banner /> renders correctly with expand/collapse button 1`] = `
 exports[`<Banner /> renders correctly with link 1`] = `
 <div>
   <div
-    class="collapsed banner-variant-alert visible-banner sc-gZMcBi bsKZGS"
+    class="collapsed banner-variant-alert visible-banner sc-gZMcBi dmfFSg"
     style="max-height: 56px;"
   >
     <div


### PR DESCRIPTION
- `@ticketmaster/aurora` version: latest
- `node` version:
- `npm` (or `yarn`) version:

Relevant code or config
https://github.com/vinodh99/aurora/commit/89a22e3b1f350f34a99bdfbee886eff4b6244d2c 
or
https://github.com/vinodh99/aurora/commit/cac63f45be4a1a115daffb43557c54b04af455b7
```
 componentDidMount() {
    // update max height to the correct value so animation works correctly
    if (this.props.content && this.state.isExpanded) {
      const maxHeight = this.text.current.offsetHeight+ this.heading.current.offsetHeight + this.content.current.offsetHeight + 32;

      // eslint-disable-next-line react/no-did-mount-set-state
      this.setState({ maxHeight: `${maxHeight}px` });
    }
    if(!this.props.content &&!this.props.isExpanded){

      // eslint-disable-next-line react/no-did-mount-set-state
      this.setState({ maxHeight: `${this.text.current.offsetHeight+this.heading.current.offsetHeight+32}px` });
    }

  }

  content = React.createRef();

  heading=React.createRef();

  text=React.createRef();

  toggleContent = () => {
    const { onButtonClick } = this.props;
    const contentHeight = this.content.current.offsetHeight;
    const headingHeight = this.heading.current.offsetHeight;
    const textHeight = this.text.current.offsetHeight;
    const collapsedMaxHeight = `${textHeight+headingHeight+32}px`;
    const expandedMaxHeight = `${contentHeight + headingHeight +textHeight +32}px`;

    this.setState(({ isExpanded }) => ({
      isExpanded: !isExpanded,
      maxHeight: isExpanded ? collapsedMaxHeight : expandedMaxHeight
    }));

    if (onButtonClick) {
      onButtonClick();
    }
  };

  renderControl = () => {
    const {
      href,
      linkText,
      expandedText,
      collapsedText,
      linkProps,
      buttonProps
    } = this.props;
    const { isExpanded } = this.state;
    if (!linkText && !expandedText && !collapsedText) {
      return null;
    }

    const props = href
      ? { ...linkProps, href }
      : { ...buttonProps, onClick: this.toggleContent };

    const text = linkText || (isExpanded ? expandedText : collapsedText);
    return (
      <Link size="hecto" {...props}>
        <div ref={this.text}>
          {text}
        </div>
      </Link>
    );
  };

  renderCloseButton = () => {
    const { onRequestClose, closeButtonTitleText } = this.props;
    if (!onRequestClose) {
      return null;
    }

    return (
      <CloseButton onClick={onRequestClose}>
        <CloseIcon size="small">
          <title>{closeButtonTitleText}</title>
        </CloseIcon>
      </CloseButton>
    );
  };

  renderIcon = () => {
    const { variant, icon } = this.props;
    if (!variant && !icon) {
      return null;
    }
    const Icon = variantsIcons[variant];

    return icon || <Icon type="filled" size="regular" />;
  };

  render() {
    const { isOpen, heading, content, variant, style } = this.props;
    const { isExpanded, maxHeight } = this.state;

    return (
      <Transition
        in={isOpen}
        timeout={isOpen ? 0 : 300} // allows to animate fade in after render correctly
        mountOnEnter
        unmountOnExit
      >
        {state => (
          <Container
            className={classnames({
              collapsed: !isExpanded,
              [`banner-variant-${variant}`]: variant,
              "visible-banner": state === "entered"
            })}
            style={{ ...style, maxHeight }}
          >
            <IconSection>{this.renderIcon()}</IconSection>
            <ContentSection>
              <Text tag="span" weight="semiBold">
              <div ref={this.heading}>
                {heading}
              </div>
              </Text>
              {this.renderControl()}
              <div ref={this.content}>
                <Content>{content}</Content>
              </div>
            </ContentSection>
            {this.renderCloseButton()}
          </Container>
        )}
      </Transition>
    );
  }
}

export default Banner;
```
https://github.com/ticketmaster/aurora/pull/403

What happened: Padding breaks for width less than 415px.

What you did: Fixed the problem above but just couldn't fix the catalog.

<!-- Please provide the full error message/screenshots/anything -->
![image (2)](https://user-images.githubusercontent.com/27710675/61428412-dc0fc700-a8d6-11e9-890d-32e5d0715811.png)


<!--
Reproduction repository:
https://github.com/ticketmaster/aurora/pull/403/files#diff-5956d04e154fd691d77e62da991e74d
-->

Problem description: 
Padding breaks on the Banner if the header text consists of two lines or more.


Suggested solution:
Should calculate the height of the `heading` and `text` and change the offset value (or) change the `box-sizing` to `content-box`