### PR TITLE
fix(HybridSelect): toggle dropdown opacity

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -247,7 +247,6 @@ class DropDownGroup extends React.Component {
       fullWidth,
       onDropDownToggle,
       hybrid,
-      hideDropdown,
       ...props
     } = this.props;
     const {
@@ -292,10 +291,10 @@ class DropDownGroup extends React.Component {
                         "dropdown--open-upward": hasOpenUpwardClass,
                         "dropdown--disabled": disabled,
                         "full-width": fullWidth,
+                        [`hybrid-margin-${size}`]: hybrid,
                         hybrid
                       })}
-                      hideDropdown={hideDropdown}
-                      tabIndex={disabled ? -1 : 0}
+                      tabIndex={disabled || hybrid ? -1 : 0}
                       aria-haspopup="listbox"
                       aria-labelledby={hiddenLabelId}
                       onKeyDown={this.onKeyDown}
@@ -396,7 +395,6 @@ DropDownGroup.propTypes = {
   chevronVisible: PropTypes.bool,
   onDropDownToggle: PropTypes.func,
   hybrid: PropTypes.bool,
-  hideDropdown: PropTypes.bool,
   dropdownMenuOpen: PropTypes.func,
   dropdownMenuClose: PropTypes.func
 };
@@ -420,7 +418,6 @@ DropDownGroup.defaultProps = {
   fullWidth: false,
   onDropDownToggle: null,
   hybrid: false,
-  hideDropdown: true,
   dropdownMenuOpen: null,
   dropdownMenuClose: null
 };

--- a/src/components/Input/DropDown/DropDownGroup.styles.js
+++ b/src/components/Input/DropDown/DropDownGroup.styles.js
@@ -154,10 +154,15 @@ export const StyledGroupWrapper = styled.div`
   }
 
   &.hybrid {
-    display: ${({ hideDropdown }) => (hideDropdown ? "none" : "inline-block")};
+    top: 0;
+    left: 0;
+    z-index: 2;
 
-    &.full-width {
-      display: ${({ hideDropdown }) => (hideDropdown ? "none" : "block")};
+    &.hybrid-margin-small {
+      margin-top: -36px;
+    }
+    &.hybrid-margin-large {
+      margin-top: -44px;
     }
   }
 `;

--- a/src/components/Input/HybridDropDown/HybridSelect.js
+++ b/src/components/Input/HybridDropDown/HybridSelect.js
@@ -36,9 +36,7 @@ class HybridSelect extends Component {
   };
 
   // update function called when value of native select is changed
