### PR TITLE
fix(hybridSelect): prevent label prop pass to Select

### DIFF
--- a/catalog/pages/inputs/HybridSelectExample.js
+++ b/catalog/pages/inputs/HybridSelectExample.js
@@ -49,8 +49,8 @@ export default class HybridSelectExample extends Component {
             Option Two
           </HybridOption>
           {/* Add prop optionText while children is not plain text */}
-          <HybridOption value="2" index={2} optionText=" Option Three">
-            <div>Option Three</div>
+          <HybridOption value="2" index={2} optionText="Option Three">
+            {label ? "Option Three" : <div>Option Three</div>}
           </HybridOption>
           <HybridOption value="3" index={3}>
             Option Four

--- a/src/components/Input/HybridDropDown/HybridSelect.js
+++ b/src/components/Input/HybridDropDown/HybridSelect.js
@@ -115,7 +115,6 @@ class HybridSelect extends Component {
           showSelect={showNativeSelect}
           value={value[0]}
           selectRef={selectRef}
-          label={label}
           onChange={this.updateValue}
           onMouseEnter={this.onMouseEnter}
         >

--- a/src/components/Input/__tests__/__snapshots__/HybridDropDown.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/HybridDropDown.spec.js.snap
@@ -1096,7 +1096,6 @@ Object {
       <select
         class="c1 select--large select--border hybrid"
         data-testid="test-hybridselect"
-        label="Sort By: "
       >
         <option
           value=""


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Prevent unnecessary prop label from being passed to Select component. And update HybridSelect example.

<!-- Why are these changes necessary? -->

**Why**: This label prop is not used anywhere in Select component.

<!-- How were these changes implemented? -->

**How**: Stopped prop from being passed to Select component.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
