### PR TITLE
fix(SearchInput): prevent form submission when user interacts with se…

### DIFF
--- a/src/components/SearchInput/__tests__/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__tests__/__snapshots__/SearchInput.spec.js.snap
@@ -3,14 +3,13 @@
 exports[`SearchInput icon only should match snapshot 1`] = `
 <div
   className="search--container search--container-icon-only VIiGN"
-  onBlur={[Function]}
   onClick={[Function]}
-  onFocus={[Function]}
 >
   <button
     aria-label="Search button"
     className="search--search-icon elbNR"
     onClick={[Function]}
+    type="button"
   >
     <svg
       className="gxyxth"
@@ -48,6 +47,7 @@ exports[`SearchInput icon only should match snapshot 1`] = `
     aria-label="Clear button"
     className="search--clear-icon bPHzCq"
     onClick={[Function]}
+    type="button"
     value=""
   >
     <svg
@@ -75,6 +75,7 @@ exports[`SearchInput icon only should match snapshot 1`] = `
     aria-label="Cancel button"
     className="search--cancel-icon bFRYwA"
     onClick={[Function]}
+    type="button"
   >
     Cancel
   </button>
@@ -84,14 +85,13 @@ exports[`SearchInput icon only should match snapshot 1`] = `
 exports[`SearchInput large should match snapshot 1`] = `
 <div
   className="search--container bSzdPT"
-  onBlur={[Function]}
   onClick={[Function]}
-  onFocus={[Function]}
 >
   <button
     aria-label="Search button"
     className="search--search-icon elbNR"
     onClick={[Function]}
+    type="button"
   >
     <svg
       className="gxyxth"
@@ -129,6 +129,7 @@ exports[`SearchInput large should match snapshot 1`] = `
     aria-label="Clear button"
     className="search--clear-icon bPHzCq"
     onClick={[Function]}
+    type="button"
     value=""
   >
     <svg
@@ -156,6 +157,7 @@ exports[`SearchInput large should match snapshot 1`] = `
     aria-label="Cancel button"
     className="search--cancel-icon bFRYwA"
     onClick={[Function]}
+    type="button"
   >
     Cancel
   </button>
@@ -165,14 +167,13 @@ exports[`SearchInput large should match snapshot 1`] = `
 exports[`SearchInput mobile and focused should match snapshot 1`] = `
 <div
   className="search--container search--container-icon-only search--container-focused dmEOlX"
-  onBlur={[Function]}
   onClick={[Function]}
-  onFocus={[Function]}
 >
   <button
     aria-label="Search button"
     className="search--search-icon doQCjb"
     onClick={[Function]}
+    type="button"
   >
     <svg
       className="gxyxth"
@@ -210,6 +211,7 @@ exports[`SearchInput mobile and focused should match snapshot 1`] = `
     aria-label="Clear button"
     className="search--clear-icon boklFi"
     onClick={[Function]}
+    type="button"
     value=""
   >
     <svg
@@ -237,6 +239,7 @@ exports[`SearchInput mobile and focused should match snapshot 1`] = `
     aria-label="Cancel button"
     className="search--cancel-icon eynrqJ"
     onClick={[Function]}
+    type="button"
   >
     Cancel
   </button>
@@ -246,14 +249,13 @@ exports[`SearchInput mobile and focused should match snapshot 1`] = `
 exports[`SearchInput small should match snapshot 1`] = `
 <div
   className="search--container search--container-has-value bodmAZ"
-  onBlur={[Function]}
   onClick={[Function]}
-  onFocus={[Function]}
 >
   <button
     aria-label="Search button"
     className="search--search-icon elbNR"
     onClick={[Function]}
+    type="button"
   >
     <svg
       className="gxyxth"
@@ -291,6 +293,7 @@ exports[`SearchInput small should match snapshot 1`] = `
     aria-label="Clear button"
     className="search--clear-icon kvTcsu"
     onClick={[Function]}
