### PR TITLE
feat(DropDownGroup): add custom icon and hide chevron prop

### DIFF
--- a/catalog/pages/inputs/index.js
+++ b/catalog/pages/inputs/index.js
@@ -24,6 +24,7 @@ import Column from "../../../src/components/Grid/Column";
 import Container from "../../../src/components/Grid/Container";
 import Row from "../../../src/components/Grid/Row";
 import Spacing from "../../../src/components/Spacing";
+import { CalendarIcon } from "../../../src/components/Icons";
 
 export default {
   path: "/inputs",
@@ -50,7 +51,8 @@ export default {
     ButtonGroup,
     QtySelector,
     SearchInput,
-    SearchInputMobile
+    SearchInputMobile,
+    CalendarIcon
   },
   content: pageLoader(() => import("./index.md"))
 };

--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -498,6 +498,14 @@ rows:
     Type: function
     Default: "null"
     Notes: Invoked with the synthetic event object when the DropDownOption is clicked
+  - Prop: chevronVisible
+    Type: bool
+    Default: true
+    Notes: Indicates whether show or hide right chevron icon
+  - Prop: icon
+    Type: node
+    Default: null
+    Notes: Inserts an icon before label text
   - Prop: ...props
     Type: any
     Default:
@@ -510,7 +518,7 @@ span: 6
 <ThemeProvider theme={{ themeName: 'tm' }}>
     <Container>
         <Row>
-            <Column medium={4}>
+            <Column medium={3}>
                 <DropDownGroup
                   size="small"
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL}
@@ -528,7 +536,7 @@ span: 6
                     <DropDownOption value="8" index={8}>Option Four</DropDownOption>
                 </DropDownGroup>
             </Column>
-            <Column medium={4}>
+            <Column medium={3}>
                 <DropDownGroup
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL}
                   value={["3"]}
@@ -558,7 +566,7 @@ span: 6
                     <DropDownOption value="20" index={20}>Option Five</DropDownOption>
                 </DropDownGroup>
             </Column>
-            <Column medium={4}>
+            <Column medium={3}>
                 <DropDownGroup
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL}
                   placeholder="Select an option"
@@ -571,10 +579,23 @@ span: 6
                     <DropDownOption value="4" index={4}>Option Five</DropDownOption>
                 </DropDownGroup>
             </Column>
+            <Column medium={3}>
+                <DropDownGroup
+                  variant={DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL}
+                  placeholder="Chevron hidden"
+                  chevronVisible={false}
+                >
+                    <DropDownOption value="0" index={0}>Option One One One One</DropDownOption>
+                    <DropDownOption value="1" index={1}>Option Two</DropDownOption>
+                    <DropDownOption value="2" index={2}>Option Three</DropDownOption>
+                    <DropDownOption value="3" index={3}>Option Four</DropDownOption>
+                    <DropDownOption value="4" index={4}>Option Five</DropDownOption>
+                </DropDownGroup>
+            </Column>
         </Row>
         <Spacing top={{small: "normal"}} />
         <Row >
-            <Column medium={4}>
+            <Column medium={3}>
                 <DropDownGroup
                   size="small"
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL}
@@ -587,7 +608,7 @@ span: 6
                     <DropDownOption value="4" index={4}>Option Five</DropDownOption>
                 </DropDownGroup>
             </Column>
-            <Column medium={4}>
+            <Column medium={3}>
                 <DropDownGroup
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL}
                   label="Sort By:"
@@ -600,7 +621,7 @@ span: 6
                     <DropDownOption value="4" index={4}>Option Five</DropDownOption>
                 </DropDownGroup>
             </Column>
-            <Column medium={4}>
+            <Column medium={3}>
                 <DropDownGroup
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL}
                   label="Sort By:"
@@ -612,6 +633,18 @@ span: 6
                     <DropDownOption value="2" index={2}>Option Three</DropDownOption>
                     <DropDownOption value="3" index={3}>Option Four</DropDownOption>
                     <DropDownOption value="4" index={4}>Option Five</DropDownOption>
+                </DropDownGroup>
+            </Column>
+            <Column medium={3}>
+                <DropDownGroup
+                  variant={DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL}
+                  value={["all"]}
+                  placeholder="date range"
+                  icon={<CalendarIcon />}
+                >
+                    <DropDownOption value="all" index={0}>All dates</DropDownOption>
+                    <DropDownOption value="this-weekend" index={1}>This weekends</DropDownOption>
+                    <DropDownOption value="custom" index={2}>Date range</DropDownOption>
                 </DropDownGroup>
             </Column>
         </Row>

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -176,6 +176,8 @@ class DropDownGroup extends React.Component {
       disabled,
       size,
       shouldOpenDownward,
+      icon,
+      chevronVisible,
       fullWidth,
       ...props
     } = this.props;
