### PR TITLE
feat(Tabs): add navigation with arrow keys

### DIFF
--- a/catalog/pages/tabs/index.md
+++ b/catalog/pages/tabs/index.md
@@ -23,6 +23,10 @@ rows:
     Type: func(index)
     Default: ()=>{}
     Notes: Optional. Function that handles onclick event on item and takes index of item as an argument.
+  - Prop: tabChangedWithArrowKeys
+    Type: func(index)
+    Default: ()=>{}
+    Notes: Optional. This function is invoked when tab is changed with arrow keys. Takes index of item as an argument.
   - Prop: variant
     Type: bool
     Default: dark
@@ -70,6 +74,7 @@ responsive: true
           defaultItemProps={{'data-custom-info': 'someDefaultInfo'}}
           index={tabIndex}
           onClick={onChangeTabIndex()}
+          tabChangedWithArrowKeys={onChangeTabIndex()}
         />
         <Column>
         <Text weight="semiBold">Content for tab #{tabIndex + 1}</Text>
@@ -101,6 +106,7 @@ responsive: true
           defaultItemProps={{'data-custom-info': 'someDefaultInfo'}}
           index={tabIndex}
           onClick={onChangeTabIndex()}
+          tabChangedWithArrowKeys={onChangeTabIndex()}
           withBorderBottom={false}
           underlineColor={themes.global.white.base}
           style={{ color: themes.global.white.base }}

--- a/src/components/Tabs/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Tabs/__tests__/__snapshots__/index.spec.js.snap
@@ -131,6 +131,7 @@ exports[`<Tabs /> should render tabs component correctly 1`] = `
           class="c3 tab__button--active"
           data-index="0"
           role="tab"
+          tabindex="0"
         >
           <div
             class="c4 text text--primary"
@@ -148,6 +149,7 @@ exports[`<Tabs /> should render tabs component correctly 1`] = `
           class="c3"
           data-index="1"
           role="tab"
+          tabindex="-1"
         >
           <div
             class="c4 text text--primary"
@@ -165,6 +167,7 @@ exports[`<Tabs /> should render tabs component correctly 1`] = `
           class="c3"
           data-index="2"
           role="tab"
+          tabindex="-1"
         >
           <div
             class="c4 text text--primary"
@@ -298,6 +301,7 @@ exports[`<Tabs /> should render tabs component correctly when withBorderBottom e
           class="c3 tab__button--active"
           data-index="0"
           role="tab"
+          tabindex="0"
         >
           <div
             class="c4 text text--primary"
