### PR TITLE
fix(Input): Define style for textarea `font-family:inherit` so that i…

### DIFF
--- a/src/components/Input/Input.styles.js
+++ b/src/components/Input/Input.styles.js
@@ -75,6 +75,7 @@ export const FieldInputBox = styled.input.attrs({
     min-height: 180px;
     padding-top: 11px;
     padding-bottom: 11px;
+    font-family: inherit;
   }
 
   &.text--input-left {

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.js.snap
@@ -63,6 +63,7 @@ textarea.c2 {
   min-height: 180px;
   padding-top: 11px;
   padding-bottom: 11px;
+  font-family: inherit;
 }
 
 .c2.text--input-left {
@@ -283,6 +284,7 @@ textarea.c2 {
   min-height: 180px;
   padding-top: 11px;
   padding-bottom: 11px;
+  font-family: inherit;
 }
 
 .c2.text--input-left {
@@ -504,6 +506,7 @@ textarea.c2 {
   min-height: 180px;
   padding-top: 11px;
   padding-bottom: 11px;
+  font-family: inherit;
 }
 
 .c2.text--input-left {
@@ -726,6 +729,7 @@ textarea.c2 {
   min-height: 180px;
   padding-top: 11px;
   padding-bottom: 11px;
+  font-family: inherit;
 }
 
 .c2.text--input-left {
@@ -981,6 +985,7 @@ textarea.c3 {
   min-height: 180px;
   padding-top: 11px;
   padding-bottom: 11px;
+  font-family: inherit;
 }
 
 .c3.text--input-left {
@@ -1208,6 +1213,7 @@ textarea.c2 {
   min-height: 180px;
   padding-top: 11px;
   padding-bottom: 11px;
+  font-family: inherit;
 }
 
 .c2.text--input-left {
@@ -1428,6 +1434,7 @@ textarea.c2 {
   min-height: 180px;
   padding-top: 11px;
   padding-bottom: 11px;
+  font-family: inherit;
 }
 
 .c2.text--input-left {
@@ -1649,6 +1656,7 @@ textarea.c2 {
   min-height: 180px;
   padding-top: 11px;
   padding-bottom: 11px;
+  font-family: inherit;
 }
 
 .c2.text--input-left {


### PR DESCRIPTION
**What**:

Add styles for `textarea` inputs to inherit the font family.

**Why**:

So that it works correctly in shadow dom trees.

**How**:

Inheriting the same font as the rest of the document

**Checklist**:

* [x] Documentation N/A
* [x] Tests
* [x] Ready to be merged 
