### PR TITLE
Add missing sizes in typography documentation

### DIFF
--- a/catalog/pages/typography/index.js
+++ b/catalog/pages/typography/index.js
@@ -23,7 +23,6 @@ const fontWeightLabelStyle = {
 
 const fontSizeRowStyle = {
   padding: "20px",
-  display: "flex",
   alignItems: "center"
 };
 

--- a/catalog/pages/typography/index.md
+++ b/catalog/pages/typography/index.md
@@ -136,56 +136,32 @@ rows:
 
 ```react
 const str = "Better is together";
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
 <Container>
-<Row style={fontSizeRowStyle}>
+  <Row style={fontSizeRowStyle}>
     <Column medium={2}>Responsive Size</Column>
     <Column medium={6}>
-        <Text responsiveSize={{ xSmall: "uno", small: "hecto", medium: "kilo", large: "giga", xLarge: "tera" }}>{str}</Text>
+      <Text responsiveSize={{ xSmall: "uno", small: "hecto", medium: "kilo", large: "giga", xLarge: "tera" }}>{str}</Text>
     </Column>
-</Row>
-<Row style={fontSizeRowStyle}>
-    <Column medium={2}>Uno - 12 px</Column>
-    <Column medium={6}>
-        <Text size="uno">{str}</Text>
-    </Column>
-</Row>
-<Row style={fontSizeRowStyle}>
-    <Column medium={2}>Hecto - 14 px</Column>
-    <Column medium={6}>
-        <Text size="hecto">{str}</Text>
-    </Column>
-</Row>
-<Row style={fontSizeRowStyle}>
-    <Column medium={2}>Kilo - 16 px</Column>
-    <Column medium={6}>
-        <Text size="kilo">{str}</Text>
-    </Column>
-</Row>
-<Row style={fontSizeRowStyle}>
-    <Column medium={2}>Giga - 20 px</Column>
-    <Column medium={6}>
-        <Text size="giga">{str}</Text>
-    </Column>
-</Row>
-<Row style={fontSizeRowStyle}>
-    <Column medium={2}>Tera - 24 px</Column>
-    <Column medium={6}>
-        <Text size="tera">{str}</Text>
-    </Column>
-</Row>
-<Row style={fontSizeRowStyle}>
-    <Column medium={2}>Zetta - 32 px</Column>
-    <Column medium={6} tyle={{fontSize: "32px"}}>
-        {str}
-    </Column>
-</Row>
-<Row style={fontSizeRowStyle}>
-    <Column medium={2}>Bronto - 46 px</Column>
-    <Column medium={6} style={{fontSize: "46px"}}>
-        {str}
-    </Column>
-</Row>
+  </Row>
 
+  {
+    Object.entries(typography.size).map(([size, value]) => {
+      const sizeLabel = `${capitalizeFirstLetter(size)} - ${value}`;
+      return (
+        <Row key={size} style={fontSizeRowStyle}>
+          <Column medium={2}>{sizeLabel}</Column>
+          <Column medium={6}>
+            <Text size={size}>{str}</Text>
+          </Column>
+        </Row>
+      )
+    })
+  }
 </Container>
 ```
 

--- a/src/components/Text/PropTypes.js
+++ b/src/components/Text/PropTypes.js
@@ -1,6 +1,15 @@
 import PropTypes from "prop-types";
 
-const ALLOWED_SIZES = ["mini", "uno", "hecto", "kilo", "giga", "tera", "zetta"];
+const ALLOWED_SIZES = [
+  "mini",
+  "uno",
+  "hecto",
+  "kilo",
+  "giga",
+  "tera",
+  "zetta",
+  "bronto"
+];
 
 export const variant = PropTypes.oneOf(["accent", "dark", "light"]);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add missing sizes in typography documentation

<!-- Why are these changes necessary? -->

**Why**: Improve imperative code

<!-- How were these changes implemented? -->

**How**: Adding functional approach using `typography.size` props

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
