### PR TITLE
fix(DropDown): icon spacing and border opacity

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.styles.js
+++ b/src/components/Input/DropDown/DropDownGroup.styles.js
@@ -61,6 +61,10 @@ export const StyledGroup = styled.label`
     color: ${getThemeValue("onyx", "muted")};
     transition: none;
 
+    &:not(.dropdown--no-border) {
+      border-color: ${getThemeValue("onyx", "muted")};
+    }
+
     .dropdown__chevron--disabled {
       opacity: 0.4;
     }

--- a/src/components/Input/DropDown/DropDownGroup.styles.js
+++ b/src/components/Input/DropDown/DropDownGroup.styles.js
@@ -184,6 +184,8 @@ export const StyledChevron = styled(DownIcon).attrs({
 `;
 
 export const StyledSelectedText = styled.div`
+  display: flex;
+  align-items: center;
   font-size: ${typography.size.hecto};
   white-space: nowrap;
   width: 85%;
@@ -238,6 +240,10 @@ export const StyledSelectedText = styled.div`
     &:not(.dropdown__text--disabled) {
       margin-left: 14px;
     }
+  }
+
+  svg {
+    margin-right: 12px;
   }
 `;
 

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -186,6 +186,14 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -237,6 +245,10 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -588,6 +600,14 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -639,6 +659,10 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -990,6 +1014,14 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -1041,6 +1073,10 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -1392,6 +1428,14 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -1443,6 +1487,10 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -1796,6 +1844,14 @@ exports[`DropDownGroup Effect when move moves over dropdown option  when focused
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -1847,6 +1903,10 @@ exports[`DropDownGroup Effect when move moves over dropdown option  when focused
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -2198,6 +2258,14 @@ exports[`DropDownGroup Effect when move moves over dropdown option when focused 
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -2249,6 +2317,10 @@ exports[`DropDownGroup Effect when move moves over dropdown option when focused 
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -2600,6 +2672,14 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -2651,6 +2731,10 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -3002,6 +3086,14 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -3053,6 +3145,10 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -3404,6 +3500,14 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -3455,6 +3559,10 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -3808,6 +3916,14 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -3859,6 +3975,10 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -4212,6 +4332,14 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -4263,6 +4391,10 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -4616,6 +4748,14 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -4667,6 +4807,10 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -5022,6 +5166,14 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -5073,6 +5225,10 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -5426,6 +5582,14 @@ exports[`DropDownGroup renders default dropdown 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -5477,6 +5641,10 @@ exports[`DropDownGroup renders default dropdown 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -5828,6 +5996,14 @@ exports[`DropDownGroup renders default dropdown that should always open downward
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -5879,6 +6055,10 @@ exports[`DropDownGroup renders default dropdown that should always open downward
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -6230,6 +6410,14 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -6281,6 +6469,10 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -6632,6 +6824,14 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -6683,6 +6883,10 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -7034,6 +7238,14 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -7085,6 +7297,10 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -7435,6 +7651,14 @@ exports[`DropDownGroup renders small dropdown 1`] = `
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -7486,6 +7710,10 @@ exports[`DropDownGroup renders small dropdown 1`] = `
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -7837,6 +8065,14 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -7888,6 +8124,10 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -8238,6 +8478,14 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -8289,6 +8537,10 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {
@@ -8642,6 +8894,14 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 }
 
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 14px;
   white-space: nowrap;
   width: 85%;
@@ -8693,6 +8953,10 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 
 .dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
   margin-left: 14px;
+}
+
+.c4 svg {
+  margin-right: 12px;
 }
 
 .c7 {

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -66,6 +66,10 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -462,6 +466,10 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -862,6 +870,10 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -1258,6 +1270,10 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -1660,6 +1676,10 @@ exports[`DropDownGroup Effect when move moves over dropdown option  when focused
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -2056,6 +2076,10 @@ exports[`DropDownGroup Effect when move moves over dropdown option when focused 
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -2456,6 +2480,10 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -2854,6 +2882,10 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -3250,6 +3282,10 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -3652,6 +3688,10 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -4052,6 +4092,10 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -4450,6 +4494,10 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -4854,6 +4902,10 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -5254,6 +5306,10 @@ exports[`DropDownGroup renders default dropdown 1`] = `
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -5650,6 +5706,10 @@ exports[`DropDownGroup renders default dropdown that should always open downward
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -6050,6 +6110,10 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -6446,6 +6510,10 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -6846,6 +6914,10 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -7241,6 +7313,10 @@ exports[`DropDownGroup renders small dropdown 1`] = `
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -7641,6 +7717,10 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   transition: none;
 }
 
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
+}
+
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
   opacity: 0.4;
 }
@@ -8036,6 +8116,10 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {
@@ -8436,6 +8520,10 @@ exports[`DropDownGroup should render the correct label when label prop is passed
   color: rgba(38,38,38,0.4);
   -webkit-transition: none;
   transition: none;
+}
+
+.dropdown--disabled .c1:not(.dropdown--no-border) {
+  border-color: rgba(38,38,38,0.4);
 }
 
 .dropdown--disabled .c1 .dropdown__chevron--disabled {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixed border opacity and icon spacing from label.

<!-- Why are these changes necessary? -->

**Why**: Border opacity should be 40%.  Spacing between icon and label was missing.

<!-- How were these changes implemented? -->

**How**:  Updated opacity to 40% and provided margin between icon and label.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation - N/A
* [ ] Tests - N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
