### PR TITLE
fix(Themes): update memoize to work properly with objects as in params

### DIFF
--- a/src/utils/__tests__/memoize.spec.js
+++ b/src/utils/__tests__/memoize.spec.js
@@ -5,22 +5,34 @@ describe("memoize", () => {
   let memoizedMock;
 
   beforeEach(() => {
-    functionMock = jest.fn((a, b) => a + b);
+    functionMock = jest.fn((a, obj) => a + obj.a.b);
     memoizedMock = memoize(functionMock);
   });
 
   it("should call function mock with respective variables when the call is not memoed", () => {
-    memoizedMock(2, 3);
+    memoizedMock(2, { a: { b: 4 } });
     expect(functionMock).toHaveBeenCalledTimes(1);
-    expect(functionMock).toHaveBeenCalledWith(2, 3);
+    expect(functionMock).toHaveBeenCalledWith(2, { a: { b: 4 } });
   });
 
   it("should call function mock with respective variables only once when momoed function is called twice with the same args", () => {
-    const initialResult = memoizedMock(2, 3);
-    const secondaryResult = memoizedMock(2, 3);
+    const initialResult = memoizedMock(2, { a: { b: 4 } });
+    const secondaryResult = memoizedMock(2, { a: { b: 4 } });
     expect(functionMock).toHaveBeenCalledTimes(1);
-    expect(functionMock).toHaveBeenCalledWith(2, 3);
-    expect(initialResult).toBe(5);
-    expect(secondaryResult).toBe(5);
+    expect(functionMock).toHaveBeenCalledWith(2, { a: { b: 4 } });
+    expect(initialResult).toBe(6);
+    expect(secondaryResult).toBe(6);
+  });
+
+  describe("when one of the parameters is nested object and memoed function called multiple times with different object", () => {
+    it("should call the function multiple times", () => {
+      const initialResult = memoizedMock(2, { a: { b: 4 } });
+      const secondaryResult = memoizedMock(2, { a: { b: 5 } });
+      expect(functionMock).toHaveBeenCalledTimes(2);
+      expect(functionMock).toHaveBeenCalledWith(2, { a: { b: 4 } });
+      expect(functionMock).toHaveBeenCalledWith(2, { a: { b: 5 } });
+      expect(initialResult).toBe(6);
+      expect(secondaryResult).toBe(7);
+    });
   });
 });

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -1,12 +1,13 @@
 /* eslint-disable no-param-reassign */
 export default fn => (...input) => {
   const args = Array.prototype.slice.call(input);
+  const argsToMemo = JSON.stringify(args);
 
   fn.cache = fn.cache || {};
 
-  const result = fn.cache[args]
-    ? fn.cache[args]
-    : (fn.cache[args] = fn.apply(this, args));
+  const result = fn.cache[argsToMemo]
+    ? fn.cache[argsToMemo]
+    : (fn.cache[argsToMemo] = fn.apply(this, args));
 
   return result;
 };


### PR DESCRIPTION
**What**:

Update memoize function to stringify in parameters.

**Why**:

When passing objects as in parameters memoize doesn't work properly right now because it cannot detect if a nested prop of the object is changed.

**How**:

Use JSON.stringify over the sliced arguments and use the stringified value to memoize the function result.

**Checklist**:
* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
