### PR TITLE
fix(Drawer): fix content overlapping after keyboard forces the screen up

### DIFF
--- a/src/components/Drawer/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Drawer/__tests__/__snapshots__/index.spec.js.snap
@@ -85,30 +85,32 @@ exports[`Drawer renders default drawer 1`] = `
   className=""
 >
   <DrawerContent>
-    <Gradient
-      className="gradient--spotlight"
-      style={
-        Object {
-          "height": "60px",
-          "position": "relative",
+    <div>
+      <Gradient
+        className="gradient--spotlight"
+        style={
+          Object {
+            "height": "60px",
+            "position": "relative",
+          }
         }
-      }
-    >
-      <HeaderContent>
-        <div />
-        <CloseButton
-          type="button"
-        >
-          <span
-            className="hamburger hamburger--closed c0"
+      >
+        <HeaderContent>
+          <div />
+          <CloseButton
+            type="button"
           >
             <span
-              className="c1"
-            />
-          </span>
-        </CloseButton>
-      </HeaderContent>
-    </Gradient>
+              className="hamburger hamburger--closed c0"
+            >
+              <span
+                className="c1"
+              />
+            </span>
+          </CloseButton>
+        </HeaderContent>
+      </Gradient>
+    </div>
   </DrawerContent>
 </DrawerContainer>
 `;
@@ -198,37 +200,39 @@ exports[`Drawer renders header elements 1`] = `
   className=""
 >
   <DrawerContent>
-    <Gradient
-      className="gradient--spotlight"
-      style={
-        Object {
-          "height": "60px",
-          "position": "relative",
+    <div>
+      <Gradient
+        className="gradient--spotlight"
+        style={
+          Object {
+            "height": "60px",
+            "position": "relative",
+          }
         }
-      }
-    >
-      <HeaderContent>
-        <div>
-          <span>
-            Some Title Element
-          </span>
-        </div>
-        <CloseButton
-          type="button"
-        >
-          <span
-            className="hamburger hamburger--closed c0"
+      >
+        <HeaderContent>
+          <div>
+            <span>
+              Some Title Element
+            </span>
+          </div>
+          <CloseButton
+            type="button"
           >
             <span
-              className="c1"
-            />
-          </span>
-        </CloseButton>
-      </HeaderContent>
-    </Gradient>
-    <span>
-      Content
-    </span>
+              className="hamburger hamburger--closed c0"
+            >
+              <span
+                className="c1"
+              />
+            </span>
+          </CloseButton>
+        </HeaderContent>
+      </Gradient>
+      <span>
+        Content
+      </span>
+    </div>
   </DrawerContent>
 </DrawerContainer>
 `;
@@ -318,39 +322,41 @@ exports[`Drawer renders multiple child elements 1`] = `
   className=""
 >
   <DrawerContent>
-    <Gradient
-      className="gradient--spotlight"
-      style={
-        Object {
-          "height": "60px",
-          "position": "relative",
+    <div>
+      <Gradient
+        className="gradient--spotlight"
+        style={
+          Object {
+            "height": "60px",
+            "position": "relative",
+          }
         }
-      }
-    >
-      <HeaderContent>
-        <div />
-        <CloseButton
-          type="button"
-        >
-          <span
-            className="hamburger hamburger--closed c0"
+      >
+        <HeaderContent>
+          <div />
+          <CloseButton
+            type="button"
           >
             <span
-              className="c1"
-            />
-          </span>
-        </CloseButton>
-      </HeaderContent>
-    </Gradient>
-    <span>
-      Content
-    </span>
-    <span>
-      Content
-    </span>
-    <span>
-      Content
-    </span>
+              className="hamburger hamburger--closed c0"
+            >
+              <span
+                className="c1"
+              />
+            </span>
+          </CloseButton>
+        </HeaderContent>
+      </Gradient>
+      <span>
+        Content
+      </span>
+      <span>
+        Content
+      </span>
+      <span>
+        Content
+      </span>
+    </div>
   </DrawerContent>
 </DrawerContainer>
 `;
@@ -448,39 +454,41 @@ exports[`Drawer renders string header header 1`] = `
   className=""
 >
   <DrawerContent>
-    <Gradient
-      className="gradient--spotlight"
-      style={
-        Object {
-          "height": "60px",
-          "position": "relative",
+    <div>
+      <Gradient
+        className="gradient--spotlight"
+        style={
+          Object {
+            "height": "60px",
+            "position": "relative",
+          }
         }
-      }
-    >
-      <HeaderContent>
-        <div>
-          <div
-            className="text text--light text--primary c0"
-            disabled={false}
-            size="kilo"
-          >
-            Some Title
+      >
+        <HeaderContent>
+          <div>
+            <div
+              className="text text--light text--primary c0"
+              disabled={false}
+              size="kilo"
+            >
+              Some Title
+            </div>
           </div>
-        </div>
-        <CloseButton
-          type="button"
-        >
-          <span
-            className="hamburger hamburger--closed c1"
+          <CloseButton
+            type="button"
           >
             <span
-              className="c2"
-            />
-          </span>
-        </CloseButton>
-      </HeaderContent>
-    </Gradient>
-    Content
+              className="hamburger hamburger--closed c1"
+            >
+              <span
+                className="c2"
+              />
+            </span>
+          </CloseButton>
+        </HeaderContent>
+      </Gradient>
+      Content
+    </div>
   </DrawerContent>
 </DrawerContainer>
 `;

--- a/src/components/Drawer/index.js
+++ b/src/components/Drawer/index.js
@@ -101,15 +101,18 @@ export default class Drawer extends React.Component {
             )}
           >
             <DrawerContent>
-              {this.renderHeader({
-                toggleDrawer,
-                isOpen,
-                withSpotLight
-              })}
-              {this.renderChildren({
-                toggleDrawer,
-                isOpen
-              })}
+              {/* This wrapper created to fix content overlapping after keyboard forces the screen up on mobile devices */}
+              <div>
+                {this.renderHeader({
+                  toggleDrawer,
+                  isOpen,
+                  withSpotLight
+                })}
+                {this.renderChildren({
+                  toggleDrawer,
+                  isOpen
+                })}
+              </div>
             </DrawerContent>
           </DrawerContainer>
         )}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added wrapper over `DrawerContent` children to avoid overlapping `LocalePicker` with `Categories` list on mobile android. 
<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
