### PR TITLE
fix(dropdown): fix dropdown keyword search

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -89,7 +89,7 @@ class DropDownGroup extends React.Component {
         this.toggleDropdown();
         break;
       default:
-        if (!isOpen && keywordSearch) {
+        if (keywordSearch) {
           this.searchKeyWord(e);
         }
         break;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Search not working properly when dropdown is open as the keyword entered by user is never cleared as it does in keyword search when dropdown is closed.

<!-- Why are these changes necessary? -->

**Why**:

When dropdown is open, user can only search a keyword once. Ex: If i started my search with letter K, I can only add character to it. I can't backspace and search for a new keyword.

<!-- How were these changes implemented? -->

**How**:

I have cleared the keyword after 1s as it is already being done for keyword search when dropdown is closed.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
