### PR TITLE
fix(DropDownGroup): fix React warning for render() being not pure

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -50,6 +50,11 @@ class DropDownGroup extends React.Component {
     if (!this.props.isOpen && isOpen && isOpen !== prevState.isOpen) {
       this.styledChildWrapper.current.scrollTop = 0;
     }
+    const { value, valueOverride } = this.props;
+    const selected = Array.isArray(valueOverride) ? valueOverride : value;
+    if (selected && selected.length > 0) {
+      this.enableNavigation();
+    }
   }
 
   componentWillUnmount() {
@@ -175,10 +180,6 @@ class DropDownGroup extends React.Component {
 
   displayLabel = selected => {
     const { placeholder, label } = this.props;
-
-    if (selected.length > 0) {
-      this.enableNavigation();
-    }
 
     if (placeholder.length > 0 && selected.length === 0) {
       return placeholder;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix a bug in DropDownGroup component that causes a React warning in console (Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state)

<!-- Why are these changes necessary? -->

**Why**: To make sure component updates properly

<!-- How were these changes implemented? -->

**How**: To relocate part of logic within `render()` that contains `setState()` to lifecycle hook `componentDidUpdate`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

In `DropDownGroup` `render()` method, it calls `displayLabel()`, which in turn calls `enableNavigation()` and eventually invokes `setState()`, which is a violation of render method being pure function.
