### PR TITLE
fix(Tabs): add role presentation

### DIFF
--- a/src/components/Tabs/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Tabs/__tests__/__snapshots__/index.spec.js.snap
@@ -124,6 +124,7 @@ exports[`<Tabs /> should render tabs component correctly 1`] = `
     >
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="true"
@@ -140,6 +141,7 @@ exports[`<Tabs /> should render tabs component correctly 1`] = `
       </div>
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="false"
@@ -156,6 +158,7 @@ exports[`<Tabs /> should render tabs component correctly 1`] = `
       </div>
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="false"
@@ -288,6 +291,7 @@ exports[`<Tabs /> should render tabs component correctly when withBorderBottom e
     >
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="true"
@@ -304,6 +308,7 @@ exports[`<Tabs /> should render tabs component correctly when withBorderBottom e
       </div>
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="false"
@@ -320,6 +325,7 @@ exports[`<Tabs /> should render tabs component correctly when withBorderBottom e
       </div>
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="false"
@@ -464,6 +470,7 @@ exports[`<Tabs /> should render tabs component correctly with props for text of 
     >
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="true"
@@ -480,6 +487,7 @@ exports[`<Tabs /> should render tabs component correctly with props for text of 
       </div>
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="false"
@@ -496,6 +504,7 @@ exports[`<Tabs /> should render tabs component correctly with props for text of 
       </div>
       <div
         class="c2"
+        role="presentation"
       >
         <button
           aria-selected="false"

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -69,7 +69,9 @@ const Content = styled.div.attrs({
   }
 `;
 
-const Tab = styled.div`
+const Tab = styled.div.attrs({
+  role: "presentation"
+})`
   ${largeAndUp`
     padding-right: ${spacing.comfy};
   `};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add role presentation.

<!-- Why are these changes necessary? -->

**Why**: To allow proper voice over read on tabs.

<!-- How were these changes implemented? -->

**How**: Added `role: "presentation"` on the div containing tab button.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
