### PR TITLE
feat(DropDown): allow option selection on enter keydown

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -10,6 +10,7 @@ import { Consumer as SelectionConsumer } from "../../SelectionProvider/Context";
 import {
   ARROWUP,
   ARROWDOWN,
+  ENTER,
   SPACEBAR,
   ESCAPE,
   TAB
@@ -80,6 +81,7 @@ class DropDownGroup extends React.Component {
           this.openDropdown();
         }
         break;
+      case ENTER:
       case SPACEBAR:
         e.preventDefault();
         this.toggleDropdown();

--- a/src/components/Input/DropDown/DropDownOption.js
+++ b/src/components/Input/DropDown/DropDownOption.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Consumer as SelectionConsumer } from "../../SelectionProvider/Context";
 import { Consumer as KeyBoardConsumer } from "../../KeyboardNavigation/Context";
 import { Consumer as DropDownConsumer } from "./Context";
-import { SPACEBAR } from "../../../utils/keyCharCodes";
+import { ENTER, SPACEBAR } from "../../../utils/keyCharCodes";
 
 import composeEventHandlers from "../../../utils/composeEventHandlers";
 import DropDownInput from "./DropDownInput";
@@ -44,7 +44,7 @@ class DropDownOption extends React.PureComponent {
                         this.focusInput();
                       }}
                       onKeyDown={e => {
-                        if (e.keyCode === SPACEBAR) {
+                        if ([ENTER, SPACEBAR].includes(e.keyCode)) {
                           onClick({ value });
                           e.preventDefault();
                         }


### PR DESCRIPTION
**What**: DropDown should allow selection of an option with Enter key.

**Why**: Current Dropdown only allows item selection with the space bar. Enter/return key should be also allowed to select the option.

**How**: Allowed item selection on keyCode of Enter key along with space key.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation - N/A
* [ ] Tests - N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
