### PR TITLE
fix(Tooltip): ToolTip not displayed in MSEdge

### DIFF
--- a/src/components/Tooltip/__tests__/index.spec.js
+++ b/src/components/Tooltip/__tests__/index.spec.js
@@ -221,10 +221,10 @@ describe("Tooltip", () => {
     const event = {
       target: {
         getBoundingClientRect: () => ({
-          y: 100,
+          top: 100,
           height: 50,
           width: 50,
-          x: 200
+          left: 200
         })
       }
     };
@@ -248,20 +248,20 @@ describe("Tooltip", () => {
     const event = {
       target: {
         getBoundingClientRect: () => ({
-          y: 100,
+          top: 100,
           height: 50,
           width: 50,
-          x: 200
+          left: 200
         })
       }
     };
 
     const parent = {
       getBoundingClientRect: () => ({
-        y: 100,
+        top: 100,
         height: 50,
         width: 50,
-        x: 200
+        left: 200
       })
     };
 

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -66,15 +66,15 @@ class Tooltip extends Component {
    */
   static getDimensionsFromEvent(e, parent) {
     const {
-      y: elTop,
+      top: elTop,
       height: elHeight,
-      x: elLeft,
+      left: elLeft,
       width: elWidth
     } = e.target.getBoundingClientRect();
     const {
-      y: offsetTop = 0,
+      top: offsetTop = 0,
       height: clientHeight = 100000,
-      x: offsetLeft = 0,
+      left: offsetLeft = 0,
       width: clientWidth = 100000
     } =
       parent && parent.getBoundingClientRect


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
fix(Tooltip): ToolTip not displayed in MSEdge
**What**:
ToolTip was not displayed on MSEdge because of taking the `x` and `y` variables calculated using `getBoundingClientRect `
<!-- Why are these changes necessary? -->

**Why**: In order to support the tooltip in MSEdge