### PR TITLE
fix(DropDownGroup): disable search when keywordSearch is false

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -62,6 +62,7 @@ class DropDownGroup extends React.Component {
 
   onKeyDown = e => {
     const { keyCode } = e;
+    const { keywordSearch } = this.props;
     const { isOpen } = this.state;
 
     switch (keyCode) {
@@ -88,7 +89,7 @@ class DropDownGroup extends React.Component {
         this.toggleDropdown();
         break;
       default:
-        if (!isOpen) {
+        if (!isOpen && keywordSearch) {
           this.searchKeyWord(e);
         }
         break;
@@ -292,7 +293,7 @@ class DropDownGroup extends React.Component {
                           }
                         )}
                       >
-                        {/* HiddenLabel is required for correct screen readers 
+                        {/* HiddenLabel is required for correct screen readers
                         readings when an option is selected */}
                         <HiddenLabel id={hiddenLabelId}>
                           {placeholder || label}

--- a/src/components/Input/__tests__/DropDownGroup.spec.js
+++ b/src/components/Input/__tests__/DropDownGroup.spec.js
@@ -169,14 +169,27 @@ describe("DropDownGroup", () => {
   });
 
   it("Typing search word should select proper value", () => {
-    const { container, getByTestId } = renderTestComponentOne();
+    const { getByTestId, queryAllByText } = renderTestComponentOne();
 
     fireEvent.keyDown(getByTestId("test-dropContainer"), {
       key: "s",
       keyCode: 83,
       which: 83
     });
-    expect(container.firstChild).toMatchSnapshot();
+    expect(queryAllByText("Second Option")).toMatchSnapshot();
+  });
+
+  it("When search disabled typing search word should NOT select any value", () => {
+    const { getByTestId, queryAllByText } = renderTestComponentOne({
+      keywordSearch: false
+    });
+
+    fireEvent.keyDown(getByTestId("test-dropContainer"), {
+      key: "s",
+      keyCode: 83,
+      which: 83
+    });
+    expect(queryAllByText("Second Option")).toMatchSnapshot();
   });
 
   it("Click outside should close the dropdown", () => {

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -4563,191 +4563,8 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
 `;
 
 exports[`DropDownGroup Typing search word should select proper value 1`] = `
-.c1 {
-  height: 44px;
-  background-color: rgba(255,255,255,1);
-  border-radius: 2px;
-  position: relative;
-  padding: 0px;
-  box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  cursor: pointer;
-  -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease 0.3s;
-  transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease 0.3s;
-  z-index: 0;
-}
-
-.c1.dropdown--small {
-  height: 36px;
-}
-
-.c1.full-width {
-  width: 100%;
-}
-
-.c1.dropdown--border {
-  border: solid 1px #999999;
-  padding: 1px;
-  text-align: left;
-}
-
-.c1.dropdown--no-border {
-  border: solid 2px rgba(255,255,255,1);
-  text-align: right;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1.dropdown--active {
-  margin: 0;
-  padding: 1px;
-  border: solid 1px #999999;
-  border-radius: 2px;
-  z-index: 10;
-  -webkit-transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
-  transition: border-color 0.3s cubic-bezier(0.455,0.03,0.515,0.955), z-index 0s ease;
-}
-
-.dropdown--disabled .c1 {
-  cursor: not-allowed;
-  color: rgba(38,38,38,0.4);
-  -webkit-transition: none;
-  transition: none;
-}
-
-.dropdown--disabled .c1:not(.dropdown--no-border) {
-  border-color: rgba(38,38,38,0.4);
-}
-
-.dropdown--disabled .c1 .dropdown__chevron--disabled {
-  opacity: 0.4;
-}
-
-.dropdown--open-upward .c1 {
-  border-radius: 2px;
-  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-}
-
-.c1:hover:not(.dropdown__label--disabled) {
-  border: solid 2px #026cdf;
-  padding: 0;
-}
-
-.c6 {
-  position: absolute;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  background-color: rgba(255,255,255,1);
-  border-radius: 2px;
-  white-space: nowrap;
-  margin-top: 2px;
-  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-  box-sizing: border-box;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  width: auto;
-  overflow: hidden;
-  z-index: 9;
-  border-color: #999999;
-  border-style: solid;
-  border-width: 0;
-  max-height: 0;
-  -webkit-transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
-  transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s ease 0.3s,padding-top 0s ease 0.3s, padding-bottom 0s ease 0.3s;
-}
-
-.c6:focus {
-  box-shadow: 0 0 5px 0 #026cdf;
-}
-
-.c6.dropdown--clicked {
-  padding-top: 4px;
-  padding-bottom: 8px;
-  border-width: 1px;
-  max-height: 606px;
-  -webkit-transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
-  transition: max-height 0.3s cubic-bezier(0.455,0.03,0.515,0.955), border-width 0s,padding-top 0s,padding-bottom 0s;
-}
-
-.c6.dropdown--overflow {
-  overflow-y: auto;
-}
-
-.dropdown--open-upward .c6 {
-  bottom: 46px;
-  border-radius: 2px;
-  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.12);
-}
-
-.dropdown--open-upward .c6.dropdown__items--small {
-  bottom: 35px;
-}
-
-.c2 {
-  display: none;
-}
-
-.c0 {
-  position: relative;
-  display: inline-block;
-  color: #262626;
-  outline: none;
-  border-radius: 2px;
-}
-
-.c0:focus {
-  box-shadow: 0 0 5px 0 #026cdf;
-}
-
-.c0.full-width {
-  width: 100%;
-  display: block;
-}
-
-.c5 {
-  color: #999999;
-  -webkit-transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  transition: opacity 0.1s cubic-bezier(0.455,0.03,0.515,0.955);
-  margin-right: 14px;
-  min-width: 16px;
-}
-
-.dropdown--small .c5 {
-  margin-right: 14px;
-}
-
-.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
-  margin-right: 14px;
-}
-
-.dropdown--small.dropdown--border:hover .c5:not(.dropdown__chevron--disabled) {
-  margin-right: 12px;
-}
-
-.c5.dropdown__icon--hide {
-  opacity: 0;
-}
-
-.c4 {
+Array [
+  .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4764,83 +4581,66 @@ exports[`DropDownGroup Typing search word should select proper value 1`] = `
   margin: 0 14px;
 }
 
-.dropdown--small .c4 {
+.dropdown--small .c1 {
   font-size: 14px;
   margin: 0 12px;
 }
 
-.dropdown--large .c4 {
+.dropdown--large .c1 {
   font-size: 16px;
 }
 
-.dropdown--no-border .c4 {
+.dropdown--no-border .c1 {
   margin-right: 14px;
 }
 
-.dropdown--no-border .c4.dropdown--small .dropdown--no-border .c3 {
+.dropdown--no-border .c1.dropdown--small .dropdown--no-border .c0 {
   margin-left: 12px;
 }
 
-.dropdown--large.dropdown--border .c4 {
+.dropdown--large.dropdown--border .c1 {
   margin-left: 14px;
 }
 
-.dropdown--small.dropdown--border .c4 {
+.dropdown--small.dropdown--border .c1 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border .c4 {
+.dropdown--active.dropdown--no-border .c1 {
   margin-right: 14px;
 }
 
-.dropdown--active.dropdown--no-border .c4.dropdown--small .dropdown--active.dropdown--no-border .c3 {
+.dropdown--active.dropdown--no-border .c1.dropdown--small .dropdown--active.dropdown--no-border .c0 {
   margin-left: 12px;
 }
 
-.dropdown--active.dropdown--no-border:hover .c4:not(.dropdown__text--disabled) {
+.dropdown--active.dropdown--no-border:hover .c1:not(.dropdown__text--disabled) {
   margin-right: 14px;
 }
 
-.dropdown--small.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+.dropdown--small.dropdown--border:hover .c1:not(.dropdown__text--disabled) {
   margin-left: 12px;
 }
 
-.dropdown--large.dropdown--border:hover .c4:not(.dropdown__text--disabled) {
+.dropdown--large.dropdown--border:hover .c1:not(.dropdown__text--disabled) {
   margin-left: 14px;
 }
 
-.c4 svg {
+.c1 svg {
   margin-right: 12px;
 }
 
-.c7 {
-  min-height: -webkit-min-content;
-  min-height: -moz-min-content;
-  min-height: min-content;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  opacity: 0;
-  -webkit-transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
-  transition: opacity 0.3s cubic-bezier(0.455,0.03,0.515,0.955);
-}
-
-.dropdown--clicked .c7 {
-  -webkit-transition-delay: 0.1s;
-  transition-delay: 0.1s;
-  opacity: 1;
-}
-
-.c8 {
+<div
+    class="c0 c1"
+  >
+    Second Option
+  </div>,
+  .c0 {
   cursor: pointer;
   box-sizing: border-box;
 }
 
-.dropdown__items .c8 {
+.dropdown__items .c0 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -4861,121 +4661,104 @@ exports[`DropDownGroup Typing search word should select proper value 1`] = `
   line-height: 1.25;
 }
 
-.dropdown__items .c8:focus {
+.dropdown__items .c0:focus {
   background-color: #026cdf;
   color: rgba(255,255,255,1);
   outline: none;
   border-radius: 2px;
 }
 
-.dropdown__items .c8.dropdown__selected {
+.dropdown__items .c0.dropdown__selected {
   color: #262626;
   background-color: #ebebeb;
   border-radius: 2px;
 }
 
-.dropdown__items.dropdown__items--small .c8 {
+.dropdown__items.dropdown__items--small .c0 {
   height: 32px;
   font-size: 14px;
   line-height: 1.3;
 }
 
-.dropdown__items.dropdown__items--large .c8 {
+.dropdown__items.dropdown__items--large .c0 {
   font-size: 16px;
 }
 
-<div
-  data-testid="test-outSideComponent"
->
-  <div
-    data-testid="something"
+<span
+    aria-selected="true"
+    class="dropdown__selected c0"
+    data-testid="test-dropDownOptionTwo"
+    role="option"
+    tabindex="-1"
+    value="ValueTwo"
   >
-    something
-  </div>
-  <div
-    aria-haspopup="listbox"
-    aria-labelledby="hidden-label__"
+    Second Option
+  </span>,
+]
+`;
+
+exports[`DropDownGroup When search disabled typing search word should NOT select any value 1`] = `
+Array [
+  .c0 {
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.dropdown__items .c0 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  height: 36px;
+  margin: 4px 8px 0 8px;
+  padding: 7px 10px;
+  font-size: 14px;
+  text-align: left;
+  border: none;
+  background-color: rgba(255,255,255,1);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  color: #262626;
+  line-height: 1.25;
+}
+
+.dropdown__items .c0:focus {
+  background-color: #026cdf;
+  color: rgba(255,255,255,1);
+  outline: none;
+  border-radius: 2px;
+}
+
+.dropdown__items .c0.dropdown__selected {
+  color: #262626;
+  background-color: #ebebeb;
+  border-radius: 2px;
+}
+
+.dropdown__items.dropdown__items--small .c0 {
+  height: 32px;
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.dropdown__items.dropdown__items--large .c0 {
+  font-size: 16px;
+}
+
+<span
+    aria-selected="false"
     class="c0"
-    data-testid="test-dropContainer"
-    tabindex="0"
+    data-testid="test-dropDownOptionTwo"
+    role="option"
+    tabindex="-1"
+    value="ValueTwo"
   >
-    <label
-      class="dropdown__label dropdown--large dropdown--border c1"
-    >
-      <span
-        class="c2"
-        id="hidden-label__"
-      />
-      <div
-        class="c3 c4"
-      >
-        Second Option
-      </div>
-      <svg
-        class="c5"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g
-          fill="none"
-          fill-rule="evenodd"
-        >
-          <path
-            d="M16 0H0v16h16z"
-          />
-          <path
-            d="M3.278 5.459A.75.75 0 0 0 2.221 6.52l5.263 5.24a.75.75 0 0 0 1.059 0L13.78 6.52a.75.75 0 0 0-1.06-1.06l-4.71 4.711L3.278 5.46z"
-            fill="#262626"
-            fill-opacity=".65"
-            fill-rule="nonzero"
-          />
-        </g>
-      </svg>
-    </label>
-    <div
-      class="dropdown__items dropdown__items--large c6"
-    >
-      <div
-        aria-labelledby="hidden-label__"
-        class="c7"
-        role="listbox"
-      >
-        <span
-          aria-selected="false"
-          class="c8"
-          data-testid="test-dropDownOptionOne"
-          role="option"
-          tabindex="-1"
-          value="ValueOne"
-        >
-          Option One
-        </span>
-        <span
-          aria-selected="true"
-          class="dropdown__selected c8"
-          data-testid="test-dropDownOptionTwo"
-          role="option"
-          tabindex="-1"
-          value="ValueTwo"
-        >
-          Second Option
-        </span>
-        <span
-          aria-selected="false"
-          class="c8"
-          data-testid="test-dropDownOptionThree"
-          role="option"
-          tabindex="-1"
-          value="ValueThree"
-        >
-          Option Three
-        </span>
-      </div>
-    </div>
-  </div>
-</div>
+    Second Option
+  </span>,
+]
 `;
 
 exports[`DropDownGroup renders bordered variant with an inner label with a placeholder prop 1`] = `


### PR DESCRIPTION
**What**:

Allow developer to disable search by keyword by passing keywordSearch props as false

**Why**:

Developer might need to disable functionality. Also feature is broken when passing something different than string as child to the DropDownOption

**How**:

Do not trigger the search if keywordSearch is false.

**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Ready to be merged
