### PR TITLE
fix(HybridSelect): fix maximum depth error

### DIFF
--- a/catalog/pages/inputs/HybridSelectExample.js
+++ b/catalog/pages/inputs/HybridSelectExample.js
@@ -31,6 +31,7 @@ export default class HybridSelectExample extends Component {
           value={value}
           onChange={this.onChange}
           label={label}
+          showOptionPlaceholder={false}
           selectProps={{ id: selectId }}
         >
           <HybridOption

--- a/src/components/Input/HybridDropDown/HybridSelect.js
+++ b/src/components/Input/HybridDropDown/HybridSelect.js
@@ -5,10 +5,6 @@ import DropDownGroup from "../DropDown/DropDownGroup";
 import Select from "../Select/Select";
 
 class HybridSelect extends Component {
-  state = {
-    dropdownFocused: false
-  };
-
   // onChange function called when value is changed
   onChange = value => {
     const { onChange } = this.props;
@@ -20,7 +16,7 @@ class HybridSelect extends Component {
   // called when dropdown wrapper get focus
   onFocus = e => {
     const { onFocus } = this.props;
-    this.setState({ dropdownFocused: true });
+    this.selectRef.current.tabIndex = -1;
     if (onFocus) {
       onFocus(e);
     }
@@ -29,11 +25,14 @@ class HybridSelect extends Component {
   // called when dropdown wrapper losses focus
   onBlur = e => {
     const { onBlur } = this.props;
-    this.setState({ dropdownFocused: false });
+    this.selectRef.current.tabIndex = 0;
     if (onBlur) {
       onBlur(e);
     }
   };
+
+  // ref to access Select component
+  selectRef = React.createRef();
 
   // update function called when value of native select is changed
   updateValue = e => this.onChange([e.target.value]); // passing value in array to match dropdown's format
@@ -50,7 +49,6 @@ class HybridSelect extends Component {
   };
 
   render() {
-    const { dropdownFocused } = this.state;
     const {
       placeholder,
       value,
@@ -61,7 +59,6 @@ class HybridSelect extends Component {
       hybridWrapperProps,
       selectProps,
       dropdownProps,
-      selectRef,
       children,
       ...props
     } = this.props;
@@ -73,9 +70,8 @@ class HybridSelect extends Component {
           {...selectProps}
           hybrid
           value={value[0]}
-          selectRef={selectRef}
+          selectRef={this.selectRef}
           onChange={this.updateValue}
-          tabIndex={dropdownFocused ? -1 : 0}
         >
           {showOptionPlaceholder && (
             <option value="" {...optionPlaceholderProps}>

--- a/src/components/Input/__tests__/__snapshots__/HybridDropDown.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/HybridDropDown.spec.js.snap
@@ -466,7 +466,6 @@ Object {
       <select
         class="c1 select--large select--border hybrid"
         data-testid="test-hybridselect"
-        tabindex="0"
       >
         <option
           value=""
@@ -1101,7 +1100,6 @@ Object {
       <select
         class="c1 select--large select--border hybrid"
         data-testid="test-hybridselect"
-        tabindex="0"
       >
         <option
           value=""
@@ -1738,7 +1736,6 @@ Object {
       <select
         class="c1 select--large select--border hybrid"
         data-testid="test-hybridselect"
-        tabindex="0"
       >
         <option
           value=""


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix maximum depth error.

<!-- Why are these changes necessary? -->

**Why**: When navigated between different HybridDropdown it gave maximum depth error leading to unresponsive page. 

<!-- How were these changes implemented? -->

**How**: Removed setState command and worked around with ref.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
