### PR TITLE
fix(CheckBox): Remove role=checkbox, aria-labelledby, and aria-checked

### DIFF
--- a/src/components/Input/CheckBox/CheckBox.js
+++ b/src/components/Input/CheckBox/CheckBox.js
@@ -59,13 +59,7 @@ const CheckBoxButton = ({
               <CheckDivStyling>
                 <StyledCheckmark size={size === "small" ? 16 : 24} />
               </CheckDivStyling>
-              <CheckBoxText
-                role="checkbox"
-                aria-labelledby={name + value}
-                aria-checked={isChecked}
-              >
-                {children}
-              </CheckBoxText>
+              <CheckBoxText>{children}</CheckBoxText>
             </CheckBoxWrapper>
           );
         }}

--- a/src/components/Input/__tests__/__snapshots__/CheckBoxGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/CheckBoxGroup.spec.js.snap
@@ -261,10 +261,7 @@ Object {
         </svg>
       </div>
       <span
-        aria-checked="true"
-        aria-labelledby="something1"
         class="c4"
-        role="checkbox"
       />
     </label>
   </div>,
@@ -563,10 +560,7 @@ Object {
         </svg>
       </div>
       <span
-        aria-checked="false"
-        aria-labelledby="something1"
         class="c4"
-        role="checkbox"
       />
     </label>
   </div>,
@@ -868,10 +862,7 @@ Object {
           </svg>
         </div>
         <span
-          aria-checked="false"
-          aria-labelledby="somethingelse"
           class="c4"
-          role="checkbox"
         />
       </label>
     </div>
@@ -1174,10 +1165,7 @@ Object {
           </svg>
         </div>
         <span
-          aria-checked="false"
-          aria-labelledby="somethingelse"
           class="c4"
-          role="checkbox"
         />
       </label>
     </div>
@@ -1480,10 +1468,7 @@ Object {
           </svg>
         </div>
         <span
-          aria-checked="false"
-          aria-labelledby="somethingelse"
           class="c4"
-          role="checkbox"
         />
       </label>
     </div>


### PR DESCRIPTION
WCAG 4.1.2 Severity 2 - Accessibility issue

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Remove role=”checkbox”, aria-labelledby, and aria-checked from Aurora's checkboxs' labels

**What**:

Checkbox label has incorrect ARIA of role=”checkbox”, aria-labelledby, and aria-checked. This text does not function as a checkbox – and the adjacent <input type=”checkbox”> is sufficient. These ARIA attributes must be removed. Severity 2 – WCAG 4.1.2 (Name, Role, Value)**

https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/F68.html


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
