### PR TITLE
feat(QtySelector): Improve QtySelector

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -420,7 +420,7 @@ rows:
     Default: "null"
     Notes: Invoked with an array of updatedSelections when one or more option(s) is selected by the user
   - Prop: variant
-    Type: 
+    Type:
       enum(
         DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL,
         DropDownGroup.LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL,
@@ -501,7 +501,7 @@ span: 6
     <Container>
         <Row>
             <Column medium={4}>
-                <DropDownGroup 
+                <DropDownGroup
                   size="small"
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL}
                   placeholder="Select an option"
@@ -849,18 +849,33 @@ rows:
     Type: bool
     Default:
     Notes: defines if toggle is disabled
+  - Prop: min
+    Type: number
+    Default: 0
+    Notes: defines min number. The decrement button is disabled when min value is reached.
+  - Prop: max
+    Type: number
+    Default: 99
+    Notes: defines max number. The increment button is disabled when max value is reached.
+  - Prop: onValueChanged
+    Type: function
+    Default:
+    Notes: call back function when value is updated either by buttons or keyboard. Use this function instead of onChange.
 ```
 
-It also accepts any event handlers. e.g. `onChange`, `onBlur`, `onFocus` etc. as well as styles object.
+It also accepts any event handlers. e.g. `onBlur`, `onFocus` etc. as well as styles object.
 
 ```react
 span: 6
 ---
 <div style={{ display: 'flex' }}>
-    <div style={{ width: '50%' }}>
+    <div style={{ width: '30%' }}>
         <QtySelector value={50} />
     </div>
-    <div style={{ width: '50%' }}>
+    <div style={{ width: '30%' }}>
+        <QtySelector value={2} min={2} max={4}/>
+    </div>
+    <div style={{ width: '30%' }}>
         <QtySelector value={50} disabled/>
     </div>
 </div>

--- a/src/components/Input/__tests__/QtySelector.spec.js
+++ b/src/components/Input/__tests__/QtySelector.spec.js
@@ -13,6 +13,11 @@ describe("QtySelector", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it("renders QtySelector correctly when there are min and max", () => {
+    const { container } = renderQtySelectorComponent({ min: 2, max: 4 });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   it("renders disabled QtySelector", () => {
     const { container } = renderQtySelectorComponent({ disabled: true });
     expect(container.firstChild).toMatchSnapshot();

--- a/src/components/Input/__tests__/__snapshots__/QtySelector.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/QtySelector.spec.js.snap
@@ -6,6 +6,7 @@ exports[`QtySelector decrements correctly 1`] = `
 >
   <button
     class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+    disabled=""
   >
     <svg
       height="24"
@@ -667,6 +668,7 @@ exports[`QtySelector decrements from non-zero value correctly 1`] = `
 >
   <button
     class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+    disabled=""
   >
     <svg
       height="24"
@@ -1328,6 +1330,7 @@ exports[`QtySelector decrements twice correctly 1`] = `
 >
   <button
     class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+    disabled=""
   >
     <svg
       height="24"
@@ -3311,6 +3314,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly 1`] = `
 >
   <button
     class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+    disabled=""
   >
     <svg
       height="24"
@@ -3341,601 +3345,601 @@ exports[`QtySelector handles input value longer than 2 chars correctly 1`] = `
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
   </div>
   <button
@@ -4601,6 +4605,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly when usin
   </div>
   <button
     class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+    disabled=""
   >
     <svg
       height="24"
@@ -4661,603 +4666,603 @@ exports[`QtySelector increments correctly 1`] = `
   >
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -0px;"
+      style="top: -34px;"
       type="text"
-      value="0"
+      value="1"
     />
   </div>
   <button
@@ -5322,603 +5327,694 @@ exports[`QtySelector increments twice correctly 1`] = `
   >
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
     />
     <input
       class="sc-gqjmRU jUkIwc"
-      style="top: -34px;"
+      style="top: -68px;"
       type="text"
-      value="1"
+      value="2"
+    />
+  </div>
+  <button
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+  >
+    <svg
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fill-rule="nonzero"
+      >
+        <path
+          d="M0 0h24v24H0z"
+        />
+        <path
+          d="M4 12h16M12 4v16"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`QtySelector renders QtySelector correctly when there are min and max 1`] = `
+<div
+  class="sc-dnqmqq gQTnSb"
+>
+  <button
+    class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+  >
+    <svg
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fill-rule="nonzero"
+      >
+        <path
+          d="M0 0h24v24H0z"
+        />
+        <path
+          d="M4 12h16"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </g>
+    </svg>
+  </button>
+  <div
+    class="sc-gZMcBi eVNOlY"
+  >
+    <input
+      class="sc-gqjmRU jUkIwc"
+      style="top: -0px;"
+      type="text"
+      value="0"
+    />
+    <input
+      class="sc-gqjmRU jUkIwc"
+      style="top: -0px;"
+      type="text"
+      value="0"
+    />
+    <input
+      class="sc-gqjmRU jUkIwc"
+      style="top: -0px;"
+      type="text"
+      value="0"
+    />
+    <input
+      class="sc-gqjmRU jUkIwc"
+      style="top: -0px;"
+      type="text"
+      value="0"
+    />
+    <input
+      class="sc-gqjmRU jUkIwc"
+      style="top: -0px;"
+      type="text"
+      value="0"
     />
   </div>
   <button
@@ -5955,6 +6051,7 @@ exports[`QtySelector renders default QtySelector 1`] = `
 >
   <button
     class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+    disabled=""
   >
     <svg
       height="24"
@@ -5985,601 +6082,601 @@ exports[`QtySelector renders default QtySelector 1`] = `
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
   </div>
   <button
@@ -6648,700 +6745,700 @@ exports[`QtySelector renders disabled QtySelector 1`] = `
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       disabled=""
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
   </div>
   <button
@@ -7379,6 +7476,7 @@ exports[`QtySelector sets focus state to false when input looses focus 1`] = `
 >
   <button
     class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+    disabled=""
   >
     <svg
       height="24"
@@ -7409,601 +7507,601 @@ exports[`QtySelector sets focus state to false when input looses focus 1`] = `
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
     <input
       class="sc-gqjmRU jUkIwc"
       style="top: -0px;"
       type="text"
-      value=""
+      value="0"
     />
   </div>
   <button
@@ -8040,6 +8138,7 @@ exports[`QtySelector sets focus state to true after input is focused 1`] = `
 >
   <button
     class="sc-iwsKbI eZUJRF noFocus sc-bdVaJa dsIgYQ"
+    disabled=""
   >
     <svg
       height="24"
@@ -8069,7 +8168,7 @@ exports[`QtySelector sets focus state to true after input is focused 1`] = `
     <input
       class="sc-gqjmRU jUkIwc"
       type="text"
-      value=""
+      value="0"
     />
   </div>
   <button


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Improvement for the QtySelector component

<!-- Why are these changes necessary? -->

**Why**:
We can pass in the initial value when rendering the QtySelector. The + and - button updated the value correctly. However, it does not inform the parent component that the value is updated since I see it only updated its internal state value. 

<!-- How were these changes implemented? -->

**How**:

- Add a callback prop `onValueUpdated` to pass the new value to the parent component.

Also, I have added the following changes:

- Added min and max props
- Disable + and - buttons when a value is already at min and max 
- The default value is 0 instead of empty string
- Adjust the Array length to only render up to the range between min and max for animation


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
