### PR TITLE
Feature: Tooltip preferTop, directionChanged props to handle tooltip display direction

### DIFF
--- a/catalog/pages/tooltip/TooltipRestrictedAsync.js
+++ b/catalog/pages/tooltip/TooltipRestrictedAsync.js
@@ -59,7 +59,9 @@ class TooltipRestrictedAsyncDemo extends React.Component {
     isOpened: false
   };
 
-  tooltipRef = React.createRef();
+  onDirectionChanged = direction => {
+    console.log("onDirectionChanged", direction);
+  };
 
   hideTooltip = () => {
     this.setState(state => ({ ...state, isOpened: false }));
@@ -70,6 +72,8 @@ class TooltipRestrictedAsyncDemo extends React.Component {
 
     this.setState(state => ({ ...state, isOpened: true, position, preferTop }));
   };
+
+  tooltipRef = React.createRef();
 
   render() {
     const { isOpened, position, preferTop } = this.state;
@@ -108,6 +112,7 @@ class TooltipRestrictedAsyncDemo extends React.Component {
           isVisible={isOpened}
           position={{ ...position }}
           preferTop={preferTop}
+          directionChanged={this.onDirectionChanged}
         >
           {isOpened ? (
             <AsyncContent onLoad={() => this.tooltipRef.current.refresh()} />

--- a/catalog/pages/tooltip/TooltipRestrictedAsync.js
+++ b/catalog/pages/tooltip/TooltipRestrictedAsync.js
@@ -65,14 +65,14 @@ class TooltipRestrictedAsyncDemo extends React.Component {
     this.setState(state => ({ ...state, isOpened: false }));
   };
 
-  showTooltip = e => {
+  showTooltip = (e, preferTop = false) => {
     const position = Tooltip.getDimensionsFromEvent(e);
 
-    this.setState(state => ({ ...state, isOpened: true, position }));
+    this.setState(state => ({ ...state, isOpened: true, position, preferTop }));
   };
 
   render() {
-    const { isOpened, position } = this.state;
+    const { isOpened, position, preferTop } = this.state;
 
     return (
       <Container>
@@ -87,14 +87,27 @@ class TooltipRestrictedAsyncDemo extends React.Component {
               onMouseEnter={this.showTooltip}
               onMouseLeave={this.hideTooltip}
             >
-              Hover for Async Tooltip
+              Hover for Async Tooltip - Bottom (default)
+            </LinkCta>
+          </TooltipButton>
+
+          <TooltipButton>
+            <LinkCta
+              onMouseEnter={e => {
+                this.showTooltip(e, true);
+              }}
+              onMouseLeave={this.hideTooltip}
+            >
+              Hover for Async Tooltip - Top
             </LinkCta>
           </TooltipButton>
         </div>
+
         <Tooltip
           ref={this.tooltipRef}
           isVisible={isOpened}
           position={{ ...position }}
+          preferTop={preferTop}
         >
           {isOpened ? (
             <AsyncContent onLoad={() => this.tooltipRef.current.refresh()} />

--- a/catalog/pages/tooltip/index.md
+++ b/catalog/pages/tooltip/index.md
@@ -27,6 +27,10 @@ rows:
     Type: Object
     Default: all props are 0
     Notes: This prop is generated from Tooltip.getDimensionsFromEvent(e, parent) static function. The function should receive the event that triggers the Tooltip (usually hover). Secondary parameter that restricts tooltip to be visible in a certain container. Work only if direction is auto
+  - Prop: preferTop
+    Type: boolean
+    Default: 'false'
+    Notes: Currently when prop is set to AUTO, the tooltip will display by default to BOTTOM of the parent element if space exists.  Set this prop to true to set display default to TOP of parent element
 ```
 
 ```react
@@ -65,12 +69,16 @@ rows:
 Example: hover over tooltip for more than 2 sec
 
 ```react
-span: 2
+span: 5
 ---
 <div>
   <TooltipRestrictedAsyncDemo />
 </div>
 ```
+
+#### Notes about PROP: preferTop
+
+- Currently when prop: `direction` is not set, the tooltip will display by default under the parent element if space exists. You can set prop: `preferTop = true` to display tooltip above parent element by default.
 
 ### Seat Tooltip
 

--- a/catalog/pages/tooltip/index.md
+++ b/catalog/pages/tooltip/index.md
@@ -31,6 +31,10 @@ rows:
     Type: boolean
     Default: 'false'
     Notes: Currently when prop is set to AUTO, the tooltip will display by default to BOTTOM of the parent element if space exists.  Set this prop to true to set display default to TOP of parent element
+  - Prop: directionChanged
+    Type: func
+    Default: 'null'
+    Notes: Callback function that can be passed to parent component when tooltip direction changes
 ```
 
 ```react
@@ -79,6 +83,10 @@ span: 5
 #### Notes about PROP: preferTop
 
 - Currently when prop: `direction` is not set, the tooltip will display by default under the parent element if space exists. You can set prop: `preferTop = true` to display tooltip above parent element by default.
+
+#### Notes about PROP: directionChanged
+
+- `directionChanged` prop is a callback function can be passed from parent component and will be triggered when tooltip direction changes, a string `direction` is passed to the callback indicating the new direction of the tooltip. (see console when rolling over above examples)
 
 ### Seat Tooltip
 

--- a/src/components/PopOver/index.js
+++ b/src/components/PopOver/index.js
@@ -136,13 +136,13 @@ class PopOver extends Component {
         ? topPosition
         : bottomPosition;
 
-    const getXPosition = Math.min(
+    const Xposition = Math.min(
       Math.max(elLeft + elWidth / 2 - width / 2, containerLeft),
       windowWidth - spaceFromEdge - width,
       containerRight
     );
 
-    const getYPosition =
+    const Yposition =
       !preferTop &&
       bottomPosition + height + spaceFromEdge <=
         Math.min(viewportBottom, containerBottom)
@@ -150,8 +150,8 @@ class PopOver extends Component {
         : topPositionWithFallback;
 
     return {
-      x: getXPosition,
-      y: getYPosition
+      x: Xposition,
+      y: Yposition
     };
   }
 

--- a/src/components/PopOver/index.js
+++ b/src/components/PopOver/index.js
@@ -136,13 +136,13 @@ class PopOver extends Component {
         ? topPosition
         : bottomPosition;
 
-    const Xposition = Math.min(
+    const xPosition = Math.min(
       Math.max(elLeft + elWidth / 2 - width / 2, containerLeft),
       windowWidth - spaceFromEdge - width,
       containerRight
     );
 
-    const Yposition =
+    const yPosition =
       !preferTop &&
       bottomPosition + height + spaceFromEdge <=
         Math.min(viewportBottom, containerBottom)
@@ -150,8 +150,8 @@ class PopOver extends Component {
         : topPositionWithFallback;
 
     return {
-      x: Xposition,
-      y: Yposition
+      x: xPosition,
+      y: yPosition
     };
   }
 

--- a/src/components/PopOver/index.js
+++ b/src/components/PopOver/index.js
@@ -83,7 +83,8 @@ class PopOver extends Component {
     dimensions,
     reduce,
     inlineWithTarget,
-    spaceFromMouse
+    spaceFromMouse,
+    preferTop
   }) {
     const {
       width,
@@ -135,17 +136,22 @@ class PopOver extends Component {
         ? topPosition
         : bottomPosition;
 
-    return {
-      x: Math.min(
-        Math.max(elLeft + elWidth / 2 - width / 2, containerLeft),
-        windowWidth - spaceFromEdge - width,
-        containerRight
-      ),
-      y:
-        bottomPosition + height + spaceFromEdge <=
+    const getXPosition = Math.min(
+      Math.max(elLeft + elWidth / 2 - width / 2, containerLeft),
+      windowWidth - spaceFromEdge - width,
+      containerRight
+    );
+
+    const getYPosition =
+      !preferTop &&
+      bottomPosition + height + spaceFromEdge <=
         Math.min(viewportBottom, containerBottom)
-          ? bottomPosition
-          : topPositionWithFallback
+        ? bottomPosition
+        : topPositionWithFallback;
+
+    return {
+      x: getXPosition,
+      y: getYPosition
     };
   }
 

--- a/src/components/Tooltip/__tests__/index.spec.js
+++ b/src/components/Tooltip/__tests__/index.spec.js
@@ -259,6 +259,51 @@ describe("Tooltip", () => {
         });
       });
 
+      it("Tooltip should be BELOW parent element when preferTop = true and there isn't enough space above", () => {
+        const parentElementPositionAbove = {
+          elBottom: 75,
+          elTop: 25,
+          elLeft: 250,
+          elRight: 300,
+          elHorizontalCenter: 325,
+          elWidth: 50,
+          offsetTop: 0,
+          clientHeight: 1000,
+          offsetLeft: 0,
+          clientWidth: 1000
+        };
+
+        const tree = renderer.create(<Tooltip preferTop />).getInstance();
+        expect(
+          tree.calculatePosition({
+            direction: "auto",
+            position: parentElementPositionAbove,
+            reduce,
+            spaceFromMouse: 10,
+            dimensions: tooltipDimensions
+          })
+        ).toEqual({
+          x: 225,
+          y: 185
+        });
+      });
+
+      it("calculate position for tooltip should be ABOVE parent element when preferTop = true", () => {
+        const tree = renderer.create(<Tooltip preferTop />).getInstance();
+        expect(
+          tree.calculatePosition({
+            direction: "auto",
+            position: parentElementPosition,
+            reduce,
+            spaceFromMouse: 10,
+            dimensions: tooltipDimensions
+          })
+        ).toEqual({
+          x: 225,
+          y: 240
+        });
+      });
+
       it("calculate position for tooltip should be BELOW parent element when preferTop = false", () => {
         const tree = renderer.create(<Tooltip />).getInstance();
         expect(

--- a/src/components/Tooltip/__tests__/index.spec.js
+++ b/src/components/Tooltip/__tests__/index.spec.js
@@ -549,7 +549,8 @@ describe("Tooltip", () => {
       actualDirection: BOTTOM
     });
 
-    const spy = jest.spyOn(tree, "setState").mockImplementation(() => {});
+    const spy = jest.spyOn(tree, "setState");
+
     tree.getPositionAndUpdateDirection({
       position: {
         elTop: 10
@@ -560,7 +561,7 @@ describe("Tooltip", () => {
     });
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({
+    expect(tree.state).toEqual({
       actualDirection: TOP,
       arrowAdjustment: 0
     });
@@ -576,7 +577,8 @@ describe("Tooltip", () => {
       actualDirection: TOP
     });
 
-    const spy = jest.spyOn(tree, "setState").mockImplementation(() => {});
+    const spy = jest.spyOn(tree, "setState");
+
     tree.getPositionAndUpdateDirection({
       position: {
         elTop: 10
@@ -587,7 +589,7 @@ describe("Tooltip", () => {
     });
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({
+    expect(tree.state).toEqual({
       actualDirection: TOP,
       arrowAdjustment: 100
     });
@@ -603,7 +605,8 @@ describe("Tooltip", () => {
       actualDirection: TOP
     });
 
-    const spy = jest.spyOn(tree, "setState").mockImplementation(() => {});
+    const spy = jest.spyOn(tree, "setState");
+
     tree.getPositionAndUpdateDirection({
       position: {
         elTop: 10
@@ -614,7 +617,7 @@ describe("Tooltip", () => {
     });
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({
+    expect(tree.state).toEqual({
       actualDirection: BOTTOM,
       arrowAdjustment: 0
     });
@@ -630,7 +633,7 @@ describe("Tooltip", () => {
       actualDirection: BOTTOM
     });
 
-    const spy = jest.spyOn(tree, "setState").mockImplementation(() => {});
+    const spy = jest.spyOn(tree, "setState");
     tree.getPositionAndUpdateDirection({
       position: {
         elTop: 10
@@ -641,7 +644,7 @@ describe("Tooltip", () => {
     });
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({
+    expect(tree.state).toEqual({
       actualDirection: BOTTOM,
       arrowAdjustment: 10
     });
@@ -649,7 +652,7 @@ describe("Tooltip", () => {
     spy.mockRestore();
   });
 
-  it("getPositionAndUpdateDirection should not call set state", () => {
+  it("getPositionAndUpdateDirection should not change state", () => {
     const tree = renderer.create(<Tooltip />).getInstance();
     PopOver.calculatePosition = jest.fn(() => ({ x: 10, y: 1000 }));
     tree.adjustArrow = jest.fn(() => 0);
@@ -657,7 +660,9 @@ describe("Tooltip", () => {
       actualDirection: BOTTOM
     });
 
-    const spy = jest.spyOn(tree, "setState").mockImplementation(() => {});
+    const currentState = tree.state;
+
+    const spy = jest.spyOn(tree, "setState");
     tree.getPositionAndUpdateDirection({
       position: {
         elTop: 10
@@ -667,7 +672,8 @@ describe("Tooltip", () => {
       }
     });
 
-    expect(spy).toHaveBeenCalledTimes(0);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(tree.state).toEqual(currentState);
 
     spy.mockRestore();
   });
@@ -690,6 +696,63 @@ describe("Tooltip", () => {
     it("should force a update the position", () => {
       expect(element.style.top).toBeTruthy();
       expect(element.style.left).toBeTruthy();
+    });
+  });
+
+  describe("tooltip directionChanged callback", () => {
+    const callback = jest.fn();
+    let tree;
+
+    beforeEach(() => {
+      PopOver.calculatePosition = jest.fn(() => ({ x: 10, y: 1000 }));
+
+      tree = renderer
+        .create(<Tooltip directionChanged={callback} />)
+        .getInstance();
+
+      tree.setState({
+        actualDirection: TOP
+      });
+
+      tree.adjustArrow = jest.fn(() => 0);
+    });
+
+    afterEach(() => {
+      callback.mockRestore();
+    });
+
+    it("calls callback when direction is changed", () => {
+      tree.getPositionAndUpdateDirection({
+        position: {
+          elTop: 10
+        },
+        dimensions: {
+          windowScroll: 100
+        }
+      });
+
+      expect(callback).toHaveBeenCalledWith(BOTTOM);
+      expect(tree.state).toEqual({
+        actualDirection: BOTTOM,
+        arrowAdjustment: 0
+      });
+    });
+
+    it("does not call callback when direction remains the same", () => {
+      tree.getPositionAndUpdateDirection({
+        position: {
+          elTop: 990
+        },
+        dimensions: {
+          windowScroll: 100
+        }
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(tree.state).toEqual({
+        actualDirection: TOP,
+        arrowAdjustment: 0
+      });
     });
   });
 });

--- a/src/components/Tooltip/__tests__/index.spec.js
+++ b/src/components/Tooltip/__tests__/index.spec.js
@@ -215,6 +215,66 @@ describe("Tooltip", () => {
       });
       spy.mockRestore();
     });
+
+    describe("tooltip preferTop prop", () => {
+      const tooltipDimensions = {
+        width: 100,
+        height: 100,
+        windowScroll: 100,
+        windowWidth: 1000,
+        windowHeight: 1000
+      };
+
+      const parentElementPosition = {
+        elBottom: 300,
+        elTop: 250,
+        elLeft: 250,
+        elRight: 300,
+        elHorizontalCenter: 325,
+        elWidth: 50,
+        offsetTop: 0,
+        clientHeight: 1000,
+        offsetLeft: 0,
+        clientWidth: 1000
+      };
+
+      const reduce = {
+        top: 0,
+        bottom: 0
+      };
+
+      it("calculate position for tooltip should be ABOVE parent element when preferTop = true", () => {
+        const tree = renderer.create(<Tooltip preferTop />).getInstance();
+        expect(
+          tree.calculatePosition({
+            direction: "auto",
+            position: parentElementPosition,
+            reduce,
+            spaceFromMouse: 10,
+            dimensions: tooltipDimensions
+          })
+        ).toEqual({
+          x: 225,
+          y: 240
+        });
+      });
+
+      it("calculate position for tooltip should be BELOW parent element when preferTop = false", () => {
+        const tree = renderer.create(<Tooltip />).getInstance();
+        expect(
+          tree.calculatePosition({
+            direction: "auto",
+            position: parentElementPosition,
+            reduce,
+            spaceFromMouse: 10,
+            dimensions: tooltipDimensions
+          })
+        ).toEqual({
+          x: 225,
+          y: 410
+        });
+      });
+    });
   });
 
   it("getDimensionsFromEvent should return calculated position props from event target", () => {

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -112,24 +112,36 @@ class Tooltip extends Component {
       preferTop
     });
 
-    const { actualDirection, arrowAdjustment } = this.state;
-
     const adjustment = this.adjustArrow({
       coords: { x: result.x, width: dimensions.width },
       position
     });
 
-    if (
-      result.y < position.elTop + dimensions.windowScroll &&
-      (actualDirection !== TOP || arrowAdjustment !== adjustment)
-    ) {
-      this.setState({ actualDirection: TOP, arrowAdjustment: adjustment });
-    } else if (
-      result.y > position.elTop + dimensions.windowScroll &&
-      (actualDirection !== BOTTOM || arrowAdjustment !== adjustment)
-    ) {
-      this.setState({ actualDirection: BOTTOM, arrowAdjustment: adjustment });
+    let direction = null;
+
+    if (result.y < position.elTop + dimensions.windowScroll) {
+      direction = TOP;
+    } else if (result.y > position.elTop + dimensions.windowScroll) {
+      direction = BOTTOM;
     }
+
+    this.setState((prevState, props) => {
+      const { directionChanged } = props;
+      const { actualDirection, arrowAdjustment } = prevState;
+
+      if (actualDirection !== direction || arrowAdjustment !== adjustment) {
+        if (direction && directionChanged) {
+          directionChanged(direction);
+        }
+
+        return {
+          actualDirection: direction || actualDirection,
+          arrowAdjustment: adjustment
+        };
+      }
+
+      return null;
+    });
 
     return result;
   };
@@ -374,7 +386,8 @@ Tooltip.propTypes = {
   spaceFromMouse: PropTypes.number,
   reduceTop: PropTypes.number,
   reduceBottom: PropTypes.number,
-  preferTop: PropTypes.bool
+  preferTop: PropTypes.bool,
+  directionChanged: PropTypes.func
 };
 
 Tooltip.defaultProps = {
@@ -393,7 +406,8 @@ Tooltip.defaultProps = {
   spaceFromMouse: SPACE_FROM_MOUSE,
   reduceTop: 0,
   reduceBottom: 0,
-  preferTop: false
+  preferTop: false,
+  directionChanged: null
 };
 
 Tooltip.displayName = "Tooltip";

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -102,12 +102,16 @@ class Tooltip extends Component {
     spaceFromMouse,
     reduce
   }) => {
+    const { preferTop } = this.props;
+
     const result = PopOver.calculatePosition({
       position,
       dimensions,
       spaceFromMouse,
-      reduce
+      reduce,
+      preferTop
     });
+
     const { actualDirection, arrowAdjustment } = this.state;
 
     const adjustment = this.adjustArrow({
@@ -369,7 +373,8 @@ Tooltip.propTypes = {
   variant: PropTypes.oneOf(VARIANTS),
   spaceFromMouse: PropTypes.number,
   reduceTop: PropTypes.number,
-  reduceBottom: PropTypes.number
+  reduceBottom: PropTypes.number,
+  preferTop: PropTypes.bool
 };
 
 Tooltip.defaultProps = {
@@ -387,7 +392,8 @@ Tooltip.defaultProps = {
   },
   spaceFromMouse: SPACE_FROM_MOUSE,
   reduceTop: 0,
-  reduceBottom: 0
+  reduceBottom: 0,
+  preferTop: false
 };
 
 Tooltip.displayName = "Tooltip";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Currently when tooltip prop `direction` is set to `auto`, the tooltip defaults to displaying to BOTTOM (below the parent element) space permitting.  Adding the boolean prop `preferTop = true` will cause the tooltip to display to TOP (above parent element) space permitting

an additional `directionChanged` prop has been added to allow the addition passing a callback function that will be triggered when the `actualDirection` state changes.  this will allow the parent component to register the direction of the tooltip display on re-render

**Why**:

This is to support tooltips being used in the ISM / Supermap

**How**:


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
