### PR TITLE
fix(SearchInput): hide user agent pseudo elements

### DIFF
--- a/src/components/SearchInput/Search.styles.js
+++ b/src/components/SearchInput/Search.styles.js
@@ -92,6 +92,10 @@ export const StyledInput = styled.input.attrs({
       !isFocused ? themes.global.white.base : themes.global.onyx.muted};
   }
 
+  &::-ms-clear {
+    display: none;
+  }
+
   :focus {
     outline: none;
   }

--- a/src/components/SearchInput/__tests__/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__tests__/__snapshots__/SearchInput.spec.js.snap
@@ -36,7 +36,7 @@ exports[`SearchInput icon only should match snapshot 1`] = `
   <input
     aria-label="Search input"
     autoComplete="off"
-    className="search--input dykHyd"
+    className="search--input ouBlI"
     onChange={[Function]}
     onFocus={[Function]}
     placeholder="Search Demo"
@@ -118,7 +118,7 @@ exports[`SearchInput large should match snapshot 1`] = `
   <input
     aria-label="Search input"
     autoComplete="off"
-    className="search--input dykHyd"
+    className="search--input ouBlI"
     onChange={[Function]}
     onFocus={[Function]}
     placeholder="Search Demo"
@@ -200,7 +200,7 @@ exports[`SearchInput mobile and focused should match snapshot 1`] = `
   <input
     aria-label="Search input"
     autoComplete="off"
-    className="search--input search--input-focused eoYmwb"
+    className="search--input search--input-focused bjaWSd"
     onChange={[Function]}
     onFocus={[Function]}
     placeholder="Search Demo"
@@ -282,7 +282,7 @@ exports[`SearchInput small should match snapshot 1`] = `
   <input
     aria-label="Search input"
     autoComplete="off"
-    className="search--input kUmVk"
+    className="search--input hlAOOB"
     onChange={[Function]}
     onFocus={[Function]}
     placeholder="Search Demo"

--- a/src/components/SearchInput/__tests__/__snapshots__/SearchInputMobile.spec.js.snap
+++ b/src/components/SearchInput/__tests__/__snapshots__/SearchInputMobile.spec.js.snap
@@ -36,7 +36,7 @@ exports[`SearchInputMobile should match snapshot 1`] = `
   <input
     aria-label="Search input"
     autoComplete="off"
-    className="search--input eoYmwb"
+    className="search--input bjaWSd"
     onChange={[Function]}
     onFocus={[Function]}
     placeholder="Search Demo"
@@ -121,7 +121,7 @@ exports[`SearchInputMobile should match snapshot when mobile opened 1`] = `
     <input
       aria-label="Search input"
       autoComplete="off"
-      className="search--input eoYmwb"
+      className="search--input bjaWSd"
       onChange={[Function]}
       onFocus={[Function]}
       placeholder="Search Demo"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Removing default `Clear` UA pseudo-element from the SearchInput in MS Edge / IE browsers

<!-- Why are these changes necessary? -->

**Why**: There's a default `Clear` control (`X`) being added in Edge/IE browser, which duplicates functionality we've implemented using custom control

![image](https://user-images.githubusercontent.com/5937440/62889620-95a36180-bcf6-11e9-852a-6153a54957e4.png)


<!-- How were these changes implemented? -->

**How**: added display: none targeting -ms-clear pseudo element selector

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
