### PR TITLE
feat(Banner): Add an ability to pass custom styles to the ContentSect…

### DIFF
--- a/catalog/pages/banner/index.md
+++ b/catalog/pages/banner/index.md
@@ -61,6 +61,10 @@ rows:
     Type: node
     Default: none
     Notes: Allows to pass a custom Icon
+  - Prop: contentSectionCss
+    Type: css string
+    Default: none
+    Notes: Allows to pass a css string with custom styles to extend the content section block styles
 ```
 
 ```react

--- a/src/components/Banner/index.js
+++ b/src/components/Banner/index.js
@@ -32,6 +32,7 @@ class Banner extends Component {
     linkProps: PropTypes.shape(),
     buttonProps: PropTypes.shape(),
     style: PropTypes.shape(),
+    contentSectionCss: PropTypes.string,
     variant: PropTypes.oneOf(variants),
     icon: PropTypes.node,
     closeButtonTitleText: PropTypes.string,
@@ -57,6 +58,7 @@ class Banner extends Component {
     style: {
       transition: `max-height 0.3s ${constants.easing.easeInOutQuad} 0s`
     },
+    contentSectionCss: "",
     variant: null,
     icon: null,
     closeButtonTitleText: "Close banner",
@@ -173,6 +175,7 @@ class Banner extends Component {
       content,
       variant,
       style,
+      contentSectionCss,
       customColors
     } = this.props;
     const { isExpanded, maxHeight } = this.state;
@@ -194,7 +197,7 @@ class Banner extends Component {
             customColors={this.isCustomVariant() && customColors}
           >
             <IconSection>{this.renderIcon()}</IconSection>
-            <ContentSection>
+            <ContentSection css={contentSectionCss}>
               <HeaderText
                 tag="span"
                 weight="semiBold"


### PR DESCRIPTION
…ion block

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added an ability to extend styles of the ContentSction styled component of the Banner

**Why**:

Our project uses aurora as a component lib and highly integrated with it, but recently we've got a UI bug related to the right padding in the Banner. According to our design, there shouldn't be right padding, and It appeared that the right padding value is hardcoded in Aurora
https://github.com/ticketmaster/aurora/blob/441a55db73cd63e31a7011943fae2195376ab111/src/components/Banner/Banner.styles.js#L62
so, as a solution to be able to extend the styles, this PR was created


**How**:

Added a new prop to pass the styles. Because this section is a styled component, we needed to use css prop to pass arbitrary data instead of the approach with passing style prop with an object value

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
