### PR TITLE
fix(Tabs): Remove Outline

### DIFF
--- a/src/components/Tabs/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Tabs/__tests__/__snapshots__/index.spec.js.snap
@@ -75,6 +75,7 @@ exports[`<Tabs /> should render tabs component correctly 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  outline: none;
 }
 
 .c3.tab__button--active {
@@ -239,6 +240,7 @@ exports[`<Tabs /> should render tabs component correctly when withBorderBottom e
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  outline: none;
 }
 
 .c3.tab__button--active {
@@ -415,6 +417,7 @@ exports[`<Tabs /> should render tabs component correctly with props for text of 
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  outline: none;
 }
 
 .c3.tab__button--active {

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -89,7 +89,7 @@ const Tab = styled.div`
 const checkIfOverflows = (content = {}) => {
   if (!content) return false;
 
-  const { offsetWidth = 0, scrollWidth = 0 } = content
+  const { offsetWidth = 0, scrollWidth = 0 } = content;
   return offsetWidth < scrollWidth;
 };
 
@@ -108,6 +108,7 @@ const TabItemButton = styled.button.attrs(props => {
   background-color: ${themes.global.transparent};
   border: none;
   appearance: none;
+  outline: none;
 
   &.tab__button--active {
     border-bottom: 4px solid


### PR DESCRIPTION

**What**:
Remove outline from Tab which appears in focused state.

**Why**:
Underline seems enough to depict focused state. Outline looks bit odd.

**How**:
Set outline of the tab to `none`.

**Checklist**:
* [ ] Documentation - N/A
* [ ] Tests - N/A
* [x] Ready to be merged 