### PR TITLE
feat(Text): add more available tags

### DIFF
--- a/catalog/pages/typography/index.md
+++ b/catalog/pages/typography/index.md
@@ -56,7 +56,7 @@ rows:
   - Prop: tag
     Type: string
     Default: div
-    Notes: Determines the tag of the underlying element. One of "div", "span", "p", "h3", "h4", "h5", and "h6".
+    Notes: Determines the tag of the underlying element. One of "div", "span", "p", "h1", "h2", "h3", "h4", "h5", and "h6".
   - Prop: variant
     Type: string
     Default: dark

--- a/src/components/Text/Base.js
+++ b/src/components/Text/Base.js
@@ -8,7 +8,7 @@ import { themeShape } from "../../utils/getThemeValue";
 import { getResponsiveSize } from "../../utils/responsiveSize";
 import { THEME_TM } from "../../theme/constants";
 
-const AVAILABLE_TAGS = ["div", "span", "p", "h3", "h4", "h5", "h6"];
+const AVAILABLE_TAGS = ["div", "span", "p", "h1", "h2", "h3", "h4", "h5", "h6"];
 
 const TextBase = ({
   tag,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add `h1` and `h2` tags to whitelist for the `Text` component.
<!-- Why are these changes necessary? -->

**Why**:
Sometimes we have to render this component as H2 tag, but since this tag is not in the whitelist it causes some warnings in console. 
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