@@ -216,7 +218,7 @@ class DropDownGroup extends React.Component {
                       className={classNames(props.className, {
                         "dropdown--open-upward": hasOpenUpwardClass,
                         "dropdown--disabled": disabled,
-                        "full-width": fullWidth
+                        "full-width": fullWidth,
                       })}
                       tabIndex={disabled ? -1 : 0}
                       aria-haspopup="listbox"
@@ -226,7 +228,7 @@ class DropDownGroup extends React.Component {
                     >
                       <StyledGroup
                         {...onClickListener}
-                        className={classNames(`dropdown--${size}`, {
+                        className={classNames(`dropdown__label dropdown--${size}`, {
                           "dropdown--active": isOpen,
                           "dropdown--border": isBorderAround,
                           "dropdown--no-border": !isBorderAround,
@@ -244,16 +246,18 @@ class DropDownGroup extends React.Component {
                             "dropdown__text--disabled": disabled
                           })}
                         >
-                          {this.displayLabel(selected)}
+                          {icon}{this.displayLabel(selected)}
                         </StyledSelectedText>
 
-                        <StyledChevron
-                          className={classNames({
-                            "dropdown__icon--hide": isOpen,
-                            "dropdown--no-border": !isBorderAround,
-                            "dropdown__chevron--disabled": disabled
-                          })}
-                        />
+                        {chevronVisible && (
+                          <StyledChevron
+                            className={classNames({
+                              "dropdown__icon--hide": isOpen,
+                              "dropdown--no-border": !isBorderAround,
+                              "dropdown__chevron--disabled": disabled
+                            })}
+                          />
+                        )}
                       </StyledGroup>
                       <Transition in={isOpen} timeout={this.ANIMATION_TIMEOUT}>
                         {wrapperState => (
@@ -306,8 +310,10 @@ DropDownGroup.propTypes = {
   withKeyboardProvider: PropTypes.bool,
   disabled: PropTypes.bool,
   size: PropTypes.oneOf(TWO_SIZE_VARIANT),
+  fullWidth: PropTypes.bool,
   shouldOpenDownward: PropTypes.bool,
-  fullWidth: PropTypes.bool
+  icon: PropTypes.node,
+  chevronVisible: PropTypes.bool
 };
 
 DropDownGroup.defaultProps = {
@@ -323,7 +329,9 @@ DropDownGroup.defaultProps = {
   disabled: false,
   size: TWO_SIZE_VARIANT[1],
   shouldOpenDownward: true,
-  fullWidth: false
+  icon: null,
+  chevronVisible: true,
+  fullWidth: false,
 };
 
 export default DropDownGroup;

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -10,6 +10,7 @@ import { LAYOUT_VARIANTS } from "../DropDown/constants";
 
 import DropDownGroup from "../DropDown/DropDownGroup";
 import DropDownOption from "../DropDown/DropDownOption";
+import CalendarIcon from "../../Icons/Calendar";
 
 describe("DropDownGroup", () => {
   function renderTestComponentOne(props = {}) {
@@ -424,6 +425,25 @@ describe("DropDownGroup", () => {
   it("should render the correct label when label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption", () => {
     const { container } = renderTestComponentTwo({ value: ["price"] });
     expect(container).toMatchSnapshot();
+  });
+
+  it("should render the label with icon", () => {
+    const { queryByTestId } = renderTestComponentTwo({
+      value: ["price"],
+      icon: <CalendarIcon data-testid="testid" />
+    });
+
+    expect(queryByTestId("testid")).toBeTruthy();
+  });
+
+  it("should hide right chevron icon icon", () => {
+    const { container } = renderTestComponentTwo({
+      value: ["price"],
+      chevronVisible: false
+    });
+    const chevron = container.querySelector("svg");
+
+    expect(chevron).toBe(null);
   });
 });
 

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -322,7 +322,7 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--active dropdown--border c1"
     >
       <span
         class="c2"
@@ -720,7 +720,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--active dropdown--border c1"
     >
       <span
         class="c2"
@@ -1118,7 +1118,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -1516,7 +1516,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--active dropdown--border c1"
     >
       <span
         class="c2"
@@ -1916,7 +1916,7 @@ exports[`DropDownGroup Effect when move moves over dropdown option  when focused
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--active dropdown--border c1"
     >
       <span
         class="c2"
@@ -2314,7 +2314,7 @@ exports[`DropDownGroup Effect when move moves over dropdown option when focused 
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--active dropdown--border c1"
     >
       <span
         class="c2"
@@ -2712,7 +2712,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -3110,7 +3110,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
     tabindex="-1"
   >
     <label
-      class="dropdown--large dropdown--border dropdown__label--disabled c1"
+      class="dropdown__label dropdown--large dropdown--border dropdown__label--disabled c1"
     >
       <span
         class="c2"
@@ -3508,7 +3508,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -3908,7 +3908,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -4308,7 +4308,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--active dropdown--border c1"
     >
       <span
         class="c2"
@@ -4708,7 +4708,7 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -5110,7 +5110,7 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--no-border c1"
+      class="dropdown__label dropdown--large dropdown--no-border c1"
     >
       <span
         class="c2"
@@ -5510,7 +5510,7 @@ exports[`DropDownGroup renders default dropdown 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -5908,7 +5908,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -6306,7 +6306,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--active dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--active dropdown--border c1"
     >
       <span
         class="c2"
@@ -6704,7 +6704,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -7102,7 +7102,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--border c1"
+      class="dropdown__label dropdown--large dropdown--border c1"
     >
       <span
         class="c2"
@@ -7499,7 +7499,7 @@ exports[`DropDownGroup renders small dropdown 1`] = `
     tabindex="0"
   >
     <label
-      class="dropdown--small dropdown--border c1"
+      class="dropdown__label dropdown--small dropdown--border c1"
     >
       <span
         class="c2"
@@ -7889,7 +7889,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--no-border c1"
+      class="dropdown__label dropdown--large dropdown--no-border c1"
     >
       <span
         class="c2"
@@ -8286,7 +8286,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--no-border c1"
+      class="dropdown__label dropdown--large dropdown--no-border c1"
     >
       <span
         class="c2"
@@ -8686,7 +8686,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
     tabindex="0"
   >
     <label
-      class="dropdown--large dropdown--no-border c1"
+      class="dropdown__label dropdown--large dropdown--no-border c1"
     >
       <span
         class="c2"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added ability to pass icon into dropdown label.
Added new prop `chevronVisible` to show or hide chevron.
<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
