### PR TITLE
fix(DropDown): Fix aria values

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -271,7 +271,7 @@ class DropDownGroup extends React.Component {
                             <DropDownProvider value={{ ...this.state, isOpen }}>
                               <StyledKeyboardProvider
                                 role="listbox"
-                                aria-labelledby={hiddenLabelId}
+                                ariaLabelledby={hiddenLabelId}
                                 {...keyboardProviderProps}
                                 navigateOptions={navigateOptions}
                               >

--- a/src/components/Input/DropDown/DropDownInput.js
+++ b/src/components/Input/DropDown/DropDownInput.js
@@ -88,6 +88,7 @@ class DropDownInput extends React.Component {
       <StyledDropDownItem
         role="option"
         tabIndex="-1"
+        aria-selected={isSelected ? "true" : "false"}
         value={value}
         index={index}
         ref={this.SelectedElement}

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -358,10 +358,12 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
       class="dropdown__items dropdown__items--large dropdown--clicked c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -371,6 +373,7 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -380,6 +383,7 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -752,10 +756,12 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
       class="dropdown__items dropdown__items--large dropdown--clicked c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -765,6 +771,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -774,6 +781,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -1146,10 +1154,12 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -1159,6 +1169,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -1168,6 +1179,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -1542,10 +1554,12 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
       class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="true"
           class="dropdown__selected c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -1555,6 +1569,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -1564,6 +1579,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -1936,10 +1952,12 @@ exports[`DropDownGroup Effect when move moves over dropdown option  when focused
       class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -1949,6 +1967,7 @@ exports[`DropDownGroup Effect when move moves over dropdown option  when focused
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -1958,6 +1977,7 @@ exports[`DropDownGroup Effect when move moves over dropdown option  when focused
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -2330,10 +2350,12 @@ exports[`DropDownGroup Effect when move moves over dropdown option when focused 
       class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -2343,6 +2365,7 @@ exports[`DropDownGroup Effect when move moves over dropdown option when focused 
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -2352,6 +2375,7 @@ exports[`DropDownGroup Effect when move moves over dropdown option when focused 
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -2724,10 +2748,12 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -2737,6 +2763,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -2746,6 +2773,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -3118,10 +3146,12 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -3131,6 +3161,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -3140,6 +3171,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -3512,10 +3544,12 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -3525,6 +3559,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -3534,6 +3569,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -3910,10 +3946,12 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="true"
           class="dropdown__selected c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -3923,6 +3961,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -3932,6 +3971,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -4306,10 +4346,12 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
       class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="true"
           class="dropdown__selected c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -4319,6 +4361,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -4328,6 +4371,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -4704,10 +4748,12 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__Select_An_Option"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -4717,6 +4763,7 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -4726,6 +4773,7 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -5100,10 +5148,12 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__Selected_Option:"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -5113,6 +5163,7 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -5122,6 +5173,7 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -5494,10 +5546,12 @@ exports[`DropDownGroup renders default dropdown 1`] = `
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -5507,6 +5561,7 @@ exports[`DropDownGroup renders default dropdown 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -5516,6 +5571,7 @@ exports[`DropDownGroup renders default dropdown 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -5888,10 +5944,12 @@ exports[`DropDownGroup renders default dropdown that should always open downward
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -5901,6 +5959,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -5910,6 +5969,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -6282,10 +6342,12 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
       class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -6295,6 +6357,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -6304,6 +6367,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -6676,10 +6740,12 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -6689,6 +6755,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -6698,6 +6765,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -7070,11 +7138,11 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
       class="dropdown__items dropdown__items--large c6"
     >
       <div
-        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -7084,6 +7152,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -7093,6 +7162,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -7465,10 +7535,12 @@ exports[`DropDownGroup renders small dropdown 1`] = `
       class="dropdown__items dropdown__items--small c6"
     >
       <div
+        aria-labelledby="hidden-label__"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
@@ -7478,6 +7550,7 @@ exports[`DropDownGroup renders small dropdown 1`] = `
           Option One
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
@@ -7487,6 +7560,7 @@ exports[`DropDownGroup renders small dropdown 1`] = `
           Second Option
         </span>
         <span
+          aria-selected="false"
           class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
@@ -7857,10 +7931,12 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__Sort_By:"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="true"
           class="dropdown__selected c8"
           role="option"
           tabindex="-1"
@@ -7869,6 +7945,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Date
         </span>
         <span
+          aria-selected="false"
           class="c8"
           role="option"
           tabindex="-1"
@@ -7878,6 +7955,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Closest
         </span>
         <span
+          aria-selected="false"
           class="c8"
           role="option"
           tabindex="-1"
@@ -8253,10 +8331,12 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__Sort_By:"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           role="option"
           tabindex="-1"
@@ -8265,6 +8345,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Date
         </span>
         <span
+          aria-selected="false"
           class="c8"
           role="option"
           tabindex="-1"
@@ -8274,6 +8355,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Closest
         </span>
         <span
+          aria-selected="true"
           class="dropdown__selected c8"
           role="option"
           tabindex="-1"
@@ -8647,10 +8729,12 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       class="dropdown__items dropdown__items--large c6"
     >
       <div
+        aria-labelledby="hidden-label__Sort_By:"
         class="c7"
         role="listbox"
       >
         <span
+          aria-selected="false"
           class="c8"
           role="option"
           tabindex="-1"
@@ -8659,6 +8743,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Date
         </span>
         <span
+          aria-selected="true"
           class="dropdown__selected c8"
           role="option"
           tabindex="-1"
@@ -8668,6 +8753,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Closest
         </span>
         <span
+          aria-selected="false"
           class="c8"
           role="option"
           tabindex="-1"
@@ -8735,6 +8821,7 @@ exports[`DropDownOption should render the correct markup when a className prop i
 }
 
 <span
+  aria-selected="false"
   className="dropdown__item--expandable c0"
   onClick={[Function]}
   onKeyDown={[Function]}

--- a/src/components/Input/__tests__/__snapshots__/DropDownInput.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownInput.spec.js.snap
@@ -51,6 +51,7 @@ exports[`<DropDownInput /> should render the correct markup 1`] = `
 }
 
 <span
+  aria-selected="false"
   className="c0"
   role="option"
   tabIndex="-1"
@@ -111,6 +112,7 @@ exports[`<DropDownInput /> should render the correct markup when additional prop
 }
 
 <span
+  aria-selected="false"
   className="c0"
   data-index={0}
   role="option"
@@ -172,6 +174,7 @@ exports[`<DropDownInput /> should render the correct markup when the className p
 }
 
 <span
+  aria-selected="false"
   className="input--drop-down c0"
   role="option"
   tabIndex="-1"
@@ -232,6 +235,7 @@ exports[`<DropDownInput /> should render the correct markup when the isSelected 
 }
 
 <span
+  aria-selected="true"
   className="dropdown__selected c0"
   role="option"
   tabIndex="-1"

--- a/src/components/KeyboardNavigation/Provider.js
+++ b/src/components/KeyboardNavigation/Provider.js
@@ -30,7 +30,8 @@ export default class KeyBoardProvider extends React.Component {
     className: PropTypes.string,
     keywordSearch: PropTypes.bool,
     keyBoardRef: PropTypes.func,
-    navigateOptions: PropTypes.bool
+    navigateOptions: PropTypes.bool,
+    ariaLabelledby: PropTypes.string,
   };
 
   static defaultProps = {
@@ -38,7 +39,8 @@ export default class KeyBoardProvider extends React.Component {
     keyBoardRef: null,
     className: null,
     keywordSearch: false,
-    navigateOptions: true
+    navigateOptions: true,
+    ariaLabelledby: null,
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -153,11 +155,12 @@ export default class KeyBoardProvider extends React.Component {
   /* eslint-enable */
 
   render() {
-    const { role, className, keyBoardRef, navigateOptions } = this.props;
+    const { role, className, keyBoardRef, ariaLabelledby, navigateOptions } = this.props;
     return (
       <Provider value={{ ...this.state, navigateOptions }}>
         {/* eslint-disable */}
         <div
+          aria-labelledby={ariaLabelledby}
           role={role}
           className={className}
           ref={keyBoardRef}


### PR DESCRIPTION

**What**:
Implement the proper ARIA listbox markup and interaction pattern (https://www.w3.org/TR/wai-aria-practices-1.1/#Listbox). Severity 2 – WCAG 4.1.2

- If the listbox is not part of another widget, then it has a visible label referenced by aria-labelledby on the element with role listbox.
- In a single-select listbox, the selected option has aria-selected set to true.

**Why**:

- Add aria-labelledby to KeyProvider component
- Add aria-selected to DropDown options

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
