### PR TITLE
feat(tooltip): Expose a refresh function on the tooltip to recalculat…

### DIFF
--- a/catalog/pages/tooltip/TooltipRestrictedAsync.js
+++ b/catalog/pages/tooltip/TooltipRestrictedAsync.js
@@ -1,4 +1,6 @@
+/* eslint-disable react/no-multi-comp */
 import React from "react";
+import * as PropTypes from "prop-types";
 import styled from "styled-components";
 import Tooltip from "../../../src/components/Tooltip";
 import { LinkCta } from "../../../src/components/Text";
@@ -14,77 +16,66 @@ const TooltipButton = styled.div`
   display: inline-block;
 `;
 
-let index = 0;
-let asyncInterval;
-
-const copy = [
-  `This is a basic tooltip. If there is a need for multiple lines, it grows downward.`,
-
-  `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
-  incididunt ut labore et dolore magna aliqua. In nisl nisi scelerisque eu ultrices. 
-  Eget aliquet nibh praesent tristique magna.`,
-
-  `Ut lectus arcu bibendum at varius vel. Vitae nunc sed velit dignissim sodales ut eu sem. 
+const bigContent = `Ut lectus arcu bibendum at varius vel. Vitae nunc sed velit dignissim sodales ut eu sem. 
   Velit sed ullamcorper morbi tincidunt ornare massa. Praesent elementum facilisis leo vel 
   fringilla est ullamcorper eget. Mauris commodo quis imperdiet massa tincidunt nunc. Tellus
   in hac habitasse platea dictumst vestibulum rhoncus. Et odio pellentesque diam volutpat. 
   Sed id semper risus in. Ut venenatis tellus in metus vulputate eu. Vitae auctor eu augue ut
-  lectus.`
-];
+  lectus.`;
+
+class AsyncContent extends React.Component {
+  state = {
+    content: "loading..."
+  };
+
+  componentDidMount() {
+    this.timeoutId = setTimeout(() => {
+      this.setState(state => ({ ...state, content: bigContent }));
+      this.props.onLoad();
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timeoutId);
+  }
+
+  render() {
+    const { content } = this.state;
+
+    return <div>{content}</div>;
+  }
+}
+
+AsyncContent.propTypes = {
+  onLoad: PropTypes.func
+};
+
+AsyncContent.defaultProps = {
+  onLoad: () => {}
+};
 
 class TooltipRestrictedAsyncDemo extends React.Component {
   state = {
-    isOpened: false,
-    asyncRefresh: false
+    isOpened: false
   };
 
-  componentWillUnmount() {
-    document.body.removeEventListener("touchstart", this.mouseLeave);
-  }
+  tooltipRef = React.createRef();
 
-  containerRef = React.createRef();
-  asyncRefresh = () => {
-    asyncInterval = setInterval(() => {
-      index = index === copy.length - 1 ? 0 : index + 1;
-
-      this.setState({
-        asyncRefresh: !this.state.asyncRefresh
-      });
-    }, 2000);
+  hideTooltip = () => {
+    this.setState(state => ({ ...state, isOpened: false }));
   };
 
-  mouseLeave = e => {
-    e.stopPropagation();
-    document.body.removeEventListener("touchstart", this.mouseLeave);
-    this.setState({
-      isOpened: false
-    });
+  showTooltip = e => {
+    const position = Tooltip.getDimensionsFromEvent(e);
 
-    clearInterval(asyncInterval);
-  };
-
-  buttonSelect = e => {
-    const data = Tooltip.getDimensionsFromEvent(e, this.containerRef.current);
-    this.asyncRefresh();
-
-    this.setState(state => {
-      if (state.isOpened) {
-        return state;
-      }
-
-      document.body.addEventListener("touchstart", this.mouseLeave);
-      return {
-        isOpened: true,
-        ...data
-      };
-    });
+    this.setState(state => ({ ...state, isOpened: true, position }));
   };
 
   render() {
-    const { isOpened, content, asyncRefresh, ...position } = this.state;
+    const { isOpened, position } = this.state;
 
     return (
-      <Container ref={this.containerRef}>
+      <Container>
         <div
           style={{
             display: "flex",
@@ -93,20 +84,23 @@ class TooltipRestrictedAsyncDemo extends React.Component {
         >
           <TooltipButton>
             <LinkCta
-              onMouseEnter={this.buttonSelect}
-              onMouseLeave={this.mouseLeave}
-              onTouchStart={this.buttonSelect}
+              onMouseEnter={this.showTooltip}
+              onMouseLeave={this.hideTooltip}
             >
               Hover for Async Tooltip
             </LinkCta>
           </TooltipButton>
         </div>
         <Tooltip
+          ref={this.tooltipRef}
           isVisible={isOpened}
           position={{ ...position }}
-          asyncRefresh={asyncRefresh}
         >
-          {copy[index]}
+          {isOpened ? (
+            <AsyncContent onLoad={() => this.tooltipRef.current.refresh()} />
+          ) : (
+            ""
+          )}
         </Tooltip>
       </Container>
     );

--- a/catalog/pages/tooltip/index.md
+++ b/catalog/pages/tooltip/index.md
@@ -58,11 +58,9 @@ rows:
 </div>
 ```
 
-#### Async Tooltip
+#### Manual Refresh
 
-- Tooltip content is refreshed while visible when Prop `asyncRefresh` is set to `true` or `false` (default `null`)
-- If `asyncRefresh` prop is set to `null` tooltip will only refresh when tooltip visibility (prop: `isVisible`) is set to `false`
-- `asyncRefresh` prop will need to be changed in the parent in order for the tooltip to refresh content.
+- If the content of a tooltip can change while the tooltip is visible, you can call a `refresh()` method on the component to reset the position based on the content.
 
 Example: hover over tooltip for more than 2 sec
 

--- a/src/components/Tooltip/__tests__/index.spec.js
+++ b/src/components/Tooltip/__tests__/index.spec.js
@@ -1,14 +1,10 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import Enzyme, { mount } from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
 
 import PopOver from "../../PopOver";
 import Tooltip from "../index";
 import { BOTTOM, TOP, LEFT, RIGHT } from "../../constants";
 import { constants } from "../../../theme";
-
-Enzyme.configure({ adapter: new Adapter() });
 
 jest.mock("../../PopOver/PopOverPortal", () => ({ children }) => children);
 
@@ -571,59 +567,24 @@ describe("Tooltip", () => {
     spy.mockRestore();
   });
 
-  describe("tooltip Async Refresh", () => {
-    const content = [
-      `This is a basic tooltip. If there is a need for multiple lines, it grows downward.`,
+  describe("tooltip refresh", () => {
+    let element;
 
-      `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
-      incididunt ut labore et dolore magna aliqua. In nisl nisi scelerisque eu ultrices. 
-      Eget aliquet nibh praesent tristique magna.`,
+    beforeEach(() => {
+      const tooltip = renderer.create(<Tooltip isVisible>test</Tooltip>);
 
-      `Ut lectus arcu bibendum at varius vel. Vitae nunc sed velit dignissim sodales ut eu sem. 
-      Velit sed ullamcorper morbi tincidunt ornare massa. Praesent elementum facilisis leo vel 
-      fringilla est ullamcorper eget. Mauris commodo quis imperdiet massa tincidunt nunc. Tellus
-      in hac habitasse platea dictumst vestibulum rhoncus. Et odio pellentesque diam volutpat. 
-      Sed id semper risus in. Ut venenatis tellus in metus vulputate eu. Vitae auctor eu augue ut
-      lectus.`
-    ];
+      element = {
+        style: {}
+      };
 
-    const renderComponent = (index, refresh) =>
-      mount(
-        <Tooltip asyncRefresh={refresh} isVisible>
-          {content[index]}
-        </Tooltip>
-      );
+      tooltip.getInstance().myRef.current = element;
 
-    it("should load tooltip contents and content changes asyncronously", () =>
-      Promise.resolve(renderComponent(0, false))
-        .then(response => {
-          expect(response.instance().props.children).toEqual(content[0]);
-          expect(response.instance().props.asyncRefresh).toEqual(false);
-          expect(response.instance().state.asyncRefresh).toEqual(true);
+      tooltip.getInstance().refresh();
+    });
 
-          response.setProps({
-            children: content[1],
-            asyncRefresh: true
-          });
-
-          return response;
-        })
-        .then(response => {
-          expect(response.instance().props.children).toEqual(content[1]);
-          expect(response.instance().props.asyncRefresh).toEqual(true);
-          expect(response.instance().state.asyncRefresh).toEqual(false);
-
-          response.setProps({
-            children: content[2],
-            asyncRefresh: false
-          });
-
-          return response;
-        })
-        .then(response => {
-          expect(response.instance().props.children).toEqual(content[2]);
-          expect(response.instance().props.asyncRefresh).toEqual(false);
-          expect(response.instance().state.asyncRefresh).toEqual(true);
-        }));
+    it("should force a update the position", () => {
+      expect(element.style.top).toBeTruthy();
+      expect(element.style.left).toBeTruthy();
+    });
   });
 });

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -38,25 +38,8 @@ class Tooltip extends Component {
 
     this.state = {
       actualDirection: props.direction,
-      arrowAdjustment: 0,
-      asyncRefresh: false
+      arrowAdjustment: 0
     };
-  }
-
-  componentDidMount() {
-    if (this.props.asyncRefresh !== null) {
-      this.asyncRefresh();
-    }
-  }
-
-  componentDidUpdate(nextProps, prevState) {
-    if (
-      this.props.isVisible &&
-      nextProps.asyncRefresh !== null &&
-      nextProps.asyncRefresh !== prevState.asyncRefresh
-    ) {
-      this.asyncRefresh();
-    }
   }
 
   /*
@@ -162,19 +145,13 @@ class Tooltip extends Component {
   };
 
   /* 
-   * Function that forces a re-render of the tooltip when tooltip children
-   * are updated asyncronously.
+   * Function that forces a re-render of the tooltip
    */
-
-  asyncRefresh = () => {
+  refresh = () => {
     if (this.props.isVisible) {
       this.tooltipEnter();
       this.tooltipEntering();
     }
-
-    this.setState({
-      asyncRefresh: !this.state.asyncRefresh
-    });
   };
 
   adjustArrow = ({ coords, position }) => {
@@ -392,8 +369,7 @@ Tooltip.propTypes = {
   variant: PropTypes.oneOf(VARIANTS),
   spaceFromMouse: PropTypes.number,
   reduceTop: PropTypes.number,
-  reduceBottom: PropTypes.number,
-  asyncRefresh: PropTypes.bool
+  reduceBottom: PropTypes.number
 };
 
 Tooltip.defaultProps = {
@@ -411,8 +387,7 @@ Tooltip.defaultProps = {
   },
   spaceFromMouse: SPACE_FROM_MOUSE,
   reduceTop: 0,
-  reduceBottom: 0,
-  asyncRefresh: null
+  reduceBottom: 0
 };
 
 Tooltip.displayName = "Tooltip";


### PR DESCRIPTION
**What**:

Expose a refresh function on the tooltip to recalculate the position programmatically

**Why**:

In some context, the content is provided asynchronously by the application when the tooltip is already visible. The current behaviour was not recalculating the position when that happens.

**How**:

Add a new method to the tooltip to manually refresh it. 

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? 

A previous iteration was done using a `asyncRefresh` prop, but it was not used yet. So even if this changes is technically breaking, it will not affect anybody.
