### PR TITLE
fix(button): add font-family "inherit" style property

### DIFF
--- a/src/components/Button/Base.styles.tsx
+++ b/src/components/Button/Base.styles.tsx
@@ -96,6 +96,7 @@ interface StyledButtonProps {
 const getPadding = ({ size }) => SIZES[size].padding;
 
 export const StyledButton = styled.button<StyledButtonProps>`
+  font-family: inherit;
   font-weight: ${typography.weight.semiBold};
   font-size: ${({ size }) => SIZES[size].fontSize};
   line-height: ${({ size }) => SIZES[size].lineHeight};

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`<Button /> renders link button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -72,6 +73,7 @@ exports[`<Button /> renders link button correctly 1`] = `
 
 exports[`<Button /> renders outline large size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 16px;
   line-height: 2.63;
@@ -138,6 +140,7 @@ exports[`<Button /> renders outline large size button correctly 1`] = `
 
 exports[`<Button /> renders outline regular size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -204,6 +207,7 @@ exports[`<Button /> renders outline regular size button correctly 1`] = `
 
 exports[`<Button /> renders outline regular size disabled button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -271,6 +275,7 @@ exports[`<Button /> renders outline regular size disabled button correctly 1`] =
 
 exports[`<Button /> renders outline small size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 12px;
   line-height: 1.84;
@@ -337,6 +342,7 @@ exports[`<Button /> renders outline small size button correctly 1`] = `
 
 exports[`<Button /> renders special large size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 16px;
   line-height: 2.63;
@@ -403,6 +409,7 @@ exports[`<Button /> renders special large size button correctly 1`] = `
 
 exports[`<Button /> renders special regular size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -469,6 +476,7 @@ exports[`<Button /> renders special regular size button correctly 1`] = `
 
 exports[`<Button /> renders special regular size disabled button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -536,6 +544,7 @@ exports[`<Button /> renders special regular size disabled button correctly 1`] =
 
 exports[`<Button /> renders special small size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 12px;
   line-height: 1.84;
@@ -602,6 +611,7 @@ exports[`<Button /> renders special small size button correctly 1`] = `
 
 exports[`<Button /> renders standard large size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 16px;
   line-height: 2.63;
@@ -668,6 +678,7 @@ exports[`<Button /> renders standard large size button correctly 1`] = `
 
 exports[`<Button /> renders standard regular size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -734,6 +745,7 @@ exports[`<Button /> renders standard regular size button correctly 1`] = `
 
 exports[`<Button /> renders standard regular size disabled button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -801,6 +813,7 @@ exports[`<Button /> renders standard regular size disabled button correctly 1`] 
 
 exports[`<Button /> renders standard small size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 12px;
   line-height: 1.84;
@@ -867,6 +880,7 @@ exports[`<Button /> renders standard small size button correctly 1`] = `
 
 exports[`<Button /> renders transparent large size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 16px;
   line-height: 2.63;
@@ -933,6 +947,7 @@ exports[`<Button /> renders transparent large size button correctly 1`] = `
 
 exports[`<Button /> renders transparent regular size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -999,6 +1014,7 @@ exports[`<Button /> renders transparent regular size button correctly 1`] = `
 
 exports[`<Button /> renders transparent regular size disabled button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -1066,6 +1082,7 @@ exports[`<Button /> renders transparent regular size disabled button correctly 1
 
 exports[`<Button /> renders transparent small size button correctly 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 12px;
   line-height: 1.84;

--- a/src/components/ButtonWithLoading/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/ButtonWithLoading/__tests__/__snapshots__/index.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`ButtonWithLoading should match snapshot 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -126,6 +127,7 @@ exports[`ButtonWithLoading should match snapshot 1`] = `
 
 exports[`ButtonWithLoading should match snapshot with default values 1`] = `
 .c0 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;

--- a/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/CalendarView/__tests__/__snapshots__/index.spec.js.snap
@@ -196,6 +196,7 @@ exports[`CalendarView should render without errors 1`] = `
 }
 
 .c24 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 12px;
   line-height: 1.84;

--- a/src/components/Input/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -40,6 +40,7 @@ Object {
 }
 
 .c8 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -299,6 +300,7 @@ Object {
 }
 
 .c8 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;

--- a/src/components/Input/__tests__/__snapshots__/QtySelector.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/QtySelector.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`QtySelector decrements correctly 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -828,6 +829,7 @@ exports[`QtySelector decrements correctly 1`] = `
 
 exports[`QtySelector decrements from non-zero value correctly 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -1654,6 +1656,7 @@ exports[`QtySelector decrements from non-zero value correctly 1`] = `
 
 exports[`QtySelector decrements twice correctly 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -2480,6 +2483,7 @@ exports[`QtySelector decrements twice correctly 1`] = `
 
 exports[`QtySelector handles case when input is deleted 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -3305,6 +3309,7 @@ exports[`QtySelector handles case when input is deleted 1`] = `
 
 exports[`QtySelector handles input value correctly 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -4130,6 +4135,7 @@ exports[`QtySelector handles input value correctly 1`] = `
 
 exports[`QtySelector handles input value longer than 2 chars correctly 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -4956,6 +4962,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly 1`] = `
 
 exports[`QtySelector handles input value longer than 2 chars correctly when using buttons 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -5782,6 +5789,7 @@ exports[`QtySelector handles input value longer than 2 chars correctly when usin
 
 exports[`QtySelector increments correctly 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -6607,6 +6615,7 @@ exports[`QtySelector increments correctly 1`] = `
 
 exports[`QtySelector increments twice correctly 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -7432,6 +7441,7 @@ exports[`QtySelector increments twice correctly 1`] = `
 
 exports[`QtySelector renders QtySelector correctly when there are min and max 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -7687,6 +7697,7 @@ exports[`QtySelector renders QtySelector correctly when there are min and max 1`
 
 exports[`QtySelector renders default QtySelector 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -8513,6 +8524,7 @@ exports[`QtySelector renders default QtySelector 1`] = `
 
 exports[`QtySelector renders disabled QtySelector 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -9440,6 +9452,7 @@ exports[`QtySelector renders disabled QtySelector 1`] = `
 
 exports[`QtySelector sets focus state to false when input looses focus 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -10266,6 +10279,7 @@ exports[`QtySelector sets focus state to false when input looses focus 1`] = `
 
 exports[`QtySelector sets focus state to true after input is focused 1`] = `
 .c1 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -232,6 +232,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -2764,6 +2765,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -5298,6 +5300,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -7830,6 +7833,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -10313,6 +10317,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -11488,6 +11493,7 @@ exports[`<ListContainer /> collapses the listRow after changing its order 1`] = 
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -14012,6 +14018,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -16653,6 +16660,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand Link 1`] =
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -19398,6 +19406,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -21922,6 +21931,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -24394,6 +24404,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -511,6 +511,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -1448,6 +1449,7 @@ exports[`<ListRow /> renders List Row with label correctly 1`] = `
 }
 
 .c22 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -2561,6 +2563,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -3543,6 +3546,7 @@ exports[`<ListRow /> renders List Row with styled button 1`] = `
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -4399,6 +4403,7 @@ exports[`<ListRow /> renders List Row with title correctly when expanded 1`] = `
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -5371,6 +5376,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;
@@ -6353,6 +6359,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
 }
 
 .c16 {
+  font-family: inherit;
   font-weight: 600;
   font-size: 14px;
   line-height: 2.43;


### PR DESCRIPTION
**What**:

Button should inherit font-family stylings

**Why**:

Fonts properties are not inherited for all form elements (button, input, select, textarea).

See: `Fonts and text` section on [MDN styling web forms](https://developer.mozilla.org/en-US/docs/Learn/Forms/Styling_web_forms)

**How**:

By explicitly define `font-family: inherit;`

**Checklist**:

* [ ] Documentation (N/A)
* [ ] Tests (N/A)
* [x] Ready to be merged
