### PR TITLE
fix(Build): Upgrade to nodejs 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '8'
+  - '12'
 script:
   - npm run lint
   - npm run lint:css


### PR DESCRIPTION
**What**:

Upgrade node to v12

**Why**:

`semantic-release` now requires node >= 10

**How**:

Change in the .travis.yml

**Checklist**:

* [x] Documentation N/A
* [x] Tests N/A
* [x] Ready to be merged

Please make sure it won't break integrators.
