### PR TITLE
chore(README): Remove greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 [![Build Status][build-badge]][build]
 [![Code Coverage][coverage-badge]][coverage]
-[![Greenkeeper badge][greenkeeper-badge]](https://greenkeeper.io/)
 [![version][version-badge]][package]
 
 [![MIT License][license-badge]][license]


### PR DESCRIPTION
**What**:
Removing Greenkeeper badge

**Why**:
The service is now deprecated in favor of Snyk

**How**:
Removed badge from README

**Checklist**:
* [ ] Documentation (N/A)
* [ ] Tests (N/A)
* [x] Ready to be merged