@@ -315,6 +319,7 @@ exports[`<Tabs /> should render tabs component correctly when withBorderBottom e
           class="c3"
           data-index="1"
           role="tab"
+          tabindex="-1"
         >
           <div
             class="c4 text text--primary"
@@ -332,6 +337,7 @@ exports[`<Tabs /> should render tabs component correctly when withBorderBottom e
           class="c3"
           data-index="2"
           role="tab"
+          tabindex="-1"
         >
           <div
             class="c4 text text--primary"
@@ -477,6 +483,7 @@ exports[`<Tabs /> should render tabs component correctly with props for text of 
           class="c3 tab__button--active"
           data-index="0"
           role="tab"
+          tabindex="0"
         >
           <div
             class="c4 text text--accent text--alert text--primary"
@@ -494,6 +501,7 @@ exports[`<Tabs /> should render tabs component correctly with props for text of 
           class="c3"
           data-index="1"
           role="tab"
+          tabindex="-1"
         >
           <div
             class="c4 text text--accent text--alert text--primary"
@@ -511,6 +519,7 @@ exports[`<Tabs /> should render tabs component correctly with props for text of 
           class="c3"
           data-index="2"
           role="tab"
+          tabindex="-1"
         >
           <div
             class="c4 text text--accent text--alert text--primary"

--- a/src/components/Tabs/__tests__/index.spec.js
+++ b/src/components/Tabs/__tests__/index.spec.js
@@ -1,10 +1,12 @@
 import React from "react";
+import renderer from "react-test-renderer";
 import { render, Simulate } from "react-testing-library";
 
 import { Tabs } from "../index";
 
 const items = ["Test tab item 1", "Test tab item 2", "Test tab item 3"];
 const onTabsClick = jest.fn();
+const tabChangedWithArrowKeysMock = jest.fn();
 const mainProps = {
   items,
   index: 0,
@@ -45,5 +47,97 @@ describe("<Tabs />", () => {
     Simulate.click(container.querySelector('button[data-index="1"]'));
     expect(onTabsClick).toHaveBeenLastCalledWith(1);
     unmount();
+  });
+
+  it("should call tabChangedWithArrowKeys with index of tab on right when right arrow key pressed", () => {
+    const { unmount, container } = render(
+      <Tabs
+        {...mainProps}
+        tabChangedWithArrowKeys={tabChangedWithArrowKeysMock}
+      />
+    );
+    Simulate.keyDown(container.querySelector('button[data-index="0"]'), {
+      key: "ArrowRight",
+      keyCode: 39
+    });
+    expect(tabChangedWithArrowKeysMock).toHaveBeenLastCalledWith(1);
+    unmount();
+  });
+
+  it("should call tabChangedWithArrowKeys with index of tab on left when left arrow key pressed", () => {
+    const { unmount, container } = render(
+      <Tabs
+        {...mainProps}
+        index="1"
+        tabChangedWithArrowKeys={tabChangedWithArrowKeysMock}
+      />
+    );
+    Simulate.keyDown(container.querySelector('button[data-index="1"]'), {
+      key: "ArrowLeft",
+      keyCode: 37
+    });
+    expect(tabChangedWithArrowKeysMock).toHaveBeenLastCalledWith(0);
+    unmount();
+  });
+
+  it("should call tabChangedWithArrowKeys with index of first tab when right arrow key pressed on last tab", () => {
+    const { unmount, container } = render(
+      <Tabs
+        {...mainProps}
+        index="2"
+        tabChangedWithArrowKeys={tabChangedWithArrowKeysMock}
+      />
+    );
+    Simulate.keyDown(container.querySelector('button[data-index="2"]'), {
+      key: "ArrowRight",
+      keyCode: 39
+    });
+    expect(tabChangedWithArrowKeysMock).toHaveBeenLastCalledWith(0);
+    unmount();
+  });
+
+  it("should call tabChangedWithArrowKeys with index of last tab when left arrow key pressed on first tab", () => {
+    const { unmount, container } = render(
+      <Tabs
+        {...mainProps}
+        tabChangedWithArrowKeys={tabChangedWithArrowKeysMock}
+      />
+    );
+    Simulate.keyDown(container.querySelector('button[data-index="0"]'), {
+      key: "ArrowLeft",
+      keyCode: 37
+    });
+    expect(tabChangedWithArrowKeysMock).toHaveBeenLastCalledWith(2);
+    unmount();
+  });
+
+  it("should call focusTab function when right arrow key pressed", () => {
+    const instance = renderer
+      .create(
+        <Tabs
+          {...mainProps}
+          tabChangedWithArrowKeys={tabChangedWithArrowKeysMock}
+        />
+      )
+      .getInstance();
+    const spyFocusTab = jest.spyOn(instance, "focusTab");
+    instance.onKeyDown({ keyCode: 39 });
+    expect(spyFocusTab).toHaveBeenLastCalledWith(1);
+    spyFocusTab.mockRestore();
+  });
+
+  it("should not call focusTab function when other key is pressed", () => {
+    const instance = renderer
+      .create(
+        <Tabs
+          {...mainProps}
+          tabChangedWithArrowKeys={tabChangedWithArrowKeysMock}
+        />
+      )
+      .getInstance();
+    const spyFocusTab = jest.spyOn(instance, "focusTab");
+    instance.onKeyDown({ keyCode: 40 });
+    expect(spyFocusTab).toHaveBeenCalledTimes(0);
+    spyFocusTab.mockRestore();
   });
 });

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -7,6 +7,7 @@ import { TabsProvider, TabsConsumer } from "./TabsProvider";
 import { Text } from "../Text";
 import { spacing, zIndex, themes } from "../../theme";
 import { largeAndUp, smallAndUp } from "../../theme/mediaQueries";
+import { ARROWRIGHT, ARROWLEFT } from "../../utils/keyCharCodes";
 
 const padding = spacing.moderate;
 
@@ -122,6 +123,7 @@ class Tabs extends Component {
     /* eslint-enable react/forbid-prop-types */
     index: PropTypes.number,
     onClick: PropTypes.func,
+    tabChangedWithArrowKeys: PropTypes.func,
     variant: PropTypes.string,
     accent: PropTypes.string,
     weight: PropTypes.string,
@@ -134,6 +136,7 @@ class Tabs extends Component {
     defaultItemProps: {},
     index: -1,
     onClick: () => {},
+    tabChangedWithArrowKeys: () => {},
     variant: null,
     accent: null,
     weight: null,
@@ -178,6 +181,40 @@ class Tabs extends Component {
     window.removeEventListener("resize", this.updateIsOverflowsState); //eslint-disable-line
   }
 
+  onKeyDown = e => {
+    const { keyCode } = e;
+    const { index, items } = this.props;
+
+    switch (keyCode) {
+      case ARROWRIGHT:
+        if (index < items.length - 1) {
+          this.focusTab(index + 1);
+        } else {
+          this.focusTab(0);
+        }
+        break;
+      case ARROWLEFT:
+        if (index > 0) {
+          this.focusTab(index - 1);
+        } else {
+          this.focusTab(items.length - 1);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  focusTab = index => {
+    const { tabChangedWithArrowKeys } = this.props;
+    if (this.itemRefs && this.itemRefs[index]) {
+      this.itemRefs[index].focus();
+      if (tabChangedWithArrowKeys) {
+        tabChangedWithArrowKeys(index);
+      }
+    }
+  };
+
   updateIsOverflowsState = () => {
     const isOverflows = checkIfOverflows(this.content);
     if (this.state.isTabsContainerOverflows !== isOverflows) {
@@ -209,8 +246,10 @@ class Tabs extends Component {
       <Tab key={areItemsValidKeys ? item : itemIndex}>
         <TabItemButton
           isActive={itemIndex === index}
+          tabIndex={itemIndex === index ? 0 : -1}
           underlineColor={underlineColor}
           onClick={() => onClick(itemIndex)}
+          onKeyDown={this.onKeyDown}
           ref={ref => {
             this.itemRefs[itemIndex] = ref;
           }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: User should navigate through tabs with right-left arrow keys.

<!-- Why are these changes necessary? -->

**Why**: This behaviour is required to be WCAG compliant.

<!-- How were these changes implemented? -->

**How**: Added an onkeyDown function to tabs which catches the right left arrow key down event and allow navigation.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
