### PR TITLE
feat(LinkItem): Add disableHoverEvents prop to disable hover interactions and enable handleOutsideClick

### DIFF
--- a/catalog/pages/nav_bar/index.md
+++ b/catalog/pages/nav_bar/index.md
@@ -21,7 +21,7 @@ state: { invert: false }
                         <NavBar.Link href="/">Link 1</NavBar.Link>
                         <NavBar.Link>Link 2</NavBar.Link>
                         <NavBar.Link>Link 3</NavBar.Link>
-                        <NavBar.Link>
+                        <NavBar.Link disableHoverEvents={true}>
                             More
                             <NavBar.LinkList style={{ width: "275px", top: '40px', left: 0}} renderAfter={<span>After Content</span>}>
                                 <NavBar.LinkListItem href="/">Link 4</NavBar.LinkListItem>

--- a/src/components/Link/__tests__/Item.spec.js
+++ b/src/components/Link/__tests__/Item.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { render } from "react-testing-library";
+import { render, Simulate } from "react-testing-library";
+import renderer from "react-test-renderer";
 
 import LinkList from "../List";
 import LinkItem from "../Item";
@@ -43,6 +44,15 @@ describe("<LinkItem />", () => {
     expect(container).toMatchSnapshot();
   });
 
+  it("renders LinkItem as button when disableHoverEvents equals true", () => {
+    const { container } = render(
+      <LinkItem role="button" disableHoverEvents>
+        Button text
+      </LinkItem>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   it("renders LinkItem as link", () => {
     const { container } = render(
       <LinkItem role="link" target="_blank" href="http://localhost/new/">
@@ -52,8 +62,80 @@ describe("<LinkItem />", () => {
     expect(container).toMatchSnapshot();
   });
 
+  it("renders LinkItem as link when disableHoverEvents equals true", () => {
+    const { container } = render(
+      <LinkItem
+        role="link"
+        target="_blank"
+        href="http://localhost/new/"
+        disableHoverEvents
+      >
+        Link text
+      </LinkItem>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   it("renders LinkItem children correctly", () => {
     const { container } = getContainer();
     expect(container).toMatchSnapshot();
+  });
+
+  it("opens onMouseEnter and closes onMouseLeave when disableHoverEvents equals false", () => {
+    const { container } = getContainer();
+    const linkItem = container.querySelector(".list-container");
+
+    Simulate.mouseEnter(linkItem);
+    expect(linkItem.classList.contains("list-container--open")).toEqual(true);
+
+    Simulate.mouseLeave(linkItem);
+    expect(linkItem.classList.contains("list-container--closed")).toEqual(true);
+  });
+
+  it("does not open onMouseEnter when disableHoverEvents equals true", () => {
+    const { container } = getContainer({ disableHoverEvents: true });
+    const linkItem = container.querySelector(".list-container");
+
+    Simulate.mouseEnter(linkItem);
+    expect(linkItem.classList.contains("list-container--closed")).toEqual(true);
+  });
+
+  it("toggles onClick", () => {
+    const { container } = getContainer();
+    const linkItem = container.querySelector(".list-container");
+
+    Simulate.click(linkItem);
+    expect(linkItem.classList.contains("list-container--open")).toEqual(true);
+
+    Simulate.click(linkItem);
+    expect(linkItem.classList.contains("list-container--closed")).toEqual(true);
+  });
+
+  it.skip("closes using handleOutsideClick when disableHoverEvents equals true", async () => {
+    const component = renderer.create(
+      <div>
+        <LinkItem role="button" disableHoverEvents>
+          Button text
+          <LinkList onItemClick={mockFn}>
+            {countries.map((option, index) => (
+              <LinkItem index={index} key={option.value} href="/" role="link">
+                {option.text}
+              </LinkItem>
+            ))}
+          </LinkList>
+        </LinkItem>
+        <span className="span--outside">Outside Span</span>
+      </div>
+    );
+
+    const linkItem = component.querySelector(".list-container");
+
+    Simulate.click(linkItem);
+    expect(linkItem.classList.contains("list-container--open")).toEqual(true);
+
+    const outsideSpan = component.querySelector(".span--outside");
+
+    Simulate.click(outsideSpan);
+    expect(linkItem.classList.contains("list-container--closed")).toEqual(true);
   });
 });

--- a/src/components/Link/__tests__/__snapshots__/Item.spec.js.snap
+++ b/src/components/Link/__tests__/__snapshots__/Item.spec.js.snap
@@ -16,7 +16,42 @@ exports[`<LinkItem /> renders LinkItem as button  1`] = `
 </div>
 `;
 
+exports[`<LinkItem /> renders LinkItem as button when disableHoverEvents equals true 1`] = `
+<div>
+  <span
+    class="list-container list-container--closed"
+    role="none"
+  >
+    <button
+      class="link sc-bxivhb kPFQWz"
+      role="button"
+    >
+      Button text
+    </button>
+  </span>
+</div>
+`;
+
 exports[`<LinkItem /> renders LinkItem as link 1`] = `
+<div>
+  <span
+    class="list-container list-container--closed"
+    role="none"
+  >
+    <a
+      class="link sc-bxivhb kPFQWz"
+      href="http://localhost/new/"
+      rel="noopener"
+      role="link"
+      target="_blank"
+    >
+      Link text
+    </a>
+  </span>
+</div>
+`;
+
+exports[`<LinkItem /> renders LinkItem as link when disableHoverEvents equals true 1`] = `
 <div>
   <span
     class="list-container list-container--closed"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I am adding the `disableHoverEvents` prop to the `LinkItem` component, enabling the developer to disable hover interactions and enable `handleOutsideClick` functionality.

<!-- Why are these changes necessary? -->

**Why**: These changes are necessary to provide a click-driven, rather than hover-driven UX for the `LinkItem` component and associated dropdown on desktop devices.

<!-- How were these changes implemented? -->

**How**: I have updated the `LinkItem` component and added interaction unit tests.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation - N/A
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
