### PR TITLE
feat(DropDown): update dropdown button and menu to be independent of each other

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -469,6 +469,10 @@ rows:
     Type: small or large
     Default: "large"
     Notes: Defines size
+  - Prop: fullWidth
+    Type: boolean
+    Default: 'false'
+    Notes: Defines if width is 100% of container
 ```
 
 ## Drop Down Option
@@ -587,6 +591,7 @@ span: 6
                 <DropDownGroup
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL}
                   label="Sort By:"
+                  placeholder="Select an option"
                 >
                     <DropDownOption value="0" index={0}>Option One</DropDownOption>
                     <DropDownOption value="1" index={1}>Option Two</DropDownOption>
@@ -599,6 +604,7 @@ span: 6
                 <DropDownGroup
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL}
                   label="Sort By:"
+                  placeholder="Select an option"
                   disabled
                 >
                     <DropDownOption value="0" index={0}>Option One</DropDownOption>
@@ -655,9 +661,11 @@ span: 6
                 </DropDownGroup>
             </Column>
             <Column medium={4}>
-                <DropDownLabel>Label text</DropDownLabel>
+                <DropDownLabel>Full Width Drop Down</DropDownLabel>
                 <DropDownGroup
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL}
+                  placeholder="Select an option"
+                  fullWidth
                 >
                     <DropDownOption value="0" index={0}>Option One</DropDownOption>
                     <DropDownOption value="1" index={1}>Option Two</DropDownOption>
@@ -671,6 +679,7 @@ span: 6
                 <DropDownGroup
                   value={["0"]}
                   variant={DropDownGroup.LAYOUT_VARIANTS.BORDERED_INNER_LABEL}
+                  placeholder="Select an option"
                   disabled
                 >
                     <DropDownOption value="0" index={0}>Option One</DropDownOption>

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -74,7 +74,11 @@ class DropDownGroup extends React.Component {
       case ARROWUP:
       case ARROWDOWN:
         e.preventDefault();
-        this.openDropdown();
+        if (this.state.isOpen) {
+          this.enableNavigation();
+        } else {
+          this.openDropdown();
+        }
         break;
       case SPACEBAR:
         e.preventDefault();
@@ -97,6 +101,12 @@ class DropDownGroup extends React.Component {
 
   openDropdown = () => this.setState({ isOpen: true });
 
+  enableNavigation = () => {
+    if (!this.state.navigateOptions) {
+      this.setState({ navigateOptions: true });
+    }
+  };
+
   toggleDropdown = () => {
     if (this.state.isOpen) {
       this.closeDropdown();
@@ -118,6 +128,10 @@ class DropDownGroup extends React.Component {
 
   displayLabel = selected => {
     const { placeholder, label } = this.props;
+
+    if (selected.length > 0) {
+      this.enableNavigation();
+    }
 
     if (placeholder.length > 0 && selected.length === 0) {
       return placeholder;
@@ -142,7 +156,8 @@ class DropDownGroup extends React.Component {
   state = {
     isOpen: false,
     isOpenPrevProp: false,
-    onClose: this.onClick
+    onClose: this.onClick,
+    navigateOptions: false
   };
   /* eslint-enable */
 
@@ -164,7 +179,7 @@ class DropDownGroup extends React.Component {
       fullWidth,
       ...props
     } = this.props;
-    const { isOpen: isOpenState } = this.state;
+    const { isOpen: isOpenState, navigateOptions } = this.state;
     const isOpen = isOpenProp || isOpenState;
     const hiddenLabelId = `hidden-label__${(placeholder || label).replace(
       / /g,
@@ -258,6 +273,7 @@ class DropDownGroup extends React.Component {
                                 role="listbox"
                                 aria-labelledby={hiddenLabelId}
                                 {...keyboardProviderProps}
+                                navigateOptions={navigateOptions}
                               >
                                 {children}
                               </StyledKeyboardProvider>

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -14,10 +14,7 @@ import {
   ESCAPE,
   TAB
 } from "../../../utils/keyCharCodes";
-import {
-  VARIANTS_WITH_BORDER,
-  LAYOUT_VARIANTS
-} from "./constants";
+import { VARIANTS_WITH_BORDER, LAYOUT_VARIANTS } from "./constants";
 import {
   StyledGroup,
   StyledChildWrapper,
@@ -164,6 +161,7 @@ class DropDownGroup extends React.Component {
       disabled,
       size,
       shouldOpenDownward,
+      fullWidth,
       ...props
     } = this.props;
     const { isOpen: isOpenState } = this.state;
@@ -202,7 +200,8 @@ class DropDownGroup extends React.Component {
                       {...props}
                       className={classNames(props.className, {
                         "dropdown--open-upward": hasOpenUpwardClass,
-                        "dropdown--disabled": disabled
+                        "dropdown--disabled": disabled,
+                        "full-width": fullWidth
                       })}
                       tabIndex={disabled ? -1 : 0}
                       aria-haspopup="listbox"
@@ -216,7 +215,8 @@ class DropDownGroup extends React.Component {
                           "dropdown--active": isOpen,
                           "dropdown--border": isBorderAround,
                           "dropdown--no-border": !isBorderAround,
-                          "dropdown__label--disabled": disabled
+                          "dropdown__label--disabled": disabled,
+                          "full-width": fullWidth
                         })}
                       >
                         {/* HiddenLabel is required for correct screen readers 
@@ -240,10 +240,7 @@ class DropDownGroup extends React.Component {
                           })}
                         />
                       </StyledGroup>
-                      <Transition
-                        in={isOpen}
-                        timeout={this.ANIMATION_TIMEOUT}
-                      >
+                      <Transition in={isOpen} timeout={this.ANIMATION_TIMEOUT}>
                         {wrapperState => (
                           <StyledChildWrapper
                             className={classNames(
@@ -251,15 +248,12 @@ class DropDownGroup extends React.Component {
                               `dropdown__items--${size}`,
                               {
                                 "dropdown--clicked": isOpen,
-                                "dropdown--overflow":
-                                  wrapperState === "entered"
+                                "dropdown--overflow": wrapperState === "entered"
                               }
                             )}
                             ref={this.styledChildWrapper}
                           >
-                            <DropDownProvider
-                              value={{ ...this.state, isOpen }}
-                            >
+                            <DropDownProvider value={{ ...this.state, isOpen }}>
                               <StyledKeyboardProvider
                                 role="listbox"
                                 aria-labelledby={hiddenLabelId}
@@ -296,7 +290,8 @@ DropDownGroup.propTypes = {
   withKeyboardProvider: PropTypes.bool,
   disabled: PropTypes.bool,
   size: PropTypes.oneOf(TWO_SIZE_VARIANT),
-  shouldOpenDownward: PropTypes.bool
+  shouldOpenDownward: PropTypes.bool,
+  fullWidth: PropTypes.bool
 };
 
 DropDownGroup.defaultProps = {
@@ -311,7 +306,8 @@ DropDownGroup.defaultProps = {
   label: "",
   disabled: false,
   size: TWO_SIZE_VARIANT[1],
-  shouldOpenDownward: true
+  shouldOpenDownward: true,
+  fullWidth: false
 };
 
 export default DropDownGroup;

--- a/src/components/Input/DropDown/DropDownGroup.styles.js
+++ b/src/components/Input/DropDown/DropDownGroup.styles.js
@@ -10,14 +10,13 @@ const { small } = constants.borderRadius;
 const DROP_DOWN_SHADOW = "0 2px 4px 0 rgba(0, 0, 0, 0.12)";
 
 export const StyledGroup = styled.label`
-  width: 100%;
   height: 44px;
   background-color: ${getThemeValue("white", "base")};
   border-radius: ${small};
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: space-between;
   cursor: pointer;
@@ -30,8 +29,13 @@ export const StyledGroup = styled.label`
     height: 36px;
   }
 
+  &.full-width {
+    width: 100%;
+  }
+
   &.dropdown--border {
     border: solid 1px ${getThemeValue("gray02")};
+    padding: 1px;
     text-align: left;
   }
 
@@ -43,8 +47,9 @@ export const StyledGroup = styled.label`
 
   &.dropdown--active {
     margin: 0;
+    padding: 1px;
     border: solid 1px ${getThemeValue("gray02")};
-    border-radius: ${small} ${small} 0 0;
+    border-radius: ${small};
     /* for the purpose of the correct box-shadow */
     z-index: ${zIndex.layout.overlay + 1};
     transition: border-color 0.3s ${constants.easing.easeInOutQuad},
@@ -55,15 +60,20 @@ export const StyledGroup = styled.label`
     cursor: default;
     color: ${getThemeValue("onyx", "muted")};
     transition: none;
+
+    .dropdown__chevron--disabled {
+      opacity: 0.4;
+    }
   }
 
   .dropdown--open-upward & {
-    border-radius: 0 0 ${small} ${small};
+    border-radius: ${small};
     box-shadow: ${DROP_DOWN_SHADOW};
   }
 
   &:hover:not(.dropdown__label--disabled) {
     border: solid 2px ${getThemeValue("primary", "base")};
+    padding: 0;
   }
 `;
 
@@ -71,16 +81,15 @@ export const StyledChildWrapper = styled.div`
   position: absolute;
   display: flex;
   background-color: ${getThemeValue("white", "base")};
-  border-radius: 0 0 ${small} ${small};
+  border-radius: ${small};
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: ${small};
   box-shadow: ${DROP_DOWN_SHADOW};
-  min-width: 100%;
   box-sizing: border-box;
 
   flex-direction: column;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: ${zIndex.layout.overlay};
   border-color: ${getThemeValue("gray02")};
@@ -91,6 +100,10 @@ export const StyledChildWrapper = styled.div`
   transition: max-height 0.3s ${constants.easing.easeInOutQuad},
     border-width 0s ease 0.3s, padding-top 0s ease 0.3s,
     padding-bottom 0s ease 0.3s;
+
+  &:focus {
+    box-shadow: 0 0 5px 0 ${getThemeValue("primary", "base")};
+  }
 
   &.dropdown--clicked {
     padding-top: 4px;
@@ -107,8 +120,8 @@ export const StyledChildWrapper = styled.div`
   }
 
   .dropdown--open-upward & {
-    bottom: 43px;
-    border-radius: ${small} ${small} 0 0;
+    bottom: 46px;
+    border-radius: ${small};
     box-shadow: ${DROP_DOWN_SHADOW};
 
     &.dropdown__items--small {
@@ -123,13 +136,17 @@ export const HiddenLabel = styled.span`
 
 export const StyledGroupWrapper = styled.div`
   position: relative;
+  display: inline-block;
   color: ${getThemeValue("gray01")};
-  width: 100%;
   outline: none;
   border-radius: ${small};
-
   &:focus {
     box-shadow: 0 0 5px 0 ${getThemeValue("primary", "base")};
+  }
+
+  &.full-width {
+    width: 100%;
+    display: block;
   }
 `;
 
@@ -138,21 +155,22 @@ export const StyledChevron = styled(DownIcon).attrs({
 })`
   color: ${getThemeValue("gray02")};
   transition: opacity 0.1s ${constants.easing.easeInOutQuad};
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 
   .dropdown--small & {
-    margin-right: 12px;
+    margin-right: 14px;
   }
 
   .dropdown--border:hover & {
     &:not(.dropdown__chevron--disabled) {
-      margin-right: 15px;
+      margin-right: 14px;
     }
   }
 
   .dropdown--small.dropdown--border:hover & {
     &:not(.dropdown__chevron--disabled) {
-      margin-right: 11px;
+      margin-right: 12px;
     }
   }
 
@@ -162,22 +180,31 @@ export const StyledChevron = styled(DownIcon).attrs({
 `;
 
 export const StyledSelectedText = styled.div`
-  font-size: ${typography.size.kilo};
+  font-size: ${typography.size.hecto};
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 
   .dropdown--small & {
     font-size: ${typography.size.hecto};
+    margin: 0 12px;
+  }
+
+  .dropdown--large & {
+    font-size: ${typography.size.kilo};
   }
 
   .dropdown--no-border & {
-    margin-right: 10px;
+    margin-right: 14px;
+    &.dropdown--small & {
+      margin-left: 12px;
+    }
   }
 
   .dropdown--large.dropdown--border & {
-    margin-left: 16px;
+    margin-left: 14px;
   }
 
   .dropdown--small.dropdown--border & {
@@ -185,24 +212,27 @@ export const StyledSelectedText = styled.div`
   }
 
   .dropdown--active.dropdown--no-border & {
-    margin-right: 11px;
+    margin-right: 14px;
+    &.dropdown--small & {
+      margin-left: 12px;
+    }
   }
 
   .dropdown--active.dropdown--no-border:hover & {
     &:not(.dropdown__text--disabled) {
-      margin-right: 10px;
+      margin-right: 14px;
     }
   }
 
   .dropdown--small.dropdown--border:hover & {
     &:not(.dropdown__text--disabled) {
-      margin-left: 11px;
+      margin-left: 12px;
     }
   }
 
   .dropdown--large.dropdown--border:hover & {
     &:not(.dropdown__text--disabled) {
-      margin-left: 15px;
+      margin-left: 14px;
     }
   }
 `;

--- a/src/components/Input/DropDown/DropDownInput.js
+++ b/src/components/Input/DropDown/DropDownInput.js
@@ -13,8 +13,8 @@ const StyledDropDownItem = styled.span`
     appearance: none;
     height: 36px;
     margin: 4px 8px 0 8px;
-    padding: 7px 12px;
-    font-size: ${typography.size.kilo};
+    padding: 7px 10px;
+    font-size: ${typography.size.hecto};
     text-align: left;
     border: none;
     background-color: ${getThemeValue("white", "base")};
@@ -28,6 +28,7 @@ const StyledDropDownItem = styled.span`
       background-color: ${getThemeValue("primary", "base")};
       color: ${getThemeValue("white", "base")};
       outline: none;
+      border-radius: ${constants.borderRadius.small};
     }
     &.dropdown__selected {
       color: ${getThemeValue("gray01")};
@@ -39,6 +40,9 @@ const StyledDropDownItem = styled.span`
     height: 32px;
     font-size: ${typography.size.hecto};
     line-height: 1.3;
+  }
+  .dropdown__items.dropdown__items--large & {
+    font-size: ${typography.size.kilo};
   }
 `;
 

--- a/src/components/Input/DropDown/DropDownLabel.js
+++ b/src/components/Input/DropDown/DropDownLabel.js
@@ -6,11 +6,12 @@ import { typography } from "../../../theme";
 import { TWO_SIZE_VARIANT } from "../../../utils/sizes";
 
 const fontForSizeMap = {
-  [TWO_SIZE_VARIANT[0]]: typography.size.hecto,
-  [TWO_SIZE_VARIANT[1]]: typography.size.kilo
+  [TWO_SIZE_VARIANT[0]]: typography.size.uno,
+  [TWO_SIZE_VARIANT[1]]: typography.size.hecto
 };
 
 const StyledLabel = styled.label`
+  display: block;
   font-size: ${({ size }) => fontForSizeMap[size]};
   opacity: ${({ disabled }) => (disabled ? "0.4" : "1")};
 `;

--- a/src/components/Input/DropDown/DropDownOption.js
+++ b/src/components/Input/DropDown/DropDownOption.js
@@ -22,7 +22,7 @@ class DropDownOption extends React.PureComponent {
 
     return (
       <KeyBoardConsumer>
-        {({ focused, focusSelected }) => (
+        {({ focused, focusSelected, navigateOptions }) => (
           <SelectionConsumer>
             {({ selected, onClick }) => {
               const isChecked = selected.includes(value);
@@ -38,9 +38,8 @@ class DropDownOption extends React.PureComponent {
                       index={index}
                       selected={selected}
                       isSelected={isChecked}
-                      isFocused={focused === index}
+                      isFocused={focused === index && navigateOptions}
                       onMouseMove={() => {
-                        if (index === focused) return;
                         focusSelected({ index });
                         this.focusInput();
                       }}

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -6,7 +6,7 @@ import {
   fireEvent,
   Simulate
 } from "react-testing-library";
-import {LAYOUT_VARIANTS} from '../DropDown/constants';
+import { LAYOUT_VARIANTS } from "../DropDown/constants";
 
 import DropDownGroup from "../DropDown/DropDownGroup";
 import DropDownOption from "../DropDown/DropDownOption";
@@ -45,7 +45,11 @@ describe("DropDownGroup", () => {
 
   function renderTestComponentTwo(props = {}) {
     return renderIntoDocument(
-      <DropDownGroup {...props} variant={LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL} label="Sort By:">
+      <DropDownGroup
+        {...props}
+        variant={LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL}
+        label="Sort By:"
+      >
         <DropDownOption value="date" index={0}>
           {"Date"}
           {null}
@@ -84,9 +88,8 @@ describe("DropDownGroup", () => {
     expect(
       renderTestComponentOne({
         placeholder: "Select An Option",
-        variant: LAYOUT_VARIANTS.BORDERED_INNER_LABEL,
-      })
-        .container.firstChild
+        variant: LAYOUT_VARIANTS.BORDERED_INNER_LABEL
+      }).container.firstChild
     ).toMatchSnapshot();
   });
 
@@ -94,9 +97,8 @@ describe("DropDownGroup", () => {
     expect(
       renderTestComponentOne({
         label: "Selected Option:",
-        variant: LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL,
-      })
-        .container.firstChild
+        variant: LAYOUT_VARIANTS.BORDERLESS_INNER_LABEL
+      }).container.firstChild
     ).toMatchSnapshot();
   });
 
@@ -178,6 +180,22 @@ describe("DropDownGroup", () => {
 
     fireEvent.click(getByTestId("test-dropDownOptionOne"));
     fireEvent.click(getByTestId("test-outSideComponent"));
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("Effect when move moves over dropdown option when focused is same as index", () => {
+    const { container, getByTestId } = renderTestComponentOne({ isOpen: true });
+
+    fireEvent.mouseMove(getByTestId("test-dropDownOptionOne"));
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("Effect when move moves over dropdown option  when focused is not same as index", () => {
+    const { container, getByTestId } = renderTestComponentOne({ isOpen: true });
+
+    fireEvent.mouseMove(getByTestId("test-dropDownOptionTwo"));
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -2,17 +2,16 @@
 
 exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -31,8 +30,13 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -47,8 +51,9 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -61,27 +66,31 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -89,7 +98,7 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -100,7 +109,11 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -109,17 +122,17 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -129,8 +142,8 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -139,70 +152,90 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -218,25 +251,25 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -250,22 +283,27 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -291,10 +329,10 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="dropdown__icon--hide c4"
+        class="dropdown__icon--hide c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -317,14 +355,14 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked c5"
+      class="dropdown__items dropdown__items--large dropdown--clicked c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -333,7 +371,7 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -342,7 +380,7 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -358,17 +396,16 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
 
 exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -387,8 +424,13 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -403,8 +445,9 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -417,27 +460,31 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -445,7 +492,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -456,7 +503,11 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -465,17 +516,17 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -485,8 +536,8 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -495,70 +546,90 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -574,25 +645,25 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -606,22 +677,27 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -647,10 +723,10 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="dropdown__icon--hide c4"
+        class="dropdown__icon--hide c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -673,14 +749,14 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked c5"
+      class="dropdown__items dropdown__items--large dropdown--clicked c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -689,7 +765,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -698,7 +774,7 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -714,17 +790,16 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
 
 exports[`DropDownGroup Click outside should close the dropdown 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -743,8 +818,13 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -759,8 +839,9 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -773,27 +854,31 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -801,7 +886,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -812,7 +897,11 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -821,17 +910,17 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -841,8 +930,8 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -851,70 +940,90 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -930,25 +1039,25 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -962,22 +1071,27 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -1003,10 +1117,10 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -1029,14 +1143,14 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -1045,7 +1159,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -1054,7 +1168,7 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -1070,17 +1184,16 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
 
 exports[`DropDownGroup Click outside should not close the dropdown when the isOpen prop equals true 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1099,8 +1212,13 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -1115,8 +1233,9 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -1129,27 +1248,31 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1157,7 +1280,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -1168,7 +1291,11 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -1177,17 +1304,17 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -1197,8 +1324,8 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -1207,70 +1334,90 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -1286,25 +1433,25 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -1318,22 +1465,27 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -1359,12 +1511,12 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       >
         Option One
       </div>
       <svg
-        class="dropdown__icon--hide c4"
+        class="dropdown__icon--hide c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -1387,14 +1539,14 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c5"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="dropdown__selected c7"
+          class="dropdown__selected c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -1403,7 +1555,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -1412,7 +1564,7 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -1426,19 +1578,18 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
 </div>
 `;
 
-exports[`DropDownGroup Escape key should close the drop down 1`] = `
+exports[`DropDownGroup Effect when move moves over dropdown option  when focused is not same as index 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1457,8 +1608,13 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -1473,8 +1629,9 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -1487,27 +1644,31 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1515,7 +1676,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -1526,7 +1687,11 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -1535,17 +1700,17 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -1555,8 +1720,8 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -1565,70 +1730,90 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -1644,25 +1829,25 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -1676,22 +1861,815 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
+}
+
+<div
+  data-testid="test-outSideComponent"
+>
+  <div
+    data-testid="something"
+  >
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__"
+    class="c0"
+    data-testid="test-dropContainer"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--active dropdown--border c1"
+    >
+      <span
+        class="c2"
+        id="hidden-label__"
+      />
+      <div
+        class="c3 c4"
+      />
+      <svg
+        class="dropdown__icon--hide c5"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            d="M16 0H0v16h16z"
+          />
+          <path
+            d="M3.278 5.459A.75.75 0 0 0 2.221 6.52l5.263 5.24a.75.75 0 0 0 1.059 0L13.78 6.52a.75.75 0 0 0-1.06-1.06l-4.71 4.711L3.278 5.46z"
+            fill="#262626"
+            fill-opacity=".65"
+            fill-rule="nonzero"
+          />
+        </g>
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
+    >
+      <div
+        class="c7"
+        role="listbox"
+      >
+        <span
+          class="c8"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
+        >
+          Option One
+        </span>
+        <span
+          class="c8"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="c8"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup Effect when move moves over dropdown option when focused is same as index 1`] = `
+.c1 {
+  height: 44px;
+  background-color: rgba(255,255,255,1);
+  border-radius: 2px;
+  position: relative;
+  padding: 0px;
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+  -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease 0.3s;
+  transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease 0.3s;
+  z-index: 0;
+}
+
+.c1.dropdown--small {
+  height: 36px;
+}
+
+.c1.full-width {
+  width: 100%;
+}
+
+.c1.dropdown--border {
+  border: solid 1px #999999;
+  padding: 1px;
+  text-align: left;
+}
+
+.c1.dropdown--no-border {
+  border: solid 2px rgba(255,255,255,1);
+  text-align: right;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.dropdown--active {
+  margin: 0;
+  padding: 1px;
+  border: solid 1px #999999;
+  border-radius: 2px;
+  z-index: 10;
+  -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
+  transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
+}
+
+.dropdown--disabled .c1 {
+  cursor: default;
+  color: rgba(38,38,38,0.4);
+  -webkit-transition: none;
+  transition: none;
+}
+
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
+.dropdown--open-upward .c1 {
+  border-radius: 2px;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
+}
+
+.c1:hover:not(.dropdown__label--disabled) {
+  border: solid 2px #026cdf;
+  padding: 0;
+}
+
+.c6 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background-color: rgba(255,255,255,1);
+  border-radius: 2px;
+  white-space: nowrap;
+  margin-top: 2px;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
+  box-sizing: border-box;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  width: auto;
+  overflow: hidden;
+  z-index: 9;
+  border-color: #999999;
+  border-style: solid;
+  border-width: 0;
+  max-height: 0;
+  -webkit-transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
+  transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
+}
+
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
+  padding-top: 4px;
+  padding-bottom: 8px;
+  border-width: 1px;
+  max-height: 606px;
+  -webkit-transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
+  transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
+}
+
+.c6.dropdown--overflow {
+  overflow-y: auto;
+}
+
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
+}
+
+.dropdown--open-upward .c6.dropdown__items--small {
+  bottom: 35px;
+}
+
+.c2 {
+  display: none;
+}
+
+.c0 {
+  position: relative;
+  display: inline-block;
+  color: #262626;
+  outline: none;
+  border-radius: 2px;
+}
+
+.c0:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
+  color: #999999;
+  -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
+  margin-right: 14px;
+  min-width: 16px;
+}
+
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 12px;
+}
+
+.c5.dropdown__icon--hide {
+  opacity: 0;
+}
+
+.c4 {
+  font-size: 14px;
+  white-space: nowrap;
+  width: 85%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0 14px;
+}
+
+.dropdown--small .c4 {
+  font-size: 14px;
+  margin: 0 12px;
+}
+
+.dropdown--large .c4 {
+  font-size: 16px;
+}
+
+.dropdown--no-border .c4 {
+  margin-right: 14px;
+}
+
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
+}
+
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
+}
+
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
+}
+
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
+}
+
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
+  min-height: -webkit-min-content;
+  min-height: -moz-min-content;
+  min-height: min-content;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+}
+
+.dropdown--clicked .c7 {
+  -webkit-transition-delay: 0.1s;
+  transition-delay: 0.1s;
+  opacity: 1;
+}
+
+.c8 {
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.dropdown__items .c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  height: 36px;
+  margin: 4px 8px 0 8px;
+  padding: 7px 10px;
+  font-size: 14px;
+  text-align: left;
+  border: none;
+  background-color: rgba(255,255,255,1);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  color: #262626;
+  line-height: 1.25;
+}
+
+.dropdown__items .c8:focus {
+  background-color: #026cdf;
+  color: rgba(255,255,255,1);
+  outline: none;
+  border-radius: 2px;
+}
+
+.dropdown__items .c8.dropdown__selected {
+  color: #262626;
+  background-color: #ebebeb;
+  border-radius: 2px;
+}
+
+.dropdown__items.dropdown__items--small .c8 {
+  height: 32px;
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
+}
+
+<div
+  data-testid="test-outSideComponent"
+>
+  <div
+    data-testid="something"
+  >
+    something
+  </div>
+  <div
+    aria-haspopup="listbox"
+    aria-labelledby="hidden-label__"
+    class="c0"
+    data-testid="test-dropContainer"
+    tabindex="0"
+  >
+    <label
+      class="dropdown--large dropdown--active dropdown--border c1"
+    >
+      <span
+        class="c2"
+        id="hidden-label__"
+      />
+      <div
+        class="c3 c4"
+      />
+      <svg
+        class="dropdown__icon--hide c5"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            d="M16 0H0v16h16z"
+          />
+          <path
+            d="M3.278 5.459A.75.75 0 0 0 2.221 6.52l5.263 5.24a.75.75 0 0 0 1.059 0L13.78 6.52a.75.75 0 0 0-1.06-1.06l-4.71 4.711L3.278 5.46z"
+            fill="#262626"
+            fill-opacity=".65"
+            fill-rule="nonzero"
+          />
+        </g>
+      </svg>
+    </label>
+    <div
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
+    >
+      <div
+        class="c7"
+        role="listbox"
+      >
+        <span
+          class="c8"
+          data-testid="test-dropDownOptionOne"
+          role="option"
+          tabindex="-1"
+          value="ValueOne"
+        >
+          Option One
+        </span>
+        <span
+          class="c8"
+          data-testid="test-dropDownOptionTwo"
+          role="option"
+          tabindex="-1"
+          value="ValueTwo"
+        >
+          Second Option
+        </span>
+        <span
+          class="c8"
+          data-testid="test-dropDownOptionThree"
+          role="option"
+          tabindex="-1"
+          value="ValueThree"
+        >
+          Option Three
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropDownGroup Escape key should close the drop down 1`] = `
+.c1 {
+  height: 44px;
+  background-color: rgba(255,255,255,1);
+  border-radius: 2px;
+  position: relative;
+  padding: 0px;
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+  -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease 0.3s;
+  transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease 0.3s;
+  z-index: 0;
+}
+
+.c1.dropdown--small {
+  height: 36px;
+}
+
+.c1.full-width {
+  width: 100%;
+}
+
+.c1.dropdown--border {
+  border: solid 1px #999999;
+  padding: 1px;
+  text-align: left;
+}
+
+.c1.dropdown--no-border {
+  border: solid 2px rgba(255,255,255,1);
+  text-align: right;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.dropdown--active {
+  margin: 0;
+  padding: 1px;
+  border: solid 1px #999999;
+  border-radius: 2px;
+  z-index: 10;
+  -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
+  transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
+}
+
+.dropdown--disabled .c1 {
+  cursor: default;
+  color: rgba(38,38,38,0.4);
+  -webkit-transition: none;
+  transition: none;
+}
+
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
+.dropdown--open-upward .c1 {
+  border-radius: 2px;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
+}
+
+.c1:hover:not(.dropdown__label--disabled) {
+  border: solid 2px #026cdf;
+  padding: 0;
+}
+
+.c6 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background-color: rgba(255,255,255,1);
+  border-radius: 2px;
+  white-space: nowrap;
+  margin-top: 2px;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
+  box-sizing: border-box;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  width: auto;
+  overflow: hidden;
+  z-index: 9;
+  border-color: #999999;
+  border-style: solid;
+  border-width: 0;
+  max-height: 0;
+  -webkit-transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
+  transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
+}
+
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
+  padding-top: 4px;
+  padding-bottom: 8px;
+  border-width: 1px;
+  max-height: 606px;
+  -webkit-transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
+  transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
+}
+
+.c6.dropdown--overflow {
+  overflow-y: auto;
+}
+
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
+}
+
+.dropdown--open-upward .c6.dropdown__items--small {
+  bottom: 35px;
+}
+
+.c2 {
+  display: none;
+}
+
+.c0 {
+  position: relative;
+  display: inline-block;
+  color: #262626;
+  outline: none;
+  border-radius: 2px;
+}
+
+.c0:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
+  color: #999999;
+  -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
+  margin-right: 14px;
+  min-width: 16px;
+}
+
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 12px;
+}
+
+.c5.dropdown__icon--hide {
+  opacity: 0;
+}
+
+.c4 {
+  font-size: 14px;
+  white-space: nowrap;
+  width: 85%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0 14px;
+}
+
+.dropdown--small .c4 {
+  font-size: 14px;
+  margin: 0 12px;
+}
+
+.dropdown--large .c4 {
+  font-size: 16px;
+}
+
+.dropdown--no-border .c4 {
+  margin-right: 14px;
+}
+
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
+}
+
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
+}
+
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
+}
+
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
+}
+
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
+  min-height: -webkit-min-content;
+  min-height: -moz-min-content;
+  min-height: min-content;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  opacity: 0;
+  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
+}
+
+.dropdown--clicked .c7 {
+  -webkit-transition-delay: 0.1s;
+  transition-delay: 0.1s;
+  opacity: 1;
+}
+
+.c8 {
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.dropdown__items .c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  height: 36px;
+  margin: 4px 8px 0 8px;
+  padding: 7px 10px;
+  font-size: 14px;
+  text-align: left;
+  border: none;
+  background-color: rgba(255,255,255,1);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  color: #262626;
+  line-height: 1.25;
+}
+
+.dropdown__items .c8:focus {
+  background-color: #026cdf;
+  color: rgba(255,255,255,1);
+  outline: none;
+  border-radius: 2px;
+}
+
+.dropdown__items .c8.dropdown__selected {
+  color: #262626;
+  background-color: #ebebeb;
+  border-radius: 2px;
+}
+
+.dropdown__items.dropdown__items--small .c8 {
+  height: 32px;
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -1717,10 +2695,10 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -1743,14 +2721,14 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -1759,7 +2737,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -1768,7 +2746,7 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -1784,17 +2762,16 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
 
 exports[`DropDownGroup Should not focus onClick 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1813,8 +2790,13 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -1829,8 +2811,9 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -1843,27 +2826,31 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1871,7 +2858,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -1882,7 +2869,11 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -1891,17 +2882,17 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -1911,8 +2902,8 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -1921,70 +2912,90 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -2000,25 +3011,25 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -2032,22 +3043,27 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -2073,10 +3089,10 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
         id="hidden-label__"
       />
       <div
-        class="dropdown__text--disabled c3"
+        class="dropdown__text--disabled c3 c4"
       />
       <svg
-        class="dropdown__chevron--disabled c4"
+        class="dropdown__chevron--disabled c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -2099,14 +3115,14 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -2115,7 +3131,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -2124,7 +3140,7 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -2140,17 +3156,16 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
 
 exports[`DropDownGroup Should open the drop down onClick 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2169,8 +3184,13 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -2185,8 +3205,9 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -2199,27 +3220,31 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -2227,7 +3252,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -2238,7 +3263,11 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -2247,17 +3276,17 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -2267,8 +3296,8 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -2277,70 +3306,90 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -2356,25 +3405,25 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -2388,22 +3437,27 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -2429,10 +3483,10 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -2455,14 +3509,14 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -2471,7 +3525,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -2480,7 +3534,7 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -2498,17 +3552,16 @@ exports[`DropDownGroup Should remove event listener when unmount 1`] = `""`;
 
 exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2527,8 +3580,13 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -2543,8 +3601,9 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -2557,27 +3616,31 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -2585,7 +3648,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -2596,7 +3659,11 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -2605,17 +3672,17 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -2625,8 +3692,8 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -2635,70 +3702,90 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -2714,25 +3801,25 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -2746,22 +3833,27 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -2787,12 +3879,12 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       >
         Option One
       </div>
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -2815,14 +3907,14 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="dropdown__selected c7"
+          class="dropdown__selected c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -2831,7 +3923,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -2840,7 +3932,7 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -2856,17 +3948,16 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
 
 exports[`DropDownGroup Space bar should select and not close dropdown when the isOpen prop equals true 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2885,8 +3976,13 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -2901,8 +3997,9 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -2915,27 +4012,31 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -2943,7 +4044,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -2954,7 +4055,11 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -2963,17 +4068,17 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -2983,8 +4088,8 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -2993,70 +4098,90 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -3072,25 +4197,25 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -3104,22 +4229,27 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -3145,12 +4275,12 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       >
         Option One
       </div>
       <svg
-        class="dropdown__icon--hide c4"
+        class="dropdown__icon--hide c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -3173,14 +4303,14 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c5"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="dropdown__selected c7"
+          class="dropdown__selected c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -3189,7 +4319,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -3198,7 +4328,7 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -3214,17 +4344,16 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
 
 exports[`DropDownGroup renders bordered variant with an inner label with a placeholder prop 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3243,8 +4372,13 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -3259,8 +4393,9 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -3273,27 +4408,31 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -3301,7 +4440,7 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -3312,7 +4451,11 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -3321,17 +4464,17 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -3341,8 +4484,8 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -3351,70 +4494,90 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -3430,25 +4593,25 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -3462,22 +4625,27 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -3505,12 +4673,12 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
         Select An Option
       </span>
       <div
-        class="c3"
+        class="c3 c4"
       >
         Select An Option
       </div>
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -3533,14 +4701,14 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -3549,7 +4717,7 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -3558,7 +4726,7 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -3574,17 +4742,16 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
 
 exports[`DropDownGroup renders borderless variant with an inner label with a label prop 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3603,8 +4770,13 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -3619,8 +4791,9 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -3633,27 +4806,31 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -3661,7 +4838,7 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -3672,7 +4849,11 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -3681,17 +4862,17 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -3701,8 +4882,8 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -3711,70 +4892,90 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -3790,25 +4991,25 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -3822,22 +5023,27 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -3865,10 +5071,10 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
         Selected Option:
       </span>
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="dropdown--no-border c4"
+        class="dropdown--no-border c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -3891,14 +5097,14 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -3907,7 +5113,7 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -3916,7 +5122,7 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -3932,17 +5138,16 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
 
 exports[`DropDownGroup renders default dropdown 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3961,8 +5166,13 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -3977,8 +5187,9 @@ exports[`DropDownGroup renders default dropdown 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -3991,27 +5202,31 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -4019,7 +5234,7 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -4030,7 +5245,11 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -4039,17 +5258,17 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -4059,8 +5278,8 @@ exports[`DropDownGroup renders default dropdown 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -4069,70 +5288,90 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -4148,25 +5387,25 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -4180,22 +5419,27 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -4221,10 +5465,10 @@ exports[`DropDownGroup renders default dropdown 1`] = `
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -4247,14 +5491,14 @@ exports[`DropDownGroup renders default dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -4263,7 +5507,7 @@ exports[`DropDownGroup renders default dropdown 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -4272,7 +5516,7 @@ exports[`DropDownGroup renders default dropdown 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -4288,17 +5532,16 @@ exports[`DropDownGroup renders default dropdown 1`] = `
 
 exports[`DropDownGroup renders default dropdown that should always open downwards 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4317,8 +5560,13 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -4333,8 +5581,9 @@ exports[`DropDownGroup renders default dropdown that should always open downward
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -4347,27 +5596,31 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -4375,7 +5628,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -4386,7 +5639,11 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -4395,17 +5652,17 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -4415,8 +5672,8 @@ exports[`DropDownGroup renders default dropdown that should always open downward
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -4425,70 +5682,90 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -4504,25 +5781,25 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -4536,22 +5813,27 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -4577,10 +5859,10 @@ exports[`DropDownGroup renders default dropdown that should always open downward
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -4603,14 +5885,14 @@ exports[`DropDownGroup renders default dropdown that should always open downward
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -4619,7 +5901,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -4628,7 +5910,7 @@ exports[`DropDownGroup renders default dropdown that should always open downward
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -4644,17 +5926,16 @@ exports[`DropDownGroup renders default dropdown that should always open downward
 
 exports[`DropDownGroup renders input correctly when the isOpen prop with a value of true is passed 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4673,8 +5954,13 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -4689,8 +5975,9 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -4703,27 +5990,31 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -4731,7 +6022,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -4742,7 +6033,11 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -4751,17 +6046,17 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -4771,8 +6066,8 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -4781,70 +6076,90 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -4860,25 +6175,25 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -4892,22 +6207,27 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -4933,10 +6253,10 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="dropdown__icon--hide c4"
+        class="dropdown__icon--hide c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -4959,14 +6279,14 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c5"
+      class="dropdown__items dropdown__items--large dropdown--clicked dropdown--overflow c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -4975,7 +6295,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -4984,7 +6304,7 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -5000,17 +6320,16 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
 
 exports[`DropDownGroup renders input correctly when the keywordSearch prop with a value of false is passed 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5029,8 +6348,13 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -5045,8 +6369,9 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -5059,27 +6384,31 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -5087,7 +6416,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -5098,7 +6427,11 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -5107,17 +6440,17 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -5127,8 +6460,8 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -5137,70 +6470,90 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -5216,25 +6569,25 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -5248,22 +6601,27 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -5289,10 +6647,10 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -5315,14 +6673,14 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -5331,7 +6689,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -5340,7 +6698,7 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -5356,17 +6714,16 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
 
 exports[`DropDownGroup renders input correctly when the withKeyboardProvider prop with a value of false is passed 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5385,8 +6742,13 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -5401,8 +6763,9 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -5415,27 +6778,31 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -5443,7 +6810,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -5454,7 +6821,11 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -5463,17 +6834,17 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -5483,8 +6854,8 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -5493,70 +6864,90 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -5572,25 +6963,25 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -5604,22 +6995,27 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -5645,10 +7041,10 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -5671,15 +7067,15 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
         aria-labelledby="hidden-label__"
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -5688,7 +7084,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -5697,7 +7093,7 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -5713,17 +7109,16 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
 
 exports[`DropDownGroup renders small dropdown 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5742,8 +7137,13 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -5758,8 +7158,9 @@ exports[`DropDownGroup renders small dropdown 1`] = `
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -5772,27 +7173,31 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -5800,7 +7205,7 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -5811,7 +7216,11 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -5820,17 +7229,17 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -5840,8 +7249,8 @@ exports[`DropDownGroup renders small dropdown 1`] = `
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -5850,70 +7259,90 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -5929,25 +7358,25 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -5961,22 +7390,27 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div
@@ -6002,10 +7436,10 @@ exports[`DropDownGroup renders small dropdown 1`] = `
         id="hidden-label__"
       />
       <div
-        class="c3"
+        class="c3 c4"
       />
       <svg
-        class="c4"
+        class="c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -6028,14 +7462,14 @@ exports[`DropDownGroup renders small dropdown 1`] = `
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--small c5"
+      class="dropdown__items dropdown__items--small c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionOne"
           role="option"
           tabindex="-1"
@@ -6044,7 +7478,7 @@ exports[`DropDownGroup renders small dropdown 1`] = `
           Option One
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionTwo"
           role="option"
           tabindex="-1"
@@ -6053,7 +7487,7 @@ exports[`DropDownGroup renders small dropdown 1`] = `
           Second Option
         </span>
         <span
-          class="c7"
+          class="c8"
           data-testid="test-dropDownOptionThree"
           role="option"
           tabindex="-1"
@@ -6069,17 +7503,16 @@ exports[`DropDownGroup renders small dropdown 1`] = `
 
 exports[`DropDownGroup should render the correct label when label prop is passed, and when an array of children containing falsy values is passed to each DropDownOption 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6098,8 +7531,13 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -6114,8 +7552,9 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -6128,27 +7567,31 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -6156,7 +7599,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -6167,7 +7610,11 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -6176,17 +7623,17 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -6196,8 +7643,8 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -6206,70 +7653,90 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -6285,25 +7752,25 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -6317,22 +7784,27 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div>
@@ -6352,14 +7824,14 @@ exports[`DropDownGroup should render the correct label when label prop is passed
         Sort By:
       </span>
       <div
-        class="c3"
+        class="c3 c4"
       >
         Sort By:
          
         Date
       </div>
       <svg
-        class="dropdown--no-border c4"
+        class="dropdown--no-border c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -6382,14 +7854,14 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="dropdown__selected c7"
+          class="dropdown__selected c8"
           role="option"
           tabindex="-1"
           value="date"
@@ -6397,7 +7869,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Date
         </span>
         <span
-          class="c7"
+          class="c8"
           role="option"
           tabindex="-1"
           value="distance"
@@ -6406,7 +7878,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Closest
         </span>
         <span
-          class="c7"
+          class="c8"
           role="option"
           tabindex="-1"
           value="price"
@@ -6424,17 +7896,16 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 exports[`DropDownGroup should render the correct label when label prop is passed, and when an array of children containing string and node values is passed to each DropDownOption 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6453,8 +7924,13 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -6469,8 +7945,9 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -6483,27 +7960,31 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -6511,7 +7992,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -6522,7 +8003,11 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -6531,17 +8016,17 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -6551,8 +8036,8 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -6561,70 +8046,90 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -6640,25 +8145,25 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -6672,22 +8177,27 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div>
@@ -6707,7 +8217,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
         Sort By:
       </span>
       <div
-        class="c3"
+        class="c3 c4"
       >
         Sort By:
          
@@ -6717,7 +8227,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
         </span>
       </div>
       <svg
-        class="dropdown--no-border c4"
+        class="dropdown--no-border c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -6740,14 +8250,14 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           role="option"
           tabindex="-1"
           value="date"
@@ -6755,7 +8265,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Date
         </span>
         <span
-          class="c7"
+          class="c8"
           role="option"
           tabindex="-1"
           value="distance"
@@ -6764,7 +8274,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Closest
         </span>
         <span
-          class="dropdown__selected c7"
+          class="dropdown__selected c8"
           role="option"
           tabindex="-1"
           value="price"
@@ -6782,17 +8292,16 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 exports[`DropDownGroup should render the correct label when label prop is passed, and when an array of children containing string values is passed to each DropDownOption 1`] = `
 .c1 {
-  width: 100%;
   height: 44px;
   background-color: rgba(255,255,255,1);
   border-radius: 2px;
   position: relative;
   padding: 0px;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6811,8 +8320,13 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   height: 36px;
 }
 
+.c1.full-width {
+  width: 100%;
+}
+
 .c1.dropdown--border {
   border: solid 1px #999999;
+  padding: 1px;
   text-align: left;
 }
 
@@ -6827,8 +8341,9 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .c1.dropdown--active {
   margin: 0;
+  padding: 1px;
   border: solid 1px #999999;
-  border-radius: 2px 2px 0 0;
+  border-radius: 2px;
   z-index: 10;
   -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
   transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
@@ -6841,27 +8356,31 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: none;
 }
 
+.dropdown--disabled .c1 .dropdown__chevron--disabled {
+  opacity: 0.4;
+}
+
 .dropdown--open-upward .c1 {
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
 .c1:hover:not(.dropdown__label--disabled) {
   border: solid 2px #026cdf;
+  padding: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   background-color: rgba(255,255,255,1);
-  border-radius: 0 0 2px 2px;
+  border-radius: 2px;
   white-space: nowrap;
-  margin-top: -1px;
+  margin-top: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  min-width: 100%;
   box-sizing: border-box;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -6869,7 +8388,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  width: 100%;
+  width: auto;
   overflow: hidden;
   z-index: 9;
   border-color: #999999;
@@ -6880,7 +8399,11 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
 }
 
-.c5.dropdown--clicked {
+.c6:focus {
+  box-shadow: 0 0 5px 0 #026cdf;
+}
+
+.c6.dropdown--clicked {
   padding-top: 4px;
   padding-bottom: 8px;
   border-width: 1px;
@@ -6889,17 +8412,17 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
 }
 
-.c5.dropdown--overflow {
+.c6.dropdown--overflow {
   overflow-y: auto;
 }
 
-.dropdown--open-upward .c5 {
-  bottom: 43px;
-  border-radius: 2px 2px 0 0;
+.dropdown--open-upward .c6 {
+  bottom: 46px;
+  border-radius: 2px;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.dropdown--open-upward .c5.dropdown__items--small {
+.dropdown--open-upward .c6.dropdown__items--small {
   bottom: 35px;
 }
 
@@ -6909,8 +8432,8 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .c0 {
   position: relative;
+  display: inline-block;
   color: #262626;
-  width: 100%;
   outline: none;
   border-radius: 2px;
 }
@@ -6919,70 +8442,90 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   box-shadow: 0 0 5px 0 #026cdf;
 }
 
-.c4 {
+.c0.full-width {
+  width: 100%;
+  display: block;
+}
+
+.c5 {
   color: #999999;
   -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
   transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 16px;
+  margin-right: 14px;
+  min-width: 16px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c5 {
+  margin-right: 14px;
+}
+
+.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
   margin-right: 12px;
 }
 
-.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 15px;
-}
-
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__chevron--disabled) {
-  margin-right: 11px;
-}
-
-.c4.dropdown__icon--hide {
+.c5.dropdown__icon--hide {
   opacity: 0;
 }
 
-.c3 {
-  font-size: 16px;
+.c4 {
+  font-size: 14px;
   white-space: nowrap;
   width: 85%;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0 14px;
 }
 
-.dropdown--small .c3 {
+.dropdown--small .c4 {
   font-size: 14px;
+  margin: 0 12px;
 }
 
-.dropdown--no-border .c3 {
-  margin-right: 10px;
+.dropdown--large .c4 {
+  font-size: 16px;
 }
 
-.dropdown--large.dropdown--border .c3 {
-  margin-left: 16px;
+.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border .c3 {
+.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c3 {
-  margin-right: 11px;
+.dropdown--large.dropdown--border .c4 {
+  margin-left: 14px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c3:not(.dropdown__text--disabled) {
-  margin-right: 10px;
+.dropdown--small.dropdown--border .c4 {
+  margin-left: 12px;
 }
 
-.dropdown--small.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 11px;
+.dropdown--active.dropdown--no-border .c4 {
+  margin-right: 14px;
 }
 
-.dropdown--large.dropdown--border:hover .c3:not(.dropdown__text--disabled) {
-  margin-left: 15px;
+.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+  margin-left: 12px;
 }
 
-.c6 {
+.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+  margin-right: 14px;
+}
+
+.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 12px;
+}
+
+.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+  margin-left: 14px;
+}
+
+.c7 {
   min-height: -webkit-min-content;
   min-height: -moz-min-content;
   min-height: min-content;
@@ -6998,25 +8541,25 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
 }
 
-.dropdown--clicked .c6 {
+.dropdown--clicked .c7 {
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
   opacity: 1;
 }
 
-.c7 {
+.c8 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c7 {
+.dropdown__items .c8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -7030,22 +8573,27 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   line-height: 1.25;
 }
 
-.dropdown__items .c7:focus {
+.dropdown__items .c8:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
-.dropdown__items .c7.dropdown__selected {
+.dropdown__items .c8.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c7 {
+.dropdown__items.dropdown__items--small .c8 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c8 {
+  font-size: 16px;
 }
 
 <div>
@@ -7065,7 +8613,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
         Sort By:
       </span>
       <div
-        class="c3"
+        class="c3 c4"
       >
         Sort By:
          
@@ -7073,7 +8621,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
         Closest
       </div>
       <svg
-        class="dropdown--no-border c4"
+        class="dropdown--no-border c5"
         height="16"
         viewBox="0 0 16 16"
         width="16"
@@ -7096,14 +8644,14 @@ exports[`DropDownGroup should render the correct label when label prop is passed
       </svg>
     </label>
     <div
-      class="dropdown__items dropdown__items--large c5"
+      class="dropdown__items dropdown__items--large c6"
     >
       <div
-        class="c6"
+        class="c7"
         role="listbox"
       >
         <span
-          class="c7"
+          class="c8"
           role="option"
           tabindex="-1"
           value="date"
@@ -7111,7 +8659,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Date
         </span>
         <span
-          class="dropdown__selected c7"
+          class="dropdown__selected c8"
           role="option"
           tabindex="-1"
           value="distance"
@@ -7120,7 +8668,7 @@ exports[`DropDownGroup should render the correct label when label prop is passed
           Closest
         </span>
         <span
-          class="c7"
+          class="c8"
           role="option"
           tabindex="-1"
           value="price"
@@ -7148,8 +8696,8 @@ exports[`DropDownOption should render the correct markup when a className prop i
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -7167,6 +8715,7 @@ exports[`DropDownOption should render the correct markup when a className prop i
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
 .dropdown__items .c0.dropdown__selected {
@@ -7179,6 +8728,10 @@ exports[`DropDownOption should render the correct markup when a className prop i
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c0 {
+  font-size: 16px;
 }
 
 <span

--- a/src/components/Input/__tests__/__snapshots__/DropDownInput.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownInput.spec.js.snap
@@ -12,8 +12,8 @@ exports[`<DropDownInput /> should render the correct markup 1`] = `
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -31,6 +31,7 @@ exports[`<DropDownInput /> should render the correct markup 1`] = `
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
 .dropdown__items .c0.dropdown__selected {
@@ -43,6 +44,10 @@ exports[`<DropDownInput /> should render the correct markup 1`] = `
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c0 {
+  font-size: 16px;
 }
 
 <span
@@ -67,8 +72,8 @@ exports[`<DropDownInput /> should render the correct markup when additional prop
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -86,6 +91,7 @@ exports[`<DropDownInput /> should render the correct markup when additional prop
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
 .dropdown__items .c0.dropdown__selected {
@@ -98,6 +104,10 @@ exports[`<DropDownInput /> should render the correct markup when additional prop
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c0 {
+  font-size: 16px;
 }
 
 <span
@@ -123,8 +133,8 @@ exports[`<DropDownInput /> should render the correct markup when the className p
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -142,6 +152,7 @@ exports[`<DropDownInput /> should render the correct markup when the className p
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
 .dropdown__items .c0.dropdown__selected {
@@ -154,6 +165,10 @@ exports[`<DropDownInput /> should render the correct markup when the className p
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c0 {
+  font-size: 16px;
 }
 
 <span
@@ -178,8 +193,8 @@ exports[`<DropDownInput /> should render the correct markup when the isSelected 
   appearance: none;
   height: 36px;
   margin: 4px 8px 0 8px;
-  padding: 7px 12px;
-  font-size: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
   text-align: left;
   border: none;
   background-color: rgba(255,255,255,1);
@@ -197,6 +212,7 @@ exports[`<DropDownInput /> should render the correct markup when the isSelected 
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
+  border-radius: 2px;
 }
 
 .dropdown__items .c0.dropdown__selected {
@@ -209,6 +225,10 @@ exports[`<DropDownInput /> should render the correct markup when the isSelected 
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c0 {
+  font-size: 16px;
 }
 
 <span

--- a/src/components/Input/__tests__/__snapshots__/DropDownLabel.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownLabel.spec.js.snap
@@ -2,7 +2,8 @@
 
 exports[`<DropDownLabel /> renders large size label correctly 1`] = `
 .c0 {
-  font-size: 16px;
+  display: block;
+  font-size: 14px;
   opacity: 1;
 }
 
@@ -17,7 +18,8 @@ exports[`<DropDownLabel /> renders large size label correctly 1`] = `
 
 exports[`<DropDownLabel /> renders small disabled label correctly 1`] = `
 .c0 {
-  font-size: 14px;
+  display: block;
+  font-size: 12px;
   opacity: 0.4;
 }
 
@@ -32,7 +34,8 @@ exports[`<DropDownLabel /> renders small disabled label correctly 1`] = `
 
 exports[`<DropDownLabel /> renders small size label correctly 1`] = `
 .c0 {
-  font-size: 14px;
+  display: block;
+  font-size: 12px;
   opacity: 1;
 }
 

--- a/src/components/KeyboardNavigation/Provider.js
+++ b/src/components/KeyboardNavigation/Provider.js
@@ -29,14 +29,16 @@ export default class KeyBoardProvider extends React.Component {
     role: PropTypes.string.isRequired,
     className: PropTypes.string,
     keywordSearch: PropTypes.bool,
-    keyBoardRef: PropTypes.func
+    keyBoardRef: PropTypes.func,
+    navigateOptions: PropTypes.bool
   };
 
   static defaultProps = {
     children: null,
     keyBoardRef: null,
     className: null,
-    keywordSearch: false
+    keywordSearch: false,
+    navigateOptions: true
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -151,9 +153,9 @@ export default class KeyBoardProvider extends React.Component {
   /* eslint-enable */
 
   render() {
-    const { role, className, keyBoardRef } = this.props;
+    const { role, className, keyBoardRef, navigateOptions } = this.props;
     return (
-      <Provider value={this.state}>
+      <Provider value={{ ...this.state, navigateOptions }}>
         {/* eslint-disable */}
         <div
           role={role}


### PR DESCRIPTION
**What**:
Separate dropdown button and menu from each other and make their width independent of each other. Also prevent first item in menu from being focused without hover or arrow key press.

**Why**:
Changes were required as per updated design specifications.

**How**:
Made various changes in the styles to match the design. Added a new bool type prop to allow 100% width of container. Also passed down an extra parameter from DropDown group via Keyboard Provider to prevent first item in menu from being focused by default.


**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Ready to be merged 


