### PR TITLE
feat(Themes): add themes support object with colors

### DIFF
--- a/src/components/Button/Base.styles.tsx
+++ b/src/components/Button/Base.styles.tsx
@@ -1,69 +1,70 @@
 import styled, { StyledComponent } from "styled-components";
 
 import { SPECIAL, Size, ButtonVariant } from "../constants";
-import { typography, constants, themes } from "../../theme";
+import { typography, constants } from "../../theme";
+import { getThemeValue } from "../../utils";
 
 const colorVariants = {
-  standard: theme => ({
-    color: theme.white.base,
-    backgroundColor: theme.primary.base,
-    backgroundColorHover: theme.primary.medium,
-    backgroundColorPressed: theme.primary.dark,
-    borderColor: theme.transparent
-  }),
-  standardDisabled: theme => ({
-    color: theme.white.base,
-    backgroundColor: theme.primary.base,
-    borderColor: theme.transparent
-  }),
-  special: theme => ({
-    color: theme.white.base,
-    backgroundColor: theme.special.base,
-    backgroundColorHover: theme.special.medium,
-    backgroundColorPressed: theme.special.dark,
-    borderColor: theme.transparent
-  }),
-  specialDisabled: theme => ({
-    color: theme.white.base,
-    backgroundColor: theme.special.base,
-    borderColor: theme.transparent
-  }),
-  outline: theme => ({
-    color: theme.primary.base,
-    backgroundColor: theme.white.base,
-    backgroundColorHover: theme.primary.light,
-    backgroundColorPressed: theme.primary.muted,
-    borderColor: theme.primary.base
-  }),
-  outlineDisabled: theme => ({
-    color: theme.primary.base,
-    backgroundColor: theme.transparent,
-    borderColor: theme.primary.base
-  }),
-  transparent: theme => ({
-    color: theme.primary.base,
-    backgroundColor: theme.transparent,
-    backgroundColorHover: theme.primary.light,
-    backgroundColorPressed: theme.primary.muted,
-    borderColor: theme.transparent
-  }),
-  transparentDisabled: theme => ({
-    color: theme.primary.base,
-    backgroundColor: theme.transparent,
-    borderColor: theme.transparent
-  }),
-  outlineGray: theme => ({
-    color: theme.darkFill,
-    backgroundColor: theme.white.base,
-    backgroundColorHover: theme.white.base,
-    backgroundColorPressed: theme.white.base,
-    borderColor: theme.gray04
-  }),
-  outlineGrayDisabled: theme => ({
-    color: theme.primary.base,
-    backgroundColor: theme.transparent,
-    borderColor: theme.gray02
-  })
+  standard: {
+    color: getThemeValue("white", "base"),
+    backgroundColor: getThemeValue("primary", "base"),
+    backgroundColorHover: getThemeValue("primary", "medium"),
+    backgroundColorPressed: getThemeValue("primary", "dark"),
+    borderColor: getThemeValue("transparent")
+  },
+  standardDisabled: {
+    color: getThemeValue("white", "base"),
+    backgroundColor: getThemeValue("primary", "base"),
+    borderColor: getThemeValue("transparent")
+  },
+  special: {
+    color: getThemeValue("white", "base"),
+    backgroundColor: getThemeValue("special", "base"),
+    backgroundColorHover: getThemeValue("special", "medium"),
+    backgroundColorPressed: getThemeValue("special", "dark"),
+    borderColor: getThemeValue("transparent")
+  },
+  specialDisabled: {
+    color: getThemeValue("white", "base"),
+    backgroundColor: getThemeValue("special", "base"),
+    borderColor: getThemeValue("transparent")
+  },
+  outline: {
+    color: getThemeValue("primary", "base"),
+    backgroundColor: getThemeValue("white", "base"),
+    backgroundColorHover: getThemeValue("primary", "light"),
+    backgroundColorPressed: getThemeValue("primary", "muted"),
+    borderColor: getThemeValue("primary", "base")
+  },
+  outlineDisabled: {
+    color: getThemeValue("primary", "base"),
+    backgroundColor: getThemeValue("transparent"),
+    borderColor: getThemeValue("primary", "base")
+  },
+  transparent: {
+    color: getThemeValue("primary", "base"),
+    backgroundColor: getThemeValue("transparent"),
+    backgroundColorHover: getThemeValue("primary", "light"),
+    backgroundColorPressed: getThemeValue("primary", "muted"),
+    borderColor: getThemeValue("transparent")
+  },
+  transparentDisabled: {
+    color: getThemeValue("primary", "base"),
+    backgroundColor: getThemeValue("transparent"),
+    borderColor: getThemeValue("transparent")
+  },
+  outlineGray: {
+    color: getThemeValue("darkFill"),
+    backgroundColor: getThemeValue("white", "base"),
+    backgroundColorHover: getThemeValue("white", "base"),
+    backgroundColorPressed: getThemeValue("white", "base"),
+    borderColor: getThemeValue("gray04")
+  },
+  outlineGrayDisabled: {
+    color: getThemeValue("primary", "base"),
+    backgroundColor: getThemeValue("transparent"),
+    borderColor: getThemeValue("gray02")
+  }
 };
 
 const SIZES = {
@@ -104,64 +105,38 @@ export const StyledButton = styled.button<StyledButtonProps>`
   border-radius: ${constants.borderRadius.small};
   cursor: pointer;
 
-  color: ${({ variant, theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return colorVariants[variant](buttonTheme).color;
-  }};
-  background-color: ${({ variant, theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return colorVariants[variant](buttonTheme).backgroundColor;
-  }};
-  border: 1px solid
-    ${({ variant, theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return colorVariants[variant](buttonTheme).borderColor;
-  }};
+  color: ${({ variant }) => colorVariants[variant].color};
+  background-color: ${({ variant }) => colorVariants[variant].backgroundColor};
+  border: 1px solid ${({ variant }) => colorVariants[variant].borderColor};
 
   transition: transform 0.1s linear;
   transition: background-color 0.3s ${constants.easing.easeInOutQuad};
 
   &:focus {
     outline: none;
-    box-shadow: ${({ theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return `0 0 5px 0 ${buttonTheme.primary.base}`;
-  }};
+    box-shadow: 0 0 5px 0 ${getThemeValue("primary", "base")};
   }
 
   &:hover {
-    background-color: ${({ variant, theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return colorVariants[variant](buttonTheme).backgroundColorHover;
-  }};
+    background-color: ${({ variant }) =>
+      colorVariants[variant].backgroundColorHover};
   }
 
   &:active {
     transform: scale(0.98, 0.98) translate(0, 1px);
-    background-color: ${({ variant, theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return colorVariants[variant](buttonTheme).backgroundColorPressed;
-  }};
+    background-color: ${({ variant }) =>
+      colorVariants[variant].backgroundColorPressed};
   }
 
   &:disabled {
     transform: none;
-    color: ${({ variant, theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return colorVariants[variant](buttonTheme).color;
-  }};
-
-    background-color: ${({ variant, theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return colorVariants[`${variant}Disabled`](buttonTheme).backgroundColor;
-  }};
-    border: 1px solid
-      ${({ variant, theme: { themeName } }) => {
-    const buttonTheme = themes[themeName];
-    return colorVariants[`${variant}Disabled`](buttonTheme).borderColor;
-  }};
+    color: ${({ variant }) => colorVariants[variant].color};
+    background-color: ${({ variant }) =>
+      colorVariants[variant].backgroundColor};
+    border: 1px solid ${({ variant }) =>
+      colorVariants[`${variant}Disabled`].borderColor};
     ${({ variant }) =>
-    variant === SPECIAL ? "opacity: 0.4;" : "opacity: 0.2;"};
+      variant === SPECIAL ? "opacity: 0.4;" : "opacity: 0.2;"};
   }
 
 
@@ -176,7 +151,12 @@ StyledButton.defaultProps = {
   }
 };
 
-export const StyledButtonLink = styled(StyledButton as StyledComponent<"a", any, StyledButtonProps, never>)`
+export const StyledButtonLink = styled(StyledButton as StyledComponent<
+  "a",
+  any,
+  StyledButtonProps,
+  never
+>)`
   display: block;
   text-decoration: none;
 `;

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Button /> renders link button correctly 1`] = `
 <a
-  className="kHnYRc"
+  className="fxGuYK"
   href="/"
   size="regular"
 >
@@ -12,7 +12,7 @@ exports[`<Button /> renders link button correctly 1`] = `
 
 exports[`<Button /> renders outline large size button correctly 1`] = `
 <button
-  className=" noFocus eBkRKA"
+  className=" noFocus fTWXaX"
   size="large"
 >
   Dummy Label
@@ -21,7 +21,7 @@ exports[`<Button /> renders outline large size button correctly 1`] = `
 
 exports[`<Button /> renders outline regular size button correctly 1`] = `
 <button
-  className=" noFocus fAhIdS"
+  className=" noFocus fcJuPe"
   size="regular"
 >
   Dummy Label
@@ -30,7 +30,7 @@ exports[`<Button /> renders outline regular size button correctly 1`] = `
 
 exports[`<Button /> renders outline regular size disabled button correctly 1`] = `
 <button
-  className=" noFocus fAhIdS"
+  className=" noFocus fcJuPe"
   disabled={true}
   size="regular"
 >
@@ -40,7 +40,7 @@ exports[`<Button /> renders outline regular size disabled button correctly 1`] =
 
 exports[`<Button /> renders outline small size button correctly 1`] = `
 <button
-  className=" noFocus dVAURc"
+  className=" noFocus xjqFN"
   size="small"
 >
   Dummy Label
@@ -49,7 +49,7 @@ exports[`<Button /> renders outline small size button correctly 1`] = `
 
 exports[`<Button /> renders special large size button correctly 1`] = `
 <button
-  className=" noFocus fxuzOL"
+  className=" noFocus cIFyVh"
   size="large"
 >
   Dummy Label
@@ -58,7 +58,7 @@ exports[`<Button /> renders special large size button correctly 1`] = `
 
 exports[`<Button /> renders special regular size button correctly 1`] = `
 <button
-  className=" noFocus iShFr"
+  className=" noFocus jVpvXK"
   size="regular"
 >
   Dummy Label
@@ -67,7 +67,7 @@ exports[`<Button /> renders special regular size button correctly 1`] = `
 
 exports[`<Button /> renders special regular size disabled button correctly 1`] = `
 <button
-  className=" noFocus iShFr"
+  className=" noFocus jVpvXK"
   disabled={true}
   size="regular"
 >
@@ -77,7 +77,7 @@ exports[`<Button /> renders special regular size disabled button correctly 1`] =
 
 exports[`<Button /> renders special small size button correctly 1`] = `
 <button
-  className=" noFocus ibrbUd"
+  className=" noFocus bEFiOZ"
   size="small"
 >
   Dummy Label
@@ -86,7 +86,7 @@ exports[`<Button /> renders special small size button correctly 1`] = `
 
 exports[`<Button /> renders standard large size button correctly 1`] = `
 <button
-  className=" noFocus kdJqXr"
+  className=" noFocus dLugRX"
   size="large"
 >
   Dummy Label
@@ -95,7 +95,7 @@ exports[`<Button /> renders standard large size button correctly 1`] = `
 
 exports[`<Button /> renders standard regular size button correctly 1`] = `
 <button
-  className=" noFocus encbkH"
+  className=" noFocus dsIgYQ"
   size="regular"
 >
   Dummy Label
@@ -104,7 +104,7 @@ exports[`<Button /> renders standard regular size button correctly 1`] = `
 
 exports[`<Button /> renders standard regular size disabled button correctly 1`] = `
 <button
-  className=" noFocus encbkH"
+  className=" noFocus dsIgYQ"
   disabled={true}
   size="regular"
 >
@@ -114,7 +114,7 @@ exports[`<Button /> renders standard regular size disabled button correctly 1`] 
 
 exports[`<Button /> renders standard small size button correctly 1`] = `
 <button
-  className=" noFocus bFeSYA"
+  className=" noFocus IyyhA"
   size="small"
 >
   Dummy Label
@@ -123,7 +123,7 @@ exports[`<Button /> renders standard small size button correctly 1`] = `
 
 exports[`<Button /> renders transparent large size button correctly 1`] = `
 <button
-  className=" noFocus hegczD"
+  className=" noFocus bGFEDe"
   size="large"
 >
   Dummy Label
@@ -132,7 +132,7 @@ exports[`<Button /> renders transparent large size button correctly 1`] = `
 
 exports[`<Button /> renders transparent regular size button correctly 1`] = `
 <button
-  className=" noFocus bSoaLb"
+  className=" noFocus dZuMkM"
   size="regular"
 >
   Dummy Label
@@ -141,7 +141,7 @@ exports[`<Button /> renders transparent regular size button correctly 1`] = `
 
 exports[`<Button /> renders transparent regular size disabled button correctly 1`] = `
 <button
-  className=" noFocus bSoaLb"
+  className=" noFocus dZuMkM"
   disabled={true}
   size="regular"
 >
@@ -151,7 +151,7 @@ exports[`<Button /> renders transparent regular size disabled button correctly 1
 
 exports[`<Button /> renders transparent small size button correctly 1`] = `
 <button
-  className=" noFocus kEKykV"
+  className=" noFocus bFxevU"
   size="small"
 >
   Dummy Label

--- a/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
@@ -97,7 +97,7 @@ exports[`CalendarView should render without errors 1`] = `
           className="c2 bIKecw"
         >
           <a
-            className="eKBcpm"
+            className="hRmYTx"
             href="#"
             size="small"
           >
@@ -108,7 +108,7 @@ exports[`CalendarView should render without errors 1`] = `
           className="c2 bIKecw"
         >
           <a
-            className="eKBcpm"
+            className="hRmYTx"
             href="#"
             size="small"
           >
@@ -191,7 +191,7 @@ exports[`CalendarView should render without errors 1`] = `
           className="c2 bIKecw"
         >
           <a
-            className="eKBcpm"
+            className="hRmYTx"
             href="#"
             size="small"
           >
@@ -202,7 +202,7 @@ exports[`CalendarView should render without errors 1`] = `
           className="c2 bIKecw"
         >
           <a
-            className="eKBcpm"
+            className="hRmYTx"
             href="#"
             size="small"
           >

--- a/src/components/Input/CheckBox/CheckBoxInput.styles.js
+++ b/src/components/Input/CheckBox/CheckBoxInput.styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { constants, themes } from "../../../theme";
+import { constants } from "../../../theme";
 import { getThemeValue } from "../../../utils";
 
 export default styled.input.attrs({
@@ -63,8 +63,7 @@ export default styled.input.attrs({
   }
   &:focus:before {
     outline: none;
-    box-shadow: ${({ theme: { themeName } }) =>
-      `0 0 5px 0 ${themes[themeName].primary.base}`};
+    box-shadow: 0 0 5px 0 ${getThemeValue("primary", "base")};
     border-color: ${getThemeValue("primary", "base")};
 
     .checkbox--small & {

--- a/src/components/Input/RadioButton/RadioButton.js
+++ b/src/components/Input/RadioButton/RadioButton.js
@@ -4,9 +4,9 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import { Consumer } from "../../SelectionProvider/Context";
 import { Consumer as KeyBoardConsumer } from "../../KeyboardNavigation/Context";
-import { themes } from "../../../theme";
 import RadioInput from "./RadioInput";
 import composeEventHandlers from "../../../utils/composeEventHandlers";
+import { getThemeValue } from "../../../utils";
 
 const RadioWrapper = styled.label`
   position: relative;
@@ -15,7 +15,7 @@ const RadioWrapper = styled.label`
   display: flex;
   align-items: center;
   text-align: left;
-  color: ${({ theme: { themeName } }) => themes[themeName].gray01};
+  color: ${getThemeValue("gray01")};
   outline: none;
   min-height: 44px;
 
@@ -98,20 +98,14 @@ RadioButton.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
-  onClick: PropTypes.func,
-  theme: PropTypes.shape({
-    themeName: PropTypes.string
-  })
+  onClick: PropTypes.func
 };
 
 RadioButton.defaultProps = {
   size: "small",
   children: null,
   isActive: true,
-  onClick: null,
-  theme: {
-    themeName: "tm"
-  }
+  onClick: null
 };
 
 RadioButton.displayName = "RadioButton";

--- a/src/components/Input/RadioButton/RadioInput.js
+++ b/src/components/Input/RadioButton/RadioInput.js
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { themes, constants } from "../../../theme";
+import { constants } from "../../../theme";
+import { getThemeValue } from "../../../utils";
 
 const RadioInput = styled.input.attrs({
   type: "radio"
@@ -36,8 +37,7 @@ const RadioInput = styled.input.attrs({
     left: 50%;
     transform: translate(-50%, -50%);
     border-radius: 50%;
-    border: ${({ theme: { themeName } }) =>
-      `1px solid ${themes[themeName].gray02}`};
+    border: 1px solid ${getThemeValue("gray02")};
 
     .radio-button--large & {
       width: 24px;
@@ -48,8 +48,7 @@ const RadioInput = styled.input.attrs({
       height: 16px;
     }
     .radio-button--disabled & {
-      border: ${({ theme: { themeName } }) =>
-        `1px solid ${themes[themeName].gray01}`};
+      border: 1px solid ${getThemeValue("gray01")};
     }
   }
   &:after {
@@ -63,8 +62,7 @@ const RadioInput = styled.input.attrs({
     left: 50%;
     transform: translate(-50%, -50%);
     border-radius: 50%;
-    background-color: ${({ theme: { themeName } }) =>
-      themes[themeName].primary.base};
+    background-color: ${getThemeValue("primary", "base")};
 
     .radio-button--large & {
       width: 8px;
@@ -76,22 +74,18 @@ const RadioInput = styled.input.attrs({
     }
 
     .radio-button--disabled & {
-      background-color: ${({ theme: { themeName } }) =>
-        themes[themeName].gray01};
+      background-color: ${getThemeValue("gray01")};
     }
   }
   &:focus:before {
     outline: none;
     border-width: 1px;
-    border-color: ${({ theme: { themeName } }) =>
-      themes[themeName].primary.base};
-    box-shadow: ${({ theme: { themeName } }) =>
-      `0 0 5px 0 ${themes[themeName].primary.base}`};
+    border-color: ${getThemeValue("primary", "base")};
+    box-shadow: 0 0 5px 0 ${getThemeValue("primary", "base")};
   }
   &:hover:before {
     border-width: 2px;
-    border-color: ${({ theme: { themeName } }) =>
-      themes[themeName].primary.base};
+    border-color: ${getThemeValue("primary", "base")};
 
     .radio-button--large & {
       width: 23px;

--- a/src/components/Input/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -34,7 +34,7 @@ Object {
             class="sc-eNQAEJ jfDpKy"
           >
             <button
-              class="button__selected sc-hMqMXs jKUFUL noFocus sc-cSHVUG ibICIf"
+              class="button__selected sc-hMqMXs jKUFUL noFocus sc-cSHVUG cpHQgj"
               data-testid="test-button0"
             >
               All
@@ -44,7 +44,7 @@ Object {
             class="sc-eNQAEJ jfDpKy"
           >
             <button
-              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG ibICIf"
+              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG cpHQgj"
               data-testid="test-button1"
             >
               Concerts
@@ -54,7 +54,7 @@ Object {
             class="sc-eNQAEJ jfDpKy"
           >
             <button
-              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG ibICIf"
+              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG cpHQgj"
               data-testid="test-button2"
             >
               Button Label
@@ -132,7 +132,7 @@ Object {
             class="sc-eNQAEJ jfDpKy"
           >
             <button
-              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG ibICIf"
+              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG cpHQgj"
               data-testid="test-button0"
             >
               All
@@ -142,7 +142,7 @@ Object {
             class="sc-eNQAEJ jfDpKy"
           >
             <button
-              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG ibICIf"
+              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG cpHQgj"
               data-testid="test-button1"
             >
               Concerts
@@ -152,7 +152,7 @@ Object {
             class="sc-eNQAEJ jfDpKy"
           >
             <button
-              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG ibICIf"
+              class="sc-hMqMXs jKUFUL noFocus sc-cSHVUG cpHQgj"
               data-testid="test-button2"
             >
               Button Label

--- a/src/components/Input/__tests__/__snapshots__/QtySelector.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/QtySelector.spec.js.snap
@@ -5,7 +5,7 @@ exports[`QtySelector decrements correctly 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -634,7 +634,7 @@ exports[`QtySelector decrements correctly 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -666,7 +666,7 @@ exports[`QtySelector decrements from non-zero value correctly 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -1295,7 +1295,7 @@ exports[`QtySelector decrements from non-zero value correctly 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -1327,7 +1327,7 @@ exports[`QtySelector decrements twice correctly 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -1956,7 +1956,7 @@ exports[`QtySelector decrements twice correctly 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -1988,7 +1988,7 @@ exports[`QtySelector handles case when input is deleted 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -2617,7 +2617,7 @@ exports[`QtySelector handles case when input is deleted 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -2649,7 +2649,7 @@ exports[`QtySelector handles input value correctly 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -3278,7 +3278,7 @@ exports[`QtySelector handles input value correctly 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -3310,7 +3310,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -3939,7 +3939,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -3971,7 +3971,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly when usin
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -4600,7 +4600,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly when usin
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -4632,7 +4632,7 @@ exports[`QtySelector increments correctly 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -5261,7 +5261,7 @@ exports[`QtySelector increments correctly 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -5293,7 +5293,7 @@ exports[`QtySelector increments twice correctly 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -5922,7 +5922,7 @@ exports[`QtySelector increments twice correctly 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -5954,7 +5954,7 @@ exports[`QtySelector renders default QtySelector 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -6583,7 +6583,7 @@ exports[`QtySelector renders default QtySelector 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -6615,7 +6615,7 @@ exports[`QtySelector renders disabled QtySelector 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
     disabled=""
   >
     <svg
@@ -7345,7 +7345,7 @@ exports[`QtySelector renders disabled QtySelector 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
     disabled=""
   >
     <svg
@@ -7378,7 +7378,7 @@ exports[`QtySelector sets focus state to false when input looses focus 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -8007,7 +8007,7 @@ exports[`QtySelector sets focus state to false when input looses focus 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -8039,7 +8039,7 @@ exports[`QtySelector sets focus state to true after input is focused 1`] = `
   class="sc-dnqmqq gQTnSb"
 >
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"
@@ -8073,7 +8073,7 @@ exports[`QtySelector sets focus state to true after input is focused 1`] = `
     />
   </div>
   <button
-    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa encbkH"
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
   >
     <svg
       height="24"

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -100,7 +100,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -510,7 +510,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -920,7 +920,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -1330,7 +1330,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -1748,7 +1748,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -2158,7 +2158,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -2568,7 +2568,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="Acheter des Billets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -2978,7 +2978,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -3396,7 +3396,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -3806,7 +3806,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -4216,7 +4216,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -4626,7 +4626,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -5044,7 +5044,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -5454,7 +5454,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -5864,7 +5864,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="Acheter des Billets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -6274,7 +6274,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -6693,7 +6693,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -6945,7 +6945,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -7355,7 +7355,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -7765,7 +7765,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -8175,7 +8175,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -8592,7 +8592,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -9002,7 +9002,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -9412,7 +9412,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -9822,7 +9822,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -10239,7 +10239,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -10681,7 +10681,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -11123,7 +11123,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -11565,7 +11565,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -12014,7 +12014,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -12424,7 +12424,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -12834,7 +12834,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -13244,7 +13244,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -13662,7 +13662,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -14072,7 +14072,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -14482,7 +14482,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="Acheter des Billets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -14892,7 +14892,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <span
               aria-label="See Tickets"
-              class="sc-hmzhuo ggcrez"
+              class="sc-hmzhuo dzlbCC"
               role="button"
               width="102px"
             >
@@ -15310,7 +15310,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -15441,7 +15441,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -15572,7 +15572,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="Acheter des Billets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >
@@ -15703,7 +15703,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <span
             aria-label="See Tickets"
-            class="sc-hmzhuo ggcrez"
+            class="sc-hmzhuo dzlbCC"
             role="button"
             width="102px"
           >

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -236,7 +236,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="lcowit"
+            className="gGqupZ"
             role="button"
             size="regular"
             width="102px"
@@ -481,7 +481,7 @@ exports[`<ListRow /> renders List Row with label correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="lcowit"
+            className="gGqupZ"
             role="button"
             size="regular"
             width="102px"
@@ -682,7 +682,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="lcowit"
+            className="gGqupZ"
             role="button"
             size="regular"
             width="102px"
@@ -924,7 +924,7 @@ exports[`<ListRow /> renders List Row with styled button 1`] = `
         >
           <span
             aria-label="More Info"
-            className="llRbMw"
+            className="dCXubg"
             role="button"
             size="regular"
             width="102px"
@@ -1125,7 +1125,7 @@ exports[`<ListRow /> renders List Row with title correctly when expanded 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="lcowit"
+            className="gGqupZ"
             role="button"
             size="regular"
             width="102px"
@@ -1326,7 +1326,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="lcowit"
+            className="gGqupZ"
             role="button"
             size="regular"
             width="102px"
@@ -1568,7 +1568,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
         >
           <span
             aria-label="See Tickets"
-            className="lcowit"
+            className="gGqupZ"
             role="button"
             size="regular"
             width="102px"

--- a/src/utils/__tests__/geThemeObject.spec.js
+++ b/src/utils/__tests__/geThemeObject.spec.js
@@ -1,0 +1,29 @@
+import { getThemeObject } from "..";
+import { themes } from "../../theme";
+
+describe("getThemeObject", () => {
+  it("should return global theme when themeName is not present in themes and customValues is not passed", () => {
+    expect(getThemeObject("uknown")).toEqual(themes.global);
+  });
+  it("should return global theme merged with customValues when themeName is not present in themes and customValues is passed", () => {
+    expect(getThemeObject("uknown", { brand: "#000000" })).toEqual({
+      ...themes.global,
+      brand: "#000000"
+    });
+  });
+
+  it("should return theme when themeName is present in themes and customValues is not passed", () => {
+    expect(getThemeObject("lne")).toEqual(themes.lne);
+  });
+
+  it("should return theme when themeName is present in themes and customValues is not object", () => {
+    expect(getThemeObject("tm", ["brand", "#000000"])).toEqual(themes.tm);
+  });
+
+  it("should return merged object of theme and customValues when both are present and valid", () => {
+    expect(getThemeObject("lne", { brand: "#000000" })).toEqual({
+      ...themes.lne,
+      brand: "#000000"
+    });
+  });
+});

--- a/src/utils/__tests__/getThemeValue.spec.js
+++ b/src/utils/__tests__/getThemeValue.spec.js
@@ -16,4 +16,30 @@ describe("getThemeValue", () => {
       getThemeValue("primary", "base", "three")({ theme: { themeName: "tm" } })
     ).toThrowError(ReferenceError);
   });
+  it("should return correct value when theme is passed as object", () => {
+    expect(
+      getThemeValue("primary", "base")({
+        theme: {
+          customValues: {
+            primary: {
+              base: "#000000"
+            }
+          }
+        }
+      })
+    ).toBe("#000000");
+  });
+  it("should return color from global theme when theme passed as object but the color is not overwritten", () => {
+    expect(
+      getThemeValue("gray01")({
+        theme: {
+          customValues: {
+            primary: {
+              base: "#000000"
+            }
+          }
+        }
+      })
+    ).toBe("#262626");
+  });
 });

--- a/src/utils/__tests__/isValidThemeColorVariant.spec.js
+++ b/src/utils/__tests__/isValidThemeColorVariant.spec.js
@@ -31,4 +31,49 @@ describe("isValidThemeColorVariant", () => {
       true
     );
   });
+
+  describe("when object is passed as theme", () => {
+    let themeObject;
+
+    beforeEach(() => {
+      themeObject = {
+        customValues: {
+          primary: {
+            base: "#000000"
+          }
+        }
+      };
+    });
+
+    it("should return true when the color and variant passed are valid for the theme object provided", () => {
+      expect(isValidThemeColorVariant(themeObject, "primary", "base")).toEqual(
+        true
+      );
+    });
+    it("should return true when the color and variant passed are valid for the result of merging global styles with the object styles passed", () => {
+      expect(isValidThemeColorVariant(themeObject, "special", "base")).toEqual(
+        true
+      );
+    });
+
+    it("should return false when the color passed does not have variants for the theme object provided", () => {
+      expect(isValidThemeColorVariant(themeObject, "brand", "dark")).toEqual(
+        false
+      );
+    });
+
+    it("should return false when an invalid variant is passed", () => {
+      expect(
+        isValidThemeColorVariant(themeObject, "accent01", "awesome")
+      ).toEqual(false);
+    });
+
+    it("should return false when no variant is passed to a color with variants", () => {
+      expect(isValidThemeColorVariant(themeObject, "brand")).toEqual(false);
+    });
+
+    it("should return false when an invalid color is passed", () => {
+      expect(isValidThemeColorVariant(themeObject, "fakecolor")).toEqual(false);
+    });
+  });
 });

--- a/src/utils/__tests__/memoize.spec.js
+++ b/src/utils/__tests__/memoize.spec.js
@@ -1,0 +1,26 @@
+import { memoize } from "..";
+
+describe("memoize", () => {
+  let functionMock;
+  let memoizedMock;
+
+  beforeEach(() => {
+    functionMock = jest.fn((a, b) => a + b);
+    memoizedMock = memoize(functionMock);
+  });
+
+  it("should call function mock with respective variables when the call is not memoed", () => {
+    memoizedMock(2, 3);
+    expect(functionMock).toHaveBeenCalledTimes(1);
+    expect(functionMock).toHaveBeenCalledWith(2, 3);
+  });
+
+  it("should call function mock with respective variables only once when momoed function is called twice with the same args", () => {
+    const initialResult = memoizedMock(2, 3);
+    const secondaryResult = memoizedMock(2, 3);
+    expect(functionMock).toHaveBeenCalledTimes(1);
+    expect(functionMock).toHaveBeenCalledWith(2, 3);
+    expect(initialResult).toBe(5);
+    expect(secondaryResult).toBe(5);
+  });
+});

--- a/src/utils/getThemeObject.js
+++ b/src/utils/getThemeObject.js
@@ -1,0 +1,16 @@
+import { themes } from "../theme";
+import { memoize } from "./";
+
+const getThemeObject = (themeName, customValues) => {
+  const baseTheme = themes[themeName] || themes.global;
+
+  if (customValues && customValues.constructor === Object) {
+    return { ...baseTheme, ...customValues };
+  }
+
+  return baseTheme;
+};
+
+const memoized = memoize(getThemeObject);
+
+export default memoized;

--- a/src/utils/getThemeValue.js
+++ b/src/utils/getThemeValue.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 
-import { themes } from "../theme";
 import { THEME_TM } from "../theme/constants";
+import { getThemeObject } from "./";
 
 export const themeShape = {
   themeName: PropTypes.string.isRequired
@@ -14,11 +14,14 @@ export const themeShape = {
  * automatically.
  */
 export default (...args) => ({
-  theme: { themeName = THEME_TM.themeName } = THEME_TM
-} = {}) =>
-  args.reduce((acc, el) => {
+  theme: { themeName = THEME_TM.themeName, customValues = null } = THEME_TM
+} = {}) => {
+  const themeObject = getThemeObject(themeName, customValues);
+
+  return args.reduce((acc, el) => {
     if (acc[el] === undefined) {
       throw new ReferenceError("value is not defined");
     }
     return acc[el];
-  }, themes[themeName]);
+  }, themeObject);
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,5 @@
+export { default as memoize } from "./memoize";
+export { default as getThemeObject } from "./getThemeObject";
 export { default as getThemeValue } from "./getThemeValue";
 export { default as composeEventHandlers } from "./composeEventHandlers";
 export { getRelByTarget, getAsProp } from "./link";

--- a/src/utils/isValidThemeColorVariant.js
+++ b/src/utils/isValidThemeColorVariant.js
@@ -1,15 +1,18 @@
-import { themes } from "../theme";
 import { THEME_TM } from "../theme/constants";
+import { getThemeObject } from "./";
 
 const isValidThemeColorVariant = (
-  { themeName = THEME_TM.themeName } = THEME_TM,
+  { themeName = THEME_TM.themeName, customValues = null } = THEME_TM,
   color,
   variant
-) =>
-  Boolean(
-    themes[themeName][color] &&
-      themes[themeName][color].constructor === Object &&
-      themes[themeName][color][variant]
+) => {
+  const themeObject = getThemeObject(themeName, customValues);
+
+  return Boolean(
+    themeObject[color] &&
+      themeObject[color].constructor === Object &&
+      themeObject[color][variant]
   );
+};
 
 export default isValidThemeColorVariant;

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-param-reassign */
+export default fn => (...input) => {
+  const args = Array.prototype.slice.call(input);
+
+  fn.cache = fn.cache || {};
+
+  const result = fn.cache[args]
+    ? fn.cache[args]
+    : (fn.cache[args] = fn.apply(this, args));
+
+  return result;
+};


### PR DESCRIPTION
**What**:

add another property to theme - customTheme, which should be an object when used. 
Allowing the user to use themeName and customTheme at the same time in order to overwrite certain colors from a certain them. 

**Why**:

Support custom themes

**How**:

Pass object to customTheme. Merge global theme or the theme passed as themeName with customTheme object so we don't loose any colors definition and get colors overwrite.

**Checklist**:

* [n/a] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