-  updateValue = e => {
-    this.onChange([e.target.value]); // passing value in array to match dropdown's format
-  };
+  updateValue = e => this.onChange([e.target.value]); // passing value in array to match dropdown's format
 
   // To add optionFor prop to the children
   renderChildren = (extraProps, children) => {

--- a/src/components/Input/HybridDropDown/HybridSelect.js
+++ b/src/components/Input/HybridDropDown/HybridSelect.js
@@ -6,27 +6,7 @@ import Select from "../Select/Select";
 
 class HybridSelect extends Component {
   state = {
-    showNativeSelect: true,
-    isOpen: false,
-    mouseOnDropdown: false
-  };
-
-  // onMouseEnter function called when mouse enters native select
-  onMouseEnter = e => {
-    const { onMouseEnter } = this.props;
-    this.hideNativeSelect();
-    if (onMouseEnter) {
-      onMouseEnter(e);
-    }
-  };
-
-  // onMouseLeave function called when mouse leave dropdown
-  onMouseLeave = e => {
-    const { onMouseLeave } = this.props;
-    this.showNativeSelect();
-    if (onMouseLeave) {
-      onMouseLeave(e);
-    }
+    dropdownFocused: false
   };
 
   // onChange function called when value is changed
@@ -37,45 +17,27 @@ class HybridSelect extends Component {
     }
   };
 
+  // called when dropdown wrapper get focus
+  onFocus = e => {
+    const { onFocus } = this.props;
+    this.setState({ dropdownFocused: true });
+    if (onFocus) {
+      onFocus(e);
+    }
+  };
+
+  // called when dropdown wrapper losses focus
+  onBlur = e => {
+    const { onBlur } = this.props;
+    this.setState({ dropdownFocused: false });
+    if (onBlur) {
+      onBlur(e);
+    }
+  };
+
   // update function called when value of native select is changed
   updateValue = e => {
     this.onChange([e.target.value]); // passing value in array to match dropdown's format
-  };
-
-  // To show native select
-  showNativeSelect = () => {
-    // Updating value when we know mouse left dropdown
-    this.setState({ mouseOnDropdown: false });
-    if (!this.state.isOpen) {
-      this.setState({ showNativeSelect: true });
-    }
-  };
-
-  // To hide native select - called when mouse enters native select
-  hideNativeSelect = () => {
-    this.setState({ showNativeSelect: false, mouseOnDropdown: true });
-  };
-
-  // Set isOpen state to true when dropdown menu opens
-  dropdownMenuOpen = () => {
-    const { dropdownMenuOpen } = this.props;
-    this.setState({ isOpen: true });
-    if (dropdownMenuOpen) {
-      dropdownMenuOpen();
-    }
-  };
-
-  // Set isOpen state to false when dropdown menu closes
-  dropdownMenuClose = () => {
-    const { dropdownMenuClose } = this.props;
-    this.setState({ isOpen: false }, () => {
-      if (!this.state.mouseOnDropdown) {
-        this.showNativeSelect();
-      }
-    });
-    if (dropdownMenuClose) {
-      dropdownMenuClose();
-    }
   };
 
   // To add optionFor prop to the children
@@ -90,7 +52,7 @@ class HybridSelect extends Component {
   };
 
   render() {
-    const { showNativeSelect } = this.state;
+    const { dropdownFocused } = this.state;
     const {
       placeholder,
       value,
@@ -112,35 +74,29 @@ class HybridSelect extends Component {
           {...props}
           {...selectProps}
           hybrid
-          showSelect={showNativeSelect}
           value={value[0]}
           selectRef={selectRef}
           onChange={this.updateValue}
-          onMouseEnter={this.onMouseEnter}
+          tabIndex={dropdownFocused ? -1 : 0}
         >
           {showOptionPlaceholder && (
             <option value="" {...optionPlaceholderProps}>
               {placeholder}
             </option>
           )}
-          {this.renderChildren(
-            { optionFor: "select", selectedValue: value[0], label },
-            children
-          )}
+          {this.renderChildren({ optionFor: "select" }, children)}
         </Select>
         <DropDownGroup
           {...props}
           {...dropdownProps}
           hybrid
-          hideDropdown={showNativeSelect}
           placeholder={placeholder}
           label={label}
           value={value}
           valueOverride={valueOverride || value}
           onChange={this.onChange}
-          dropdownMenuOpen={this.dropdownMenuOpen}
-          dropdownMenuClose={this.dropdownMenuClose}
-          onMouseLeave={this.onMouseLeave}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
         >
           {this.renderChildren({ optionFor: "dropdown" }, children)}
         </DropDownGroup>

--- a/src/components/Input/Select/Select.styles.js
+++ b/src/components/Input/Select/Select.styles.js
@@ -88,8 +88,13 @@ const StyledSelect = styled.select`
   }
 
   &.hybrid {
-    display: ${({ showSelect }) => (showSelect ? "inline-block" : "none")};
-    transition: none;
+    top: 0;
+    left: 0;
+    opacity: 0;
+
+    &:focus {
+      opacity: 1;
+    }
   }
 
   &:hover:not(.select--disabled) {

--- a/src/components/Input/__tests__/HybridDropDown.spec.js
+++ b/src/components/Input/__tests__/HybridDropDown.spec.js
@@ -54,13 +54,22 @@ describe("HybridDropDown", () => {
     ).toMatchSnapshot();
   });
 
-  it("should call onMouseEnter", () => {
-    const onMouseEnter = jest.fn();
-    const { getByTestId } = renderTestComponent({ onMouseEnter });
+  it("should call onFocus", () => {
+    const onFocus = jest.fn();
+    const { getByTestId } = renderTestComponent({ onFocus });
 
-    fireEvent.mouseEnter(getByTestId("test-hybridselect"));
+    fireEvent.focus(getByTestId("test-hybriddropdown"));
+    fireEvent.blur(getByTestId("test-hybriddropdown"));
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
 
-    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+  it("should call onBlur", () => {
+    const onBlur = jest.fn();
+    const { getByTestId } = renderTestComponent({ onBlur });
+
+    fireEvent.focus(getByTestId("test-hybriddropdown"));
+    fireEvent.blur(getByTestId("test-hybriddropdown"));
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
   it("should call onChange when option is clicked", () => {
@@ -81,28 +90,5 @@ describe("HybridDropDown", () => {
     expect(spyOnChange).toHaveBeenCalledTimes(1);
     expect(spyOnChange).toHaveBeenCalledWith(["1"]);
     spyOnChange.mockRestore();
-  });
-
-  it("should show native select when dropdown close and mouse leave", () => {
-    const instance = renderer
-      .create(testComponentHTML({ dropdownMenuClose: jest.fn() }))
-      .getInstance();
-    instance.onMouseEnter();
-    instance.dropdownMenuOpen();
-    instance.dropdownMenuClose();
-    instance.onMouseLeave();
-    expect(instance.state.showNativeSelect).toBe(true);
-  });
-
-  it("should not show native select when mouse leave dropdown before dropdown close", () => {
-    const instance = renderer
-      .create(testComponentHTML({ onMouseLeave: jest.fn() }))
-      .getInstance();
-    instance.onMouseEnter();
-    instance.dropdownMenuOpen();
-    instance.onMouseLeave();
-    expect(instance.state.showNativeSelect).toBe(false);
-    instance.dropdownMenuClose();
-    expect(instance.state.showNativeSelect).toBe(true);
   });
 });

--- a/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/DropDownGroup.spec.js.snap
@@ -162,11 +162,17 @@ exports[`DropDownGroup Arrow key down should open the drop down 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -584,11 +590,17 @@ exports[`DropDownGroup Arrow key up should open the drop down 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -1006,11 +1018,17 @@ exports[`DropDownGroup Click outside should close the dropdown 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -1428,11 +1446,17 @@ exports[`DropDownGroup Click outside should not close the dropdown when the isOp
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -1852,11 +1876,17 @@ exports[`DropDownGroup Effect when move moves over dropdown option  when focused
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -2274,11 +2304,17 @@ exports[`DropDownGroup Effect when move moves over dropdown option when focused 
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -2696,11 +2732,17 @@ exports[`DropDownGroup Escape key should close the drop down 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -3118,11 +3160,17 @@ exports[`DropDownGroup Should not focus onClick 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -3540,11 +3588,17 @@ exports[`DropDownGroup Should open the drop down onClick 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -3964,11 +4018,17 @@ exports[`DropDownGroup Space bar should select and close dropdown 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -4388,11 +4448,17 @@ exports[`DropDownGroup Space bar should select and not close dropdown when the i
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -4812,11 +4878,17 @@ exports[`DropDownGroup Space bar should select but not close dropdown 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -5435,11 +5507,17 @@ exports[`DropDownGroup renders bordered variant with an inner label with a place
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -5861,11 +5939,17 @@ exports[`DropDownGroup renders borderless variant with an inner label with a lab
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -6285,11 +6369,17 @@ exports[`DropDownGroup renders borderless variant with label and hiddenLabel pro
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -6709,11 +6799,17 @@ exports[`DropDownGroup renders default dropdown 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -7131,11 +7227,17 @@ exports[`DropDownGroup renders default dropdown that should always open downward
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -7553,11 +7655,17 @@ exports[`DropDownGroup renders hybrid dropdown 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -7732,9 +7840,9 @@ exports[`DropDownGroup renders hybrid dropdown 1`] = `
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="c0 hybrid"
+    class="c0 hybrid-margin-large hybrid"
     data-testid="test-dropContainer"
-    tabindex="0"
+    tabindex="-1"
   >
     <label
       class="c1 dropdown__label dropdown--large dropdown--border"
@@ -7975,11 +8083,17 @@ exports[`DropDownGroup renders hybrid dropdown when hideDropdown is false 1`] = 
 }
 
 .c0.hybrid {
-  display: inline-block;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: block;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -8154,9 +8268,9 @@ exports[`DropDownGroup renders hybrid dropdown when hideDropdown is false 1`] = 
   <div
     aria-haspopup="listbox"
     aria-labelledby="hidden-label__"
-    class="c0 hybrid"
+    class="c0 hybrid-margin-large hybrid"
     data-testid="test-dropContainer"
-    tabindex="0"
+    tabindex="-1"
   >
     <label
       class="c1 dropdown__label dropdown--large dropdown--border"
@@ -8397,11 +8511,17 @@ exports[`DropDownGroup renders input correctly when the isOpen prop with a value
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -8819,11 +8939,17 @@ exports[`DropDownGroup renders input correctly when the keywordSearch prop with 
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -9241,11 +9367,17 @@ exports[`DropDownGroup renders input correctly when the withKeyboardProvider pro
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -9662,11 +9794,17 @@ exports[`DropDownGroup renders small dropdown 1`] = `
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -10084,11 +10222,17 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -10505,11 +10649,17 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {
@@ -10929,11 +11079,17 @@ exports[`DropDownGroup should render the correct label when label prop is passed
 }
 
 .c0.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c0.hybrid.full-width {
-  display: none;
+.c0.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c0.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c5 {

--- a/src/components/Input/__tests__/__snapshots__/HybridDropDown.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/HybridDropDown.spec.js.snap
@@ -167,11 +167,17 @@ Object {
 }
 
 .c2.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c2.hybrid.full-width {
-  display: none;
+.c2.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c2.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c7 {
@@ -371,9 +377,13 @@ Object {
 }
 
 .c1.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c1.hybrid:focus {
+  opacity: 1;
 }
 
 .c1:hover:not(.select--disabled) {
@@ -464,6 +474,7 @@ Object {
       <select
         class="c1 select--large select--border hybrid"
         data-testid="test-hybridselect"
+        tabindex="0"
       >
         <option
           value=""
@@ -502,9 +513,9 @@ Object {
       <div
         aria-haspopup="listbox"
         aria-labelledby="hidden-label__"
-        class="c2 hybrid"
+        class="c2 hybrid-margin-large hybrid"
         data-testid="test-hybriddropdown"
-        tabindex="0"
+        tabindex="-1"
       >
         <label
           class="c3 dropdown__label dropdown--large dropdown--border"
@@ -799,11 +810,17 @@ Object {
 }
 
 .c2.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c2.hybrid.full-width {
-  display: none;
+.c2.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c2.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c7 {
@@ -1003,9 +1020,13 @@ Object {
 }
 
 .c1.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c1.hybrid:focus {
+  opacity: 1;
 }
 
 .c1:hover:not(.select--disabled) {
@@ -1096,6 +1117,7 @@ Object {
       <select
         class="c1 select--large select--border hybrid"
         data-testid="test-hybridselect"
+        tabindex="0"
       >
         <option
           value=""
@@ -1134,9 +1156,9 @@ Object {
       <div
         aria-haspopup="listbox"
         aria-labelledby="hidden-label__Sort_By:_"
-        class="c2 hybrid"
+        class="c2 hybrid-margin-large hybrid"
         data-testid="test-hybriddropdown"
-        tabindex="0"
+        tabindex="-1"
       >
         <label
           class="c3 dropdown__label dropdown--large dropdown--border"
@@ -1433,11 +1455,17 @@ Object {
 }
 
 .c2.hybrid {
-  display: none;
+  top: 0;
+  left: 0;
+  z-index: 2;
 }
 
-.c2.hybrid.full-width {
-  display: none;
+.c2.hybrid.hybrid-margin-small {
+  margin-top: -36px;
+}
+
+.c2.hybrid.hybrid-margin-large {
+  margin-top: -44px;
 }
 
 .c7 {
@@ -1637,9 +1665,13 @@ Object {
 }
 
 .c1.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c1.hybrid:focus {
+  opacity: 1;
 }
 
 .c1:hover:not(.select--disabled) {
@@ -1730,6 +1762,7 @@ Object {
       <select
         class="c1 select--large select--border hybrid"
         data-testid="test-hybridselect"
+        tabindex="0"
       >
         <option
           value=""
@@ -1770,9 +1803,9 @@ Object {
       <div
         aria-haspopup="listbox"
         aria-labelledby="hidden-label__Select_an_option"
-        class="c2 hybrid"
+        class="c2 hybrid-margin-large hybrid"
         data-testid="test-hybriddropdown"
-        tabindex="0"
+        tabindex="-1"
       >
         <label
           class="c3 dropdown__label dropdown--large dropdown--border"

--- a/src/components/Input/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Select.spec.js.snap
@@ -87,9 +87,13 @@ Object {
 }
 
 .c0.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c0.hybrid:focus {
+  opacity: 1;
 }
 
 .c0:hover:not(.select--disabled) {
@@ -282,9 +286,13 @@ Object {
 }
 
 .c0.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c0.hybrid:focus {
+  opacity: 1;
 }
 
 .c0:hover:not(.select--disabled) {
@@ -477,9 +485,13 @@ Object {
 }
 
 .c0.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c0.hybrid:focus {
+  opacity: 1;
 }
 
 .c0:hover:not(.select--disabled) {
@@ -672,9 +684,13 @@ Object {
 }
 
 .c0.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c0.hybrid:focus {
+  opacity: 1;
 }
 
 .c0:hover:not(.select--disabled) {
@@ -867,9 +883,13 @@ Object {
 }
 
 .c0.hybrid {
-  display: none;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c0.hybrid:focus {
+  opacity: 1;
 }
 
 .c0:hover:not(.select--disabled) {
@@ -1062,9 +1082,13 @@ Object {
 }
 
 .c0.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c0.hybrid:focus {
+  opacity: 1;
 }
 
 .c0:hover:not(.select--disabled) {
@@ -1257,9 +1281,13 @@ Object {
 }
 
 .c0.hybrid {
-  display: inline-block;
-  -webkit-transition: none;
-  transition: none;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+.c0.hybrid:focus {
+  opacity: 1;
 }
 
 .c0:hover:not(.select--disabled) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Toggle native and aurora dropdown with opacity.

<!-- Why are these changes necessary? -->

**Why**: Using display property is an inconsistent solution. Aurora dropdown should be always visible but should not be focusable via tab.

<!-- How were these changes implemented? -->

**How**: Overlapped the Select and Dropdown over each other and toggled the opacity. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
