### PR TITLE
feat(DropDownGroup): add onDropDownToggle callback

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -473,6 +473,10 @@ rows:
     Type: boolean
     Default: 'false'
     Notes: Defines if width is 100% of container
+  - Prop: onDropDownToggle
+    Type: function
+    Default: 'null'
+    Notes: Callback invoked when dropdown open/hide event fired
 ```
 
 ## Drop Down Option

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -108,10 +108,17 @@ class DropDownGroup extends React.Component {
   };
 
   toggleDropdown = () => {
-    if (this.state.isOpen) {
+    const { onDropDownToggle } = this.props;
+    const { isOpen } = this.state;
+
+    if (isOpen) {
       this.closeDropdown();
     } else {
       this.openDropdown();
+    }
+
+    if (onDropDownToggle) {
+      onDropDownToggle(!isOpen);
     }
   };
 
@@ -218,7 +225,7 @@ class DropDownGroup extends React.Component {
                       className={classNames(props.className, {
                         "dropdown--open-upward": hasOpenUpwardClass,
                         "dropdown--disabled": disabled,
-                        "full-width": fullWidth,
+                        "full-width": fullWidth
                       })}
                       tabIndex={disabled ? -1 : 0}
                       aria-haspopup="listbox"
@@ -228,13 +235,16 @@ class DropDownGroup extends React.Component {
                     >
                       <StyledGroup
                         {...onClickListener}
-                        className={classNames(`dropdown__label dropdown--${size}`, {
-                          "dropdown--active": isOpen,
-                          "dropdown--border": isBorderAround,
-                          "dropdown--no-border": !isBorderAround,
-                          "dropdown__label--disabled": disabled,
-                          "full-width": fullWidth
-                        })}
+                        className={classNames(
+                          `dropdown__label dropdown--${size}`,
+                          {
+                            "dropdown--active": isOpen,
+                            "dropdown--border": isBorderAround,
+                            "dropdown--no-border": !isBorderAround,
+                            "dropdown__label--disabled": disabled,
+                            "full-width": fullWidth
+                          }
+                        )}
                       >
                         {/* HiddenLabel is required for correct screen readers 
                         readings when an option is selected */}
@@ -246,7 +256,8 @@ class DropDownGroup extends React.Component {
                             "dropdown__text--disabled": disabled
                           })}
                         >
-                          {icon}{this.displayLabel(selected)}
+                          {icon}
+                          {this.displayLabel(selected)}
                         </StyledSelectedText>
 
                         {chevronVisible && (
@@ -313,7 +324,8 @@ DropDownGroup.propTypes = {
   fullWidth: PropTypes.bool,
   shouldOpenDownward: PropTypes.bool,
   icon: PropTypes.node,
-  chevronVisible: PropTypes.bool
+  chevronVisible: PropTypes.bool,
+  onDropDownToggle: PropTypes.func
 };
 
 DropDownGroup.defaultProps = {
@@ -332,6 +344,7 @@ DropDownGroup.defaultProps = {
   icon: null,
   chevronVisible: true,
   fullWidth: false,
+  onDropDownToggle: null
 };
 
 export default DropDownGroup;

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -445,6 +445,17 @@ describe("DropDownGroup", () => {
 
     expect(chevron).toBe(null);
   });
+
+  it("should fire onDropDownToggle if its passed", () => {
+    const onDropDownToggleEvent = jest.fn();
+    const { container } = renderTestComponentOne({
+      onDropDownToggle: onDropDownToggleEvent
+    });
+    const labelTag = container.getElementsByTagName("LABEL")[0];
+
+    Simulate.click(labelTag);
+    expect(onDropDownToggleEvent).toBeCalled();
+  });
 });
 
 describe("DropDownOption", () => {


### PR DESCRIPTION
feat(DropDownGroup): add docs description

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added onDropDownToggle callback which invoked after dropdown open/hide event fired.
<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