+    type="button"
     value="test"
   >
     <svg
@@ -323,6 +326,7 @@ exports[`SearchInput small should match snapshot 1`] = `
     aria-label="Cancel button"
     className="search--cancel-icon bFRYwA"
     onClick={[Function]}
+    type="button"
   >
     Cancel
   </button>

--- a/src/components/SearchInput/__tests__/__snapshots__/SearchInputMobile.spec.js.snap
+++ b/src/components/SearchInput/__tests__/__snapshots__/SearchInputMobile.spec.js.snap
@@ -3,14 +3,13 @@
 exports[`SearchInputMobile should match snapshot 1`] = `
 <div
   className="search--container kuAkVI"
-  onBlur={[Function]}
   onClick={[Function]}
-  onFocus={[Function]}
 >
   <button
     aria-label="Search button"
     className="search--search-icon doQCjb"
     onClick={[Function]}
+    type="button"
   >
     <svg
       className="gxyxth"
@@ -48,6 +47,7 @@ exports[`SearchInputMobile should match snapshot 1`] = `
     aria-label="Clear button"
     className="search--clear-icon boklFi"
     onClick={[Function]}
+    type="button"
     value=""
   >
     <svg
@@ -75,6 +75,7 @@ exports[`SearchInputMobile should match snapshot 1`] = `
     aria-label="Cancel button"
     className="search--cancel-icon jiWdvT"
     onClick={[Function]}
+    type="button"
   >
     Cancel
   </button>
@@ -87,14 +88,13 @@ exports[`SearchInputMobile should match snapshot when mobile opened 1`] = `
 >
   <div
     className="search--container kuAkVI"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
   >
     <button
       aria-label="Search button"
       className="search--search-icon doQCjb"
       onClick={[Function]}
+      type="button"
     >
       <svg
         className="gxyxth"
@@ -132,6 +132,7 @@ exports[`SearchInputMobile should match snapshot when mobile opened 1`] = `
       aria-label="Clear button"
       className="search--clear-icon boklFi"
       onClick={[Function]}
+      type="button"
       value=""
     >
       <svg
@@ -159,6 +160,7 @@ exports[`SearchInputMobile should match snapshot when mobile opened 1`] = `
       aria-label="Cancel button"
       className="search--cancel-icon jiWdvT"
       onClick={[Function]}
+      type="button"
     >
       Cancel
     </button>

--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -112,6 +112,8 @@ class SearchInput extends Component {
       isSuggestOpened,
       hasBackground,
       isMobile,
+      onFocus,
+      onBlur,
       ...rest
     } = this.props;
     const { isFocused } = this.state;
@@ -131,6 +133,7 @@ class SearchInput extends Component {
         })}
       >
         <StyledSearchIcon
+          type="button"
           variant={variant}
           isFocused={isStyleForFocusedUsed}
           onClick={this.searchIconClick}
@@ -153,6 +156,7 @@ class SearchInput extends Component {
           })}
         />
         <Clear
+          type="button"
           onClick={this.clearTextClick}
           value={value}
           aria-label={clearBtnAreaLabel}
@@ -163,6 +167,7 @@ class SearchInput extends Component {
           <ClearIcon size={variant} color="currentColor" />
         </Clear>
         <Cancel
+          type="button"
           isFocused={isStyleForFocusedUsed}
           showElement={showCancelButton}
           onClick={this.cancelClick}


### PR DESCRIPTION
…arch input

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Preventing a form submission when SearchInput is used inside `<form />` element

<!-- Why are these changes necessary? -->

**Why**: bad UX

<!-- How were these changes implemented? -->

**How**: Updated `<button />` inside SearchInput component to have `type="button"` so that when it is used inside a form - interacting with these button elements won't submit the form. Also properly handling props spreading, so that onFocus/onBlur callbacks do not get added as an event listeners on the search input container. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
