### PR TITLE
feat(QtySelector): add aria-label to quantity selector buttons

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -919,6 +919,14 @@ rows:
     Type: function
     Default:
     Notes: call back function when value is updated either by buttons or keyboard. Use this function instead of onChange.
+  - Prop: incrementBtnLabel
+    Type: string
+    Default: Increase Quantity
+    Notes: Aria label of the Increment button for accessibility requirement
+  - Prop: decrementBtnLabel
+    Type: string
+    Default: Decrease Quantity
+    Notes: Aria label of the Decrement button for accessibility requirement
 ```
 
 It also accepts any event handlers. e.g. `onBlur`, `onFocus` etc. as well as styles object.

--- a/src/components/Input/QtySelector/QtySelector.js
+++ b/src/components/Input/QtySelector/QtySelector.js
@@ -34,7 +34,9 @@ class QtySelector extends Component {
     style: PropTypes.objectOf(PropTypes.string),
     min: PropTypes.number,
     max: PropTypes.number,
-    onValueUpdated: PropTypes.func
+    onValueUpdated: PropTypes.func,
+    incrementBtnLabel: PropTypes.string,
+    decrementBtnLabel: PropTypes.string
   };
 
   static defaultProps = {
@@ -43,7 +45,9 @@ class QtySelector extends Component {
     value: 0,
     min: QtySelector.MIN_INPUT_VALUE,
     max: QtySelector.MAX_INPUT_VALUE,
-    onValueUpdated: () => {}
+    onValueUpdated: () => {},
+    incrementBtnLabel: "Increase Quantity",
+    decrementBtnLabel: "Decrease Quantity"
   };
 
   state = {
@@ -156,20 +160,36 @@ class QtySelector extends Component {
   };
 
   render() {
-    const { disabled, min, max } = this.props;
+    const {
+      disabled,
+      min,
+      max,
+      decrementBtnLabel,
+      incrementBtnLabel
+    } = this.props;
     const { value } = this.state;
 
     return (
       <Container>
-        <Button onClick={this.decrement} disabled={disabled || min === value}>
+        <Button
+          onClick={this.decrement}
+          disabled={disabled || min === value}
+          aria-label={decrementBtnLabel}
+        >
           <QtySelectorMinusIcon />
         </Button>
         <InputFieldContainer
-          className={classNames({ InputFieldContainer__disabled: disabled })}
+          className={classNames({
+            InputFieldContainer__disabled: disabled
+          })}
         >
           {this.renderInput()}
         </InputFieldContainer>
-        <Button onClick={this.increment} disabled={disabled || max === value}>
+        <Button
+          onClick={this.increment}
+          disabled={disabled || max === value}
+          aria-label={incrementBtnLabel}
+        >
           <QtySelectorPlusIcon />
         </Button>
       </Container>

--- a/src/components/Input/__tests__/__snapshots__/QtySelector.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/QtySelector.spec.js.snap
@@ -167,6 +167,7 @@ exports[`QtySelector decrements correctly 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -797,6 +798,7 @@ exports[`QtySelector decrements correctly 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -991,6 +993,7 @@ exports[`QtySelector decrements from non-zero value correctly 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -1621,6 +1624,7 @@ exports[`QtySelector decrements from non-zero value correctly 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -1815,6 +1819,7 @@ exports[`QtySelector decrements twice correctly 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -2445,6 +2450,7 @@ exports[`QtySelector decrements twice correctly 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -2639,6 +2645,7 @@ exports[`QtySelector handles case when input is deleted 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -3268,6 +3275,7 @@ exports[`QtySelector handles case when input is deleted 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -3462,6 +3470,7 @@ exports[`QtySelector handles input value correctly 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -4091,6 +4100,7 @@ exports[`QtySelector handles input value correctly 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -4285,6 +4295,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -4915,6 +4926,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -5109,6 +5121,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly when usin
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -5738,6 +5751,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly when usin
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -5933,6 +5947,7 @@ exports[`QtySelector increments correctly 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -6562,6 +6577,7 @@ exports[`QtySelector increments correctly 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -6756,6 +6772,7 @@ exports[`QtySelector increments twice correctly 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -7385,6 +7402,7 @@ exports[`QtySelector increments twice correctly 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -7579,6 +7597,7 @@ exports[`QtySelector renders QtySelector correctly when there are min and max 1`
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -7638,6 +7657,7 @@ exports[`QtySelector renders QtySelector correctly when there are min and max 1`
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -7832,6 +7852,7 @@ exports[`QtySelector renders default QtySelector 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -8462,6 +8483,7 @@ exports[`QtySelector renders default QtySelector 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -8656,6 +8678,7 @@ exports[`QtySelector renders disabled QtySelector 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -9386,6 +9409,7 @@ exports[`QtySelector renders disabled QtySelector 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -9581,6 +9605,7 @@ exports[`QtySelector sets focus state to false when input looses focus 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -10211,6 +10236,7 @@ exports[`QtySelector sets focus state to false when input looses focus 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg
@@ -10405,6 +10431,7 @@ exports[`QtySelector sets focus state to true after input is focused 1`] = `
   class="c0"
 >
   <button
+    aria-label="Decrease Quantity"
     class="c1 c2  noFocus"
     disabled=""
   >
@@ -10440,6 +10467,7 @@ exports[`QtySelector sets focus state to true after input is focused 1`] = `
     />
   </div>
   <button
+    aria-label="Increase Quantity"
     class="c1 c2  noFocus"
   >
     <svg


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The – and + icons for quantity selectors do not provide accessible alternative text. Ensure these buttons provide descriptive text, such as "Decrease Quantity".

<!-- Why are these changes necessary? -->

**Why**:
**Severity 1 – WCAG 1.1.1 (Non-text Content – Level A)**
<!-- How were these changes implemented? -->

**How**:
Add aria-label property to satisfy the NFB requirements

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
