### PR TITLE
fix(*): TypeScript typings now properly packaged upon release

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
   "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "files": [
-    "dist"
+    "dist",
+    "lib"
   ],
   "license": "MIT",
   "scripts": {
     "build": "npm run build:dev && npm run build:prod && npm run tsc:declaration",
-    "build:dev": "rollup -c config/rollup.dev.config.js",
-    "build:prod": "rollup -c config/rollup.prod.config.js",
+    "build:dev": "rollup -c config/rollup.dev.config.js && npm run tsc:declaration",
+    "build:prod": "rollup -c config/rollup.prod.config.js && npm run tsc:declaration",
     "catalog-start": "NODE_ENV=development catalog start",
     "catalog-build": "catalog build  -u \"/aurora\"",
     "lint": "eslint \"{src,catalog}/**/*.{js,jsx,ts,tsx}\"",
@@ -31,7 +32,7 @@
     "test:ci": "NODE_ENV=test jest --changedSince=master --runInBand",
     "add-icons": "pixo $* --out-dir src/components/Icons",
     "tsc:declaration": "tsc -p tsconfig.declaration.json",
-    "posttsc:declaration": "node scripts/declarejs.js"
+    "posttsc:declaration": "node -e 'require(\"./scripts/declarejs\").generateStubTypings()'"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/declarejs.js
+++ b/scripts/declarejs.js
@@ -21,7 +21,7 @@ if (typeof Array.prototype.flatMap !== "function") {
 
 const srcPath = path.resolve(__dirname, "..", "src");
 const libPath = path.resolve(__dirname, "..", "lib");
-const exportPattern = /^\s*export[\s\n\r]+(default|class|const|var|let)[\s\n\r]+([a-zA-Z0-9_$]+)?/gm;
+const exportPattern = /(?<=\s*export[\s\n\r]+(default|class|const|var|let)[\s\n\r]+\{?[^=]*)[^{\s\n\r,;=}]+(?=[^}]*}?\s*(=|;).*)/gm;
 const exportSymbolsPattern = /^\s*export\s*\{[^}]*}[^;]*;/gm;
 const fromPattern = /\bfrom\b/;
 const symbolPattern = /[{,][\s\n\r]*([A-Za-z0-9_$]+)(?:[\s\n\r]+as[\s\n\r]+([A-Za-z0-9_$]+))?/g;
@@ -71,7 +71,7 @@ const stubExports = content =>
   [
     matches(content, exportPattern).map(
       match =>
-        match[1] === "default" ? stubDefaultExport() : stubNamedExport(match[2])
+        match[1] === "default" ? stubDefaultExport() : stubNamedExport(match[0])
     ),
     matches(content, exportSymbolsPattern)
       .map(match => match[0])
@@ -109,7 +109,10 @@ function* matchesGenerator(str, re) {
   }
 }
 
-readdirRecursive(srcPath)
-  .filter(name => path.extname(name) === ".js" && !name.includes("__tests__"))
-  .map(name => path.relative(srcPath, name))
-  .forEach(createDeclaration);
+module.exports.generateStubTypings = () =>
+  readdirRecursive(srcPath)
+    .filter(name => path.extname(name) === ".js" && !name.includes("__tests__"))
+    .map(name => path.relative(srcPath, name))
+    .forEach(createDeclaration);
+
+module.exports.generateStub = stubExports; // Exported for tests

--- a/scripts/declarejs.spec.js
+++ b/scripts/declarejs.spec.js
@@ -1,0 +1,41 @@
+import { generateStub } from "./declarejs";
+
+const cleanLines = input =>
+  input
+    .split("\n")
+    .filter(s => s !== "")
+    .map(s => s.trim());
+
+describe("declarejs, when generating types", () => {
+  describe("for a simple default export", () => {
+    it("should generate a single default export of type 'any'", () => {
+      expect(cleanLines(generateStub("export default Card;"))).toEqual([
+        "declare const component: any;",
+        "export default component;"
+      ]);
+    });
+  });
+
+  describe("for a complex named export", () => {
+    it("should generate a single named export", () => {
+      const complexInput = `export const withDeviceSize = Component => props => (
+                <Consumer>{value => <Component deviceSize={value} {...props} />}</Consumer>
+              );`;
+      expect(cleanLines(generateStub(complexInput))).toEqual([
+        "export const withDeviceSize: any;"
+      ]);
+    });
+  });
+
+  describe("for a complex export with multiple names", () => {
+    it("should generate multiple named exports", () => {
+      expect(
+        cleanLines(
+          generateStub(
+            "export const { Provider, Consumer } = React.createContext({ isSmall: true });"
+          )
+        )
+      ).toEqual(["export const Provider: any;", "export const Consumer: any;"]);
+    });
+  });
+});


### PR DESCRIPTION
fix(*): TypeScript typings now properly packaged upon release and no longer generates 'undefined' types

**What**:
Typescript typings are now packaged with the released module and properly generated.

**Why**:
Without the change, IDEs (reported on IntelliJ, observed on VSCode) were unable to find typings for the components.

**How**:
3 changes were made:
- the 'lib' folder is now included in the tarball during npm pack+release
- the declarejs script has been fixed (was generating 'undefined' types under certain circumstances)
- unit-tested the stub-generating piece of the declarejs script

**Checklist**:

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged